### PR TITLE
Apply hero layout to public consumer pages

### DIFF
--- a/client/src/components/public-hero-layout.tsx
+++ b/client/src/components/public-hero-layout.tsx
@@ -1,0 +1,116 @@
+import { ReactNode } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import chainLogo from "@/assets/chain-logo.png";
+import { cn } from "@/lib/utils";
+
+interface PublicHeroLayoutProps {
+  badgeText?: string;
+  title: string;
+  description?: string;
+  supportingContent?: ReactNode;
+  children?: ReactNode;
+  headerActions?: ReactNode;
+  showDefaultHeaderActions?: boolean;
+  contentClassName?: string;
+  mainContainerClassName?: string;
+  disableSurface?: boolean;
+}
+
+export function PublicHeroLayout({
+  badgeText,
+  title,
+  description,
+  supportingContent,
+  children,
+  headerActions,
+  showDefaultHeaderActions = true,
+  contentClassName,
+  mainContainerClassName,
+  disableSurface = false,
+}: PublicHeroLayoutProps) {
+  const defaultHeaderActions = (
+    <>
+      <Button
+        variant="ghost"
+        className="text-blue-100 hover:bg-white/10"
+        onClick={() => (window.location.href = "/consumer-login")}
+      >
+        Sign in
+      </Button>
+      <Button
+        className="bg-blue-500 hover:bg-blue-400"
+        onClick={() => (window.location.href = "/consumer-register")}
+      >
+        Create account
+      </Button>
+    </>
+  );
+
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-slate-950 text-white">
+      <div className="pointer-events-none absolute inset-0 overflow-hidden">
+        <div className="absolute -top-32 right-0 h-96 w-96 rounded-full bg-blue-500/30 blur-3xl" />
+        <div className="absolute bottom-0 left-0 h-[28rem] w-[28rem] rounded-full bg-indigo-500/20 blur-3xl" />
+        <div className="absolute top-1/2 left-1/2 h-72 w-72 -translate-x-1/2 -translate-y-1/2 rounded-full bg-blue-400/10 blur-3xl" />
+      </div>
+
+      <div className="relative">
+        <header className="border-b border-white/10 bg-slate-950/60 backdrop-blur">
+          <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-6">
+            <div className="flex items-center gap-3">
+              <img src={chainLogo} alt="Chain Software Group" className="h-10 w-auto" />
+              <div>
+                <p className="text-sm uppercase tracking-wide text-blue-200">Chain Consumer Portal</p>
+                <p className="text-xs text-blue-100/80">Modern tools for managing your obligations with confidence</p>
+              </div>
+            </div>
+            <div className="hidden gap-3 sm:flex">
+              {headerActions ?? (showDefaultHeaderActions ? defaultHeaderActions : null)}
+            </div>
+          </div>
+        </header>
+
+        <main className={cn("px-6 py-12 sm:py-20", mainContainerClassName)}>
+          <section className="mx-auto grid max-w-6xl gap-12 lg:grid-cols-[1.1fr_0.9fr] lg:items-start">
+            <div>
+              {badgeText ? (
+                <Badge variant="outline" className="border-blue-400/50 bg-blue-500/10 text-blue-100">
+                  {badgeText}
+                </Badge>
+              ) : null}
+              <h1 className="mt-6 text-4xl font-semibold tracking-tight text-white sm:text-5xl">
+                {title}
+              </h1>
+              {description ? (
+                <p className="mt-6 max-w-xl text-lg text-blue-100/80">{description}</p>
+              ) : null}
+              {supportingContent ? (
+                <div className="mt-10 space-y-6 text-blue-100/80">{supportingContent}</div>
+              ) : null}
+            </div>
+
+            {children ? (
+              <div className="relative">
+                <div className="absolute -top-6 -right-6 h-32 w-32 rounded-full bg-blue-500/20 blur-3xl" />
+                <div
+                  className={cn(
+                    "relative z-10",
+                    disableSurface
+                      ? undefined
+                      : "rounded-3xl border border-white/10 bg-white/5 shadow-xl shadow-blue-900/20 backdrop-blur",
+                    contentClassName,
+                  )}
+                >
+                  {children}
+                </div>
+              </div>
+            ) : null}
+          </section>
+        </main>
+      </div>
+    </div>
+  );
+}
+
+export default PublicHeroLayout;

--- a/client/src/pages/consumer-login.tsx
+++ b/client/src/pages/consumer-login.tsx
@@ -3,13 +3,11 @@ import { useMutation } from "@tanstack/react-query";
 import { useRoute, useLocation } from "wouter";
 import { apiRequest } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Building2, Mail, Lock, ArrowRight, UserCheck } from "lucide-react";
-import chainLogo from "@/assets/chain-logo.png";
+import { Building2, Mail, Lock, ArrowRight, ShieldCheck, UserCheck } from "lucide-react";
+import PublicHeroLayout from "@/components/public-hero-layout";
 
 interface LoginForm {
   email: string;
@@ -154,155 +152,169 @@ export default function ConsumerLogin() {
     loginMutation.mutate(form);
   };
 
-  // Common agency slugs for quick selection
-  const commonAgencies = [
-    { slug: "agency-pro", name: "Agency Pro" },
-    { slug: "collections-plus", name: "Collections Plus" },
-    { slug: "debt-solutions", name: "Debt Solutions" },
-  ];
-
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 flex items-center justify-center px-4">
-      <div className="max-w-md w-full space-y-6">
-        {/* Header */}
-        <div className="text-center">
-          {agencyContext ? (
-            <>
-              <div className="mb-4">
-                <img src={chainLogo} alt="Chain Software Group" className="h-12 object-contain mx-auto mb-2" />
-                <h1 className="text-3xl font-bold text-gray-900">Access Your Account</h1>
-                <p className="text-lg text-blue-600 font-medium mt-2">
-                  {agencyContext.name}
-                </p>
-                <p className="text-gray-600 text-sm">
-                  Sign in to view your account information
-                </p>
+    <PublicHeroLayout
+      badgeText="Secure consumer access"
+      title={agencyContext ? `Welcome back to ${agencyContext.name}` : "Access your account"}
+      description={
+        agencyContext
+          ? "Verify your information to review balances, download documents, and stay in touch with your agency."
+          : "Log in to review balances, download documents, and stay ahead of every update in one connected hub."
+      }
+      supportingContent={(
+        <>
+          <div className="text-base text-blue-100/80">
+            Enter the email address on file and your date of birth. We'll securely match you with the right agency and guide you to your information.
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="flex items-start gap-3 rounded-2xl border border-white/10 bg-white/5 p-4">
+              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-blue-500/20">
+                <Lock className="h-5 w-5 text-blue-200" />
               </div>
-            </>
-          ) : (
-            <>
-              <div className="w-16 h-16 bg-blue-600 rounded-full mx-auto flex items-center justify-center mb-4">
-                <Building2 className="h-8 w-8 text-white" />
+              <div className="space-y-1">
+                <p className="text-sm font-semibold text-white">Protected verification</p>
+                <p className="text-sm text-blue-100/70">Bank-level encryption and identity checks keep every login secure.</p>
               </div>
-              <h1 className="text-3xl font-bold text-gray-900">Consumer Portal</h1>
-              <p className="text-gray-600 mt-2">
-                Find and access your accounts from any agency
-              </p>
-            </>
-          )}
-        </div>
-
-        {/* Login Form */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center">
-              <UserCheck className="h-5 w-5 mr-2 text-blue-600" />
-              Sign In to Your Account
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <form onSubmit={handleSubmit} className="space-y-4">
-              <div>
-                <Label htmlFor="email">Email Address *</Label>
-                <div className="relative">
-                  <Mail className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
-                  <Input
-                    id="email"
-                    type="email"
-                    value={form.email}
-                    onChange={(e) => handleInputChange("email", e.target.value)}
-                    placeholder="your@email.com"
-                    className="pl-10"
-                    data-testid="input-consumer-email"
-                    required
-                  />
-                </div>
-              </div>
-
-
-              <div>
-                <Label htmlFor="dob">Date of Birth *</Label>
-                <div className="relative">
-                  <Lock className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
-                  <Input
-                    id="dob"
-                    type="date"
-                    value={form.dateOfBirth}
-                    onChange={(e) => handleInputChange("dateOfBirth", e.target.value)}
-                    className="pl-10"
-                    data-testid="input-date-of-birth"
-                    required
-                  />
-                </div>
-                <p className="text-xs text-gray-500 mt-1">
-                  Used for identity verification and security
-                </p>
-              </div>
-
-              <Button 
-                type="submit" 
-                className="w-full"
-                disabled={loginMutation.isPending}
-                data-testid="button-consumer-login"
-              >
-                {loginMutation.isPending ? (
-                  <>
-                    <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2"></div>
-                    Verifying...
-                  </>
-                ) : (
-                  <>
-                    Sign In to Your Account
-                    <ArrowRight className="h-4 w-4 ml-2" />
-                  </>
-                )}
-              </Button>
-            </form>
-          </CardContent>
-        </Card>
-
-        {/* Registration Link */}
-        <div className="text-center">
-          <p className="text-gray-600 text-sm">
-            New to the system?{" "}
-            <button
-              onClick={() => setLocation("/consumer-register")}
-              className="text-blue-600 hover:text-blue-800 font-medium"
-              data-testid="link-register"
-            >
-              Create an account
-            </button>
-          </p>
-        </div>
-
-        {/* Help */}
-        <div className="bg-blue-50 rounded-lg p-4">
-          <div className="flex items-start">
-            <div className="flex-shrink-0">
-              <Building2 className="h-5 w-5 text-blue-600" />
             </div>
-            <div className="ml-3">
-              <h3 className="text-sm font-medium text-blue-800">How it works</h3>
-              <p className="text-sm text-blue-700 mt-1">
-                Simply enter your email and date of birth. We'll search across all agencies to find your accounts and help you get set up if you're new.
+            <div className="flex items-start gap-3 rounded-2xl border border-white/10 bg-white/5 p-4">
+              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-blue-500/20">
+                <ShieldCheck className="h-5 w-5 text-blue-200" />
+              </div>
+              <div className="space-y-1">
+                <p className="text-sm font-semibold text-white">Stay connected</p>
+                <p className="text-sm text-blue-100/70">Get account alerts, request support, and collaborate with your agency.</p>
+              </div>
+            </div>
+          </div>
+        </>
+      )}
+      headerActions={(
+        <>
+          <Button
+            variant="ghost"
+            className="text-blue-100 hover:bg-white/10"
+            onClick={() => (window.location.href = "/")}
+          >
+            Home
+          </Button>
+          <Button
+            className="bg-blue-500 hover:bg-blue-400"
+            onClick={() => setLocation("/consumer-register")}
+          >
+            Create account
+          </Button>
+        </>
+      )}
+      showDefaultHeaderActions={false}
+      contentClassName="p-8 sm:p-10"
+    >
+      <div className="space-y-8 text-left">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <p className="text-xs uppercase tracking-[0.2em] text-blue-200">Consumer portal</p>
+            <h2 className="mt-2 text-2xl font-semibold text-white">Sign in to continue</h2>
+            <p className="mt-3 text-sm text-blue-100/70">
+              Provide your details below to access your dashboard and manage every account in one place.
+            </p>
+          </div>
+          <div className="hidden h-12 w-12 items-center justify-center rounded-full bg-blue-500/20 sm:flex">
+            <UserCheck className="h-6 w-6 text-blue-200" />
+          </div>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-5">
+          <div className="space-y-2">
+            <Label htmlFor="email" className="text-sm font-medium text-blue-100">
+              Email address
+            </Label>
+            <div className="relative">
+              <Mail className="pointer-events-none absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-blue-200/70" />
+              <Input
+                id="email"
+                type="email"
+                value={form.email}
+                onChange={(e) => handleInputChange("email", e.target.value)}
+                placeholder="you@example.com"
+                className="h-12 rounded-2xl border-white/20 bg-slate-900/60 pl-12 text-base text-white placeholder:text-blue-100/50 focus-visible:ring-blue-400"
+                data-testid="input-consumer-email"
+                required
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="dob" className="text-sm font-medium text-blue-100">
+              Date of birth
+            </Label>
+            <div className="relative">
+              <Lock className="pointer-events-none absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-blue-200/70" />
+              <Input
+                id="dob"
+                type="date"
+                value={form.dateOfBirth}
+                onChange={(e) => handleInputChange("dateOfBirth", e.target.value)}
+                className="h-12 rounded-2xl border-white/20 bg-slate-900/60 pl-12 text-base text-white placeholder:text-blue-100/50 focus-visible:ring-blue-400"
+                data-testid="input-date-of-birth"
+                required
+              />
+            </div>
+            <p className="text-xs text-blue-100/60">We use this information only to confirm your identity.</p>
+          </div>
+
+          <Button
+            type="submit"
+            className="h-12 w-full rounded-full bg-blue-500 text-base font-medium text-white transition hover:bg-blue-400"
+            disabled={loginMutation.isPending}
+            data-testid="button-consumer-login"
+          >
+            {loginMutation.isPending ? (
+              <>
+                <div className="mr-2 h-4 w-4 animate-spin rounded-full border-b-2 border-white"></div>
+                Verifying
+              </>
+            ) : (
+              <>
+                Access your account
+                <ArrowRight className="ml-2 h-4 w-4" />
+              </>
+            )}
+          </Button>
+        </form>
+
+        <div className="rounded-2xl border border-white/10 bg-white/5 p-4 text-sm text-blue-100/70">
+          <div className="flex items-start gap-3">
+            <div className="flex h-9 w-9 items-center justify-center rounded-full bg-blue-500/20">
+              <Building2 className="h-5 w-5 text-blue-200" />
+            </div>
+            <div className="space-y-2">
+              <p className="font-semibold text-white">Need to register instead?</p>
+              <p>
+                New to the portal? We’ll guide you through finding your accounts and verifying your information in just a minute.
               </p>
+              <button
+                onClick={() => setLocation("/consumer-register")}
+                className="text-sm font-medium text-blue-200 transition hover:text-white"
+                data-testid="link-register"
+              >
+                Start registration
+              </button>
             </div>
           </div>
         </div>
 
-        {/* Footer Links */}
-        <div className="mt-8 text-center border-t pt-4">
-          <div className="text-sm text-gray-600 space-x-4">
-            <a href="/terms-of-service" className="hover:text-blue-600 hover:underline">
+        <div className="flex flex-wrap items-center justify-between gap-3 text-xs text-blue-100/60">
+          <div className="flex items-center gap-3">
+            <a href="/terms-of-service" className="transition hover:text-white hover:underline">
               Terms of Service
             </a>
             <span>•</span>
-            <a href="/privacy-policy" className="hover:text-blue-600 hover:underline">
+            <a href="/privacy-policy" className="transition hover:text-white hover:underline">
               Privacy Policy
             </a>
           </div>
+          <p>Secure access powered by Chain Software Group</p>
         </div>
       </div>
-    </div>
+    </PublicHeroLayout>
   );
 }

--- a/client/src/pages/consumer-registration.tsx
+++ b/client/src/pages/consumer-registration.tsx
@@ -3,15 +3,14 @@ import { useParams, useLocation } from "wouter";
 import { useMutation } from "@tanstack/react-query";
 import { apiRequest } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Textarea } from "@/components/ui/textarea";
 import { Checkbox } from "@/components/ui/checkbox";
 import { UserPlus, ArrowRight, Shield, MapPin, AlertTriangle } from "lucide-react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
+import PublicHeroLayout from "@/components/public-hero-layout";
 
 export default function ConsumerRegistration() {
   const { tenantSlug } = useParams();
@@ -177,252 +176,323 @@ export default function ConsumerRegistration() {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50 py-8">
-      <div className="max-w-2xl mx-auto px-4">
-        <div className="text-center mb-8">
-          <UserPlus className="h-12 w-12 text-blue-600 mx-auto mb-4" />
-          <h1 className="text-3xl font-bold text-gray-900 mb-2">Consumer Registration</h1>
-          <p className="text-gray-600">
-            Enter your information below. We'll automatically find your agency and set up your account.
-          </p>
+    <PublicHeroLayout
+      badgeText="Complete your profile"
+      title="Create your secure consumer account"
+      description="We’ll automatically match you with the right agency and unlock your full account experience."
+      supportingContent={(
+        <div className="grid gap-4">
+          <div className="flex items-start gap-3 rounded-2xl border border-white/10 bg-white/5 p-4">
+            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-blue-500/20">
+              <Shield className="h-5 w-5 text-blue-200" />
+            </div>
+            <div className="space-y-1">
+              <p className="text-sm font-semibold text-white">Trusted security</p>
+              <p className="text-sm text-blue-100/70">Identity checks and encrypted data keep your information safe end-to-end.</p>
+            </div>
+          </div>
+          <div className="flex items-start gap-3 rounded-2xl border border-white/10 bg-white/5 p-4">
+            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-blue-500/20">
+              <MapPin className="h-5 w-5 text-blue-200" />
+            </div>
+            <div className="space-y-1">
+              <p className="text-sm font-semibold text-white">Automatically routed</p>
+              <p className="text-sm text-blue-100/70">We locate the right agency so you can start communicating without any guesswork.</p>
+            </div>
+          </div>
+        </div>
+      )}
+      headerActions={(
+        <>
+          <Button
+            variant="ghost"
+            className="text-blue-100 hover:bg-white/10"
+            onClick={() => navigate("/consumer-login")}
+          >
+            Back to login
+          </Button>
+          <Button
+            className="bg-blue-500 hover:bg-blue-400"
+            onClick={() => navigate("/")}
+          >
+            Consumer home
+          </Button>
+        </>
+      )}
+      showDefaultHeaderActions={false}
+      contentClassName="p-8 sm:p-10"
+    >
+      <div className="space-y-8 text-left text-white">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <p className="text-xs uppercase tracking-[0.2em] text-blue-200">Registration</p>
+            <h2 className="mt-2 text-2xl font-semibold">Tell us a few details</h2>
+            <p className="mt-3 text-sm text-blue-100/70">
+              {effectiveTenantSlug
+                ? `We’ll connect you with ${effectiveTenantSlug.replace(/-/g, " ")} and activate your access immediately.`
+                : "Share your information and we’ll locate the right agency for you automatically."}
+            </p>
+          </div>
+          <div className="hidden h-12 w-12 items-center justify-center rounded-full bg-blue-500/20 sm:flex">
+            <UserPlus className="h-6 w-6 text-blue-200" />
+          </div>
         </div>
 
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center">
-              <Shield className="h-5 w-5 mr-2" />
-              Registration Information
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <form onSubmit={handleSubmit} className="space-y-6">
-              {/* Warning if no agency selected */}
-              {!effectiveTenantSlug && (
-                <Alert className="bg-yellow-50 border-yellow-200">
-                  <AlertTriangle className="h-4 w-4 text-yellow-600" />
-                  <AlertDescription className="text-yellow-800">
-                    <strong>Agency Required:</strong> You must select an agency to complete registration. 
-                    Please go to your agency's website to register.
-                  </AlertDescription>
-                </Alert>
-              )}
-              
-              {/* Basic Information */}
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div>
-                  <Label htmlFor="firstName">First Name *</Label>
-                  <Input
-                    id="firstName"
-                    data-testid="input-firstName"
-                    value={formData.firstName}
-                    onChange={(e) => handleInputChange("firstName", e.target.value)}
-                    required
-                  />
-                </div>
-                <div>
-                  <Label htmlFor="lastName">Last Name *</Label>
-                  <Input
-                    id="lastName"
-                    data-testid="input-lastName"
-                    value={formData.lastName}
-                    onChange={(e) => handleInputChange("lastName", e.target.value)}
-                    required
-                  />
-                </div>
-              </div>
+        {!effectiveTenantSlug && (
+          <Alert className="border-yellow-400/40 bg-yellow-500/10 text-yellow-100">
+            <AlertTriangle className="h-4 w-4 text-yellow-200" />
+            <AlertDescription className="text-sm">
+              <strong className="text-yellow-100">Agency required:</strong> Choose your agency’s dedicated link to finish registration. If you reached this page by mistake, return to your agency’s website and follow the registration button.
+            </AlertDescription>
+          </Alert>
+        )}
 
-              {/* Email Address */}
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="firstName" className="text-sm font-medium text-blue-100">
+                First name *
+              </Label>
+              <Input
+                id="firstName"
+                data-testid="input-firstName"
+                value={formData.firstName}
+                onChange={(e) => handleInputChange("firstName", e.target.value)}
+                className="h-11 rounded-2xl border-white/20 bg-slate-900/60 px-4 text-white placeholder:text-blue-100/50 focus-visible:ring-blue-400"
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="lastName" className="text-sm font-medium text-blue-100">
+                Last name *
+              </Label>
+              <Input
+                id="lastName"
+                data-testid="input-lastName"
+                value={formData.lastName}
+                onChange={(e) => handleInputChange("lastName", e.target.value)}
+                className="h-11 rounded-2xl border-white/20 bg-slate-900/60 px-4 text-white placeholder:text-blue-100/50 focus-visible:ring-blue-400"
+                required
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="email" className="text-sm font-medium text-blue-100">
+              Email address *
+            </Label>
+            <Input
+              id="email"
+              type="email"
+              data-testid="input-email"
+              value={formData.email}
+              onChange={(e) => handleInputChange("email", e.target.value)}
+              placeholder="you@example.com"
+              className="h-11 rounded-2xl border-white/20 bg-slate-900/60 px-4 text-white placeholder:text-blue-100/50 focus-visible:ring-blue-400"
+              required
+            />
+            <p className="text-xs text-blue-100/60">We’ll use this to locate your account and send secure updates.</p>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="dateOfBirth" className="text-sm font-medium text-blue-100">
+              Date of birth *
+            </Label>
+            <Input
+              id="dateOfBirth"
+              type="date"
+              data-testid="input-dateOfBirth"
+              value={formData.dateOfBirth}
+              onChange={(e) => handleInputChange("dateOfBirth", e.target.value)}
+              className="h-11 rounded-2xl border-white/20 bg-slate-900/60 px-4 text-white focus-visible:ring-blue-400"
+              required
+            />
+            <p className="text-xs text-blue-100/60">Only used to confirm your identity with your agency.</p>
+          </div>
+
+          <div className="space-y-4">
+            <div className="flex items-center gap-2">
+              <div className="flex h-9 w-9 items-center justify-center rounded-full bg-blue-500/20">
+                <MapPin className="h-5 w-5 text-blue-200" />
+              </div>
               <div>
-                <Label htmlFor="email">Email Address *</Label>
+                <p className="text-sm font-semibold text-white">Address information</p>
+                <p className="text-xs text-blue-100/60">Helps your agency personalize communication and confirm records.</p>
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="address" className="text-sm font-medium text-blue-100">
+                Street address *
+              </Label>
+              <Input
+                id="address"
+                data-testid="input-address"
+                value={formData.address}
+                onChange={(e) => handleInputChange("address", e.target.value)}
+                placeholder="123 Main Street"
+                className="h-11 rounded-2xl border-white/20 bg-slate-900/60 px-4 text-white placeholder:text-blue-100/50 focus-visible:ring-blue-400"
+                required
+              />
+            </div>
+
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+              <div className="space-y-2">
+                <Label htmlFor="city" className="text-sm font-medium text-blue-100">
+                  City
+                </Label>
                 <Input
-                  id="email"
-                  type="email"
-                  data-testid="input-email"
-                  value={formData.email}
-                  onChange={(e) => handleInputChange("email", e.target.value)}
-                  placeholder="your@email.com"
-                  required
+                  id="city"
+                  data-testid="input-city"
+                  value={formData.city}
+                  onChange={(e) => handleInputChange("city", e.target.value)}
+                  className="h-11 rounded-2xl border-white/20 bg-slate-900/60 px-4 text-white placeholder:text-blue-100/50 focus-visible:ring-blue-400"
                 />
-                <p className="text-xs text-gray-500 mt-1">
-                  We'll use this to find your agency account
-                </p>
               </div>
-
-              {/* Date of Birth */}
-              <div>
-                <Label htmlFor="dateOfBirth">Date of Birth *</Label>
+              <div className="space-y-2">
+                <Label htmlFor="state" className="text-sm font-medium text-blue-100">
+                  State
+                </Label>
+                <Select value={formData.state} onValueChange={(value) => handleInputChange("state", value)}>
+                  <SelectTrigger
+                    data-testid="select-state"
+                    className="h-11 rounded-2xl border-white/20 bg-slate-900/60 px-4 text-left text-white focus:ring-blue-400"
+                  >
+                    <SelectValue placeholder="Select state" />
+                  </SelectTrigger>
+                  <SelectContent className="bg-slate-900/95 text-blue-50">
+                    <SelectItem value="AL">Alabama</SelectItem>
+                    <SelectItem value="AK">Alaska</SelectItem>
+                    <SelectItem value="AZ">Arizona</SelectItem>
+                    <SelectItem value="AR">Arkansas</SelectItem>
+                    <SelectItem value="CA">California</SelectItem>
+                    <SelectItem value="CO">Colorado</SelectItem>
+                    <SelectItem value="CT">Connecticut</SelectItem>
+                    <SelectItem value="DE">Delaware</SelectItem>
+                    <SelectItem value="FL">Florida</SelectItem>
+                    <SelectItem value="GA">Georgia</SelectItem>
+                    <SelectItem value="HI">Hawaii</SelectItem>
+                    <SelectItem value="ID">Idaho</SelectItem>
+                    <SelectItem value="IL">Illinois</SelectItem>
+                    <SelectItem value="IN">Indiana</SelectItem>
+                    <SelectItem value="IA">Iowa</SelectItem>
+                    <SelectItem value="KS">Kansas</SelectItem>
+                    <SelectItem value="KY">Kentucky</SelectItem>
+                    <SelectItem value="LA">Louisiana</SelectItem>
+                    <SelectItem value="ME">Maine</SelectItem>
+                    <SelectItem value="MD">Maryland</SelectItem>
+                    <SelectItem value="MA">Massachusetts</SelectItem>
+                    <SelectItem value="MI">Michigan</SelectItem>
+                    <SelectItem value="MN">Minnesota</SelectItem>
+                    <SelectItem value="MS">Mississippi</SelectItem>
+                    <SelectItem value="MO">Missouri</SelectItem>
+                    <SelectItem value="MT">Montana</SelectItem>
+                    <SelectItem value="NE">Nebraska</SelectItem>
+                    <SelectItem value="NV">Nevada</SelectItem>
+                    <SelectItem value="NH">New Hampshire</SelectItem>
+                    <SelectItem value="NJ">New Jersey</SelectItem>
+                    <SelectItem value="NM">New Mexico</SelectItem>
+                    <SelectItem value="NY">New York</SelectItem>
+                    <SelectItem value="NC">North Carolina</SelectItem>
+                    <SelectItem value="ND">North Dakota</SelectItem>
+                    <SelectItem value="OH">Ohio</SelectItem>
+                    <SelectItem value="OK">Oklahoma</SelectItem>
+                    <SelectItem value="OR">Oregon</SelectItem>
+                    <SelectItem value="PA">Pennsylvania</SelectItem>
+                    <SelectItem value="RI">Rhode Island</SelectItem>
+                    <SelectItem value="SC">South Carolina</SelectItem>
+                    <SelectItem value="SD">South Dakota</SelectItem>
+                    <SelectItem value="TN">Tennessee</SelectItem>
+                    <SelectItem value="TX">Texas</SelectItem>
+                    <SelectItem value="UT">Utah</SelectItem>
+                    <SelectItem value="VT">Vermont</SelectItem>
+                    <SelectItem value="VA">Virginia</SelectItem>
+                    <SelectItem value="WA">Washington</SelectItem>
+                    <SelectItem value="WV">West Virginia</SelectItem>
+                    <SelectItem value="WI">Wisconsin</SelectItem>
+                    <SelectItem value="WY">Wyoming</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="zipCode" className="text-sm font-medium text-blue-100">
+                  ZIP code
+                </Label>
                 <Input
-                  id="dateOfBirth"
-                  type="date"
-                  data-testid="input-dateOfBirth"
-                  value={formData.dateOfBirth}
-                  onChange={(e) => handleInputChange("dateOfBirth", e.target.value)}
-                  required
+                  id="zipCode"
+                  data-testid="input-zipCode"
+                  value={formData.zipCode}
+                  onChange={(e) => {
+                    const value = e.target.value.replace(/\D/g, "");
+                    handleInputChange("zipCode", value);
+                  }}
+                  placeholder="12345"
+                  maxLength={5}
+                  className="h-11 rounded-2xl border-white/20 bg-slate-900/60 px-4 text-white placeholder:text-blue-100/50 focus-visible:ring-blue-400"
                 />
-                <p className="text-xs text-gray-500 mt-1">
-                  Used for account verification and security
-                </p>
               </div>
+            </div>
+          </div>
 
-              {/* Address Information */}
-              <div className="space-y-4">
-                <h3 className="text-lg font-medium text-gray-900">Address Information</h3>
-                
-                <div>
-                  <Label htmlFor="address">Street Address *</Label>
-                  <Input
-                    id="address"
-                    data-testid="input-address"
-                    value={formData.address}
-                    onChange={(e) => handleInputChange("address", e.target.value)}
-                    placeholder="123 Main Street"
-                    required
-                  />
-                </div>
-                
-                <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                  <div>
-                    <Label htmlFor="city">City</Label>
-                    <Input
-                      id="city"
-                      data-testid="input-city"
-                      value={formData.city}
-                      onChange={(e) => handleInputChange("city", e.target.value)}
-                    />
-                  </div>
-                  <div>
-                    <Label htmlFor="state">State</Label>
-                    <Select value={formData.state} onValueChange={(value) => handleInputChange("state", value)}>
-                      <SelectTrigger data-testid="select-state">
-                        <SelectValue placeholder="Select state" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="AL">Alabama</SelectItem>
-                        <SelectItem value="AK">Alaska</SelectItem>
-                        <SelectItem value="AZ">Arizona</SelectItem>
-                        <SelectItem value="AR">Arkansas</SelectItem>
-                        <SelectItem value="CA">California</SelectItem>
-                        <SelectItem value="CO">Colorado</SelectItem>
-                        <SelectItem value="CT">Connecticut</SelectItem>
-                        <SelectItem value="DE">Delaware</SelectItem>
-                        <SelectItem value="FL">Florida</SelectItem>
-                        <SelectItem value="GA">Georgia</SelectItem>
-                        <SelectItem value="HI">Hawaii</SelectItem>
-                        <SelectItem value="ID">Idaho</SelectItem>
-                        <SelectItem value="IL">Illinois</SelectItem>
-                        <SelectItem value="IN">Indiana</SelectItem>
-                        <SelectItem value="IA">Iowa</SelectItem>
-                        <SelectItem value="KS">Kansas</SelectItem>
-                        <SelectItem value="KY">Kentucky</SelectItem>
-                        <SelectItem value="LA">Louisiana</SelectItem>
-                        <SelectItem value="ME">Maine</SelectItem>
-                        <SelectItem value="MD">Maryland</SelectItem>
-                        <SelectItem value="MA">Massachusetts</SelectItem>
-                        <SelectItem value="MI">Michigan</SelectItem>
-                        <SelectItem value="MN">Minnesota</SelectItem>
-                        <SelectItem value="MS">Mississippi</SelectItem>
-                        <SelectItem value="MO">Missouri</SelectItem>
-                        <SelectItem value="MT">Montana</SelectItem>
-                        <SelectItem value="NE">Nebraska</SelectItem>
-                        <SelectItem value="NV">Nevada</SelectItem>
-                        <SelectItem value="NH">New Hampshire</SelectItem>
-                        <SelectItem value="NJ">New Jersey</SelectItem>
-                        <SelectItem value="NM">New Mexico</SelectItem>
-                        <SelectItem value="NY">New York</SelectItem>
-                        <SelectItem value="NC">North Carolina</SelectItem>
-                        <SelectItem value="ND">North Dakota</SelectItem>
-                        <SelectItem value="OH">Ohio</SelectItem>
-                        <SelectItem value="OK">Oklahoma</SelectItem>
-                        <SelectItem value="OR">Oregon</SelectItem>
-                        <SelectItem value="PA">Pennsylvania</SelectItem>
-                        <SelectItem value="RI">Rhode Island</SelectItem>
-                        <SelectItem value="SC">South Carolina</SelectItem>
-                        <SelectItem value="SD">South Dakota</SelectItem>
-                        <SelectItem value="TN">Tennessee</SelectItem>
-                        <SelectItem value="TX">Texas</SelectItem>
-                        <SelectItem value="UT">Utah</SelectItem>
-                        <SelectItem value="VT">Vermont</SelectItem>
-                        <SelectItem value="VA">Virginia</SelectItem>
-                        <SelectItem value="WA">Washington</SelectItem>
-                        <SelectItem value="WV">West Virginia</SelectItem>
-                        <SelectItem value="WI">Wisconsin</SelectItem>
-                        <SelectItem value="WY">Wyoming</SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </div>
-                  <div>
-                    <Label htmlFor="zipCode">ZIP Code</Label>
-                    <Input
-                      id="zipCode"
-                      data-testid="input-zipCode"
-                      value={formData.zipCode}
-                      onChange={(e) => {
-                        const value = e.target.value.replace(/\D/g, "");
-                        handleInputChange("zipCode", value);
-                      }}
-                      placeholder="12345"
-                      maxLength={5}
-                    />
-                  </div>
-                </div>
+          <div className="rounded-2xl border border-white/10 bg-white/5 p-5">
+            <div className="flex items-start gap-3">
+              <Checkbox
+                id="agreeToTerms"
+                data-testid="checkbox-agreeToTerms"
+                checked={formData.agreeToTerms}
+                onCheckedChange={(checked) => handleInputChange("agreeToTerms", checked)}
+                className="mt-1 h-5 w-5 rounded-md border-white/40"
+              />
+              <div className="space-y-2 text-sm text-blue-100/80">
+                <Label htmlFor="agreeToTerms" className="font-semibold text-white">
+                  I agree to the {" "}
+                  <a href="/terms-of-service" target="_blank" className="text-blue-200 underline-offset-4 hover:underline">
+                    Terms of Service
+                  </a>{" "}
+                  and {" "}
+                  <a href="/privacy-policy" target="_blank" className="text-blue-200 underline-offset-4 hover:underline">
+                    Privacy Policy
+                  </a>{" "}
+                  *
+                </Label>
+                <p>By registering, you consent to account alerts and communication from your agency.</p>
               </div>
+            </div>
+          </div>
 
-              {/* Terms Agreement */}
-              <div className="bg-gray-50 p-4 rounded-lg">
-                <div className="flex items-start space-x-3">
-                  <Checkbox
-                    id="agreeToTerms"
-                    data-testid="checkbox-agreeToTerms"
-                    checked={formData.agreeToTerms}
-                    onCheckedChange={(checked) => handleInputChange("agreeToTerms", checked)}
-                  />
-                  <div className="text-sm">
-                    <Label htmlFor="agreeToTerms" className="font-medium">
-                      I agree to the <a href="/terms-of-service" target="_blank" className="text-blue-600 hover:underline">Terms of Service</a> and <a href="/privacy-policy" target="_blank" className="text-blue-600 hover:underline">Privacy Policy</a> *
-                    </Label>
-                    <p className="text-gray-600 mt-1">
-                      By registering, you consent to receive notifications about your accounts and communication from our agency.
-                    </p>
-                  </div>
-                </div>
-              </div>
+          <Button
+            type="submit"
+            data-testid="button-register"
+            className="h-12 w-full rounded-full bg-blue-500 text-base font-medium text-white transition hover:bg-blue-400"
+            disabled={registrationMutation.isPending}
+          >
+            {registrationMutation.isPending ? (
+              <>
+                <div className="mr-2 h-4 w-4 animate-spin rounded-full border-b-2 border-white"></div>
+                Registering
+              </>
+            ) : (
+              <>
+                Complete registration
+                <ArrowRight className="ml-2 h-4 w-4" />
+              </>
+            )}
+          </Button>
+        </form>
 
-              {/* Submit Button */}
-              <Button
-                type="submit"
-                data-testid="button-register"
-                className="w-full"
-                disabled={registrationMutation.isPending}
-              >
-                {registrationMutation.isPending ? (
-                  <>
-                    <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2"></div>
-                    Registering...
-                  </>
-                ) : (
-                  <>
-                    Register
-                    <ArrowRight className="h-4 w-4 ml-2" />
-                  </>
-                )}
-              </Button>
-            </form>
-          </CardContent>
-        </Card>
-        
-        {/* Footer Links */}
-        <div className="mt-8 text-center border-t pt-4">
-          <div className="text-sm text-gray-600 space-x-4">
-            <a href="/terms-of-service" className="hover:text-blue-600 hover:underline">
+        <div className="flex flex-wrap items-center justify-between gap-3 text-xs text-blue-100/60">
+          <div className="flex items-center gap-3">
+            <a href="/terms-of-service" className="transition hover:text-white hover:underline">
               Terms of Service
             </a>
             <span>•</span>
-            <a href="/privacy-policy" className="hover:text-blue-600 hover:underline">
+            <a href="/privacy-policy" className="transition hover:text-white hover:underline">
               Privacy Policy
             </a>
           </div>
+          <p>Need help? Contact your agency’s support team anytime.</p>
         </div>
       </div>
-    </div>
+    </PublicHeroLayout>
   );
 }

--- a/client/src/pages/privacy-policy.tsx
+++ b/client/src/pages/privacy-policy.tsx
@@ -1,79 +1,121 @@
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, ShieldCheck, Mail, Phone } from "lucide-react";
 import { useLocation } from "wouter";
+import PublicHeroLayout from "@/components/public-hero-layout";
 
 export default function PrivacyPolicy() {
   const [, navigate] = useLocation();
 
   return (
-    <div className="min-h-screen bg-gray-50 py-8">
-      <div className="container mx-auto px-4 max-w-4xl">
-        <Button 
-          onClick={() => window.history.back()} 
-          variant="ghost" 
-          className="mb-4"
+    <PublicHeroLayout
+      badgeText="Policy center"
+      title="Privacy notice"
+      description="Understand how Chain Software Group protects your information, communicates with you, and supports your rights as a consumer."
+      supportingContent={(
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="flex items-start gap-3 rounded-2xl border border-white/10 bg-white/5 p-4">
+            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-blue-500/20">
+              <ShieldCheck className="h-5 w-5 text-blue-200" />
+            </div>
+            <div className="space-y-1">
+              <p className="text-sm font-semibold text-white">Security first</p>
+              <p className="text-sm text-blue-100/70">Data encryption, role-based access, and audit trails keep your information safe.</p>
+            </div>
+          </div>
+          <div className="flex items-start gap-3 rounded-2xl border border-white/10 bg-white/5 p-4">
+            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-blue-500/20">
+              <Mail className="h-5 w-5 text-blue-200" />
+            </div>
+            <div className="space-y-1">
+              <p className="text-sm font-semibold text-white">Clear communication</p>
+              <p className="text-sm text-blue-100/70">Opt in and out of SMS, email, or push at any time—your preferences are honored instantly.</p>
+            </div>
+          </div>
+        </div>
+      )}
+      headerActions={(
+        <Button
+          variant="ghost"
+          className="text-blue-100 hover:bg-white/10"
+          onClick={() => navigate("/")}
+        >
+          Back to home
+        </Button>
+      )}
+      showDefaultHeaderActions={false}
+      contentClassName="p-8 sm:p-10"
+    >
+      <div className="space-y-8 text-left text-white">
+        <Button
+          onClick={() => window.history.back()}
+          variant="ghost"
+          className="w-fit text-blue-100 hover:bg-white/10"
           data-testid="button-back"
         >
           <ArrowLeft className="mr-2 h-4 w-4" />
           Back
         </Button>
-        
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-2xl">Privacy Notice</CardTitle>
-            <p className="text-sm text-gray-600">Last updated: January 2025</p>
-          </CardHeader>
-          <CardContent className="prose prose-gray max-w-none">
-            <div className="space-y-6 text-gray-700">
-              <div>
-                <h3 className="text-lg font-semibold mb-2">Controller/Processor Roles</h3>
-                <p>Chain operates the platform and generally acts as a processor/service provider for participating agencies, who are responsible for the debts and related notices. For some operations (e.g., App analytics, account creation) Chain may act as an independent controller.</p>
-              </div>
 
-              <div>
-                <h3 className="text-lg font-semibold mb-2">What We Collect</h3>
-                <p>Identifiers (name, email, phone), account references provided by agencies, device data, app usage, communication preferences, consent logs.</p>
-                <p className="mt-2">Payment details are processed by integrated processors; we store only tokens/metadata where needed (no full card or bank numbers).</p>
-              </div>
-
-              <div>
-                <h3 className="text-lg font-semibold mb-2">Why We Use Data</h3>
-                <p>Provide and secure the Service, show account details, deliver communications (SMS/email/push), support, prevent fraud, comply with law.</p>
-              </div>
-
-              <div>
-                <h3 className="text-lg font-semibold mb-2">Communications (SMS/Email/Push) & Consent</h3>
-                <p>By opting in within the App, you agree to receive account-related messages by SMS, email, and push. Message & data rates may apply. Frequency varies. Reply STOP to SMS to opt out; use unsubscribe links for email; disable push in device/App settings. Consent is not required to obtain services. We log all consent and opt-out events.</p>
-              </div>
-
-              <div>
-                <h3 className="text-lg font-semibold mb-2">Sharing</h3>
-                <p>With the agency responsible for your account; with vendors (hosting, messaging, analytics, payment); as required by law; during a merger or acquisition with notice.</p>
-              </div>
-
-              <div>
-                <h3 className="text-lg font-semibold mb-2">Your Choices</h3>
-                <p>Manage notification preferences in the App; opt out of SMS by replying STOP; request copies or deletion of data (subject to legal retention) via support@chainsoftwaregroup.com.</p>
-              </div>
-
-              <div>
-                <h3 className="text-lg font-semibold mb-2">Data Security & Retention</h3>
-                <p>We use industry safeguards (e.g., encryption in transit, role-based access). Data is retained as long as needed for the purposes above or as required by law/agency contracts.</p>
-              </div>
-
-              <div>
-                <h3 className="text-lg font-semibold mb-2">Contact</h3>
-                <p>
-                  <strong>Email:</strong> support@chainsoftwaregroup.com<br />
-                  <strong>Phone:</strong> (716) 534-3086<br />
-                  <strong>Mail:</strong> 1845 Cleveland Ave, Niagara Falls, NY
-                </p>
-              </div>
+        <div className="rounded-3xl border border-white/10 bg-white/5 p-6 text-sm shadow-lg shadow-blue-900/20 backdrop-blur sm:p-8">
+          <div className="flex flex-wrap items-center justify-between gap-3 border-b border-white/10 pb-4">
+            <div>
+              <h2 className="text-2xl font-semibold text-white">Privacy notice</h2>
+              <p className="text-xs uppercase tracking-[0.2em] text-blue-200">Last updated January 2025</p>
             </div>
-          </CardContent>
-        </Card>
+            <div className="flex items-center gap-3 text-xs text-blue-100/60">
+              <Phone className="h-4 w-4" />
+              <span>(716) 534-3086</span>
+            </div>
+          </div>
+
+          <div className="prose prose-invert mt-6 max-w-none space-y-6 text-blue-100/80">
+            <section>
+              <h3>Controller/Processor roles</h3>
+              <p>Chain operates the platform and generally acts as a processor/service provider for participating agencies, who are responsible for the debts and related notices. For some operations (e.g., app analytics, account creation) Chain may act as an independent controller.</p>
+            </section>
+
+            <section>
+              <h3>What we collect</h3>
+              <p>Identifiers (name, email, phone), account references provided by agencies, device data, app usage, communication preferences, consent logs.</p>
+              <p>Payment details are processed by integrated processors; we store only tokens or metadata where needed—never full card or bank numbers.</p>
+            </section>
+
+            <section>
+              <h3>Why we use data</h3>
+              <p>Provide and secure the service, display account details, deliver communications (SMS/email/push), support you, prevent fraud, and comply with legal requirements.</p>
+            </section>
+
+            <section>
+              <h3>Communications & consent</h3>
+              <p>By opting in within the app, you agree to receive account-related messages by SMS, email, and push. Message and data rates may apply. Reply STOP to SMS to opt out; use unsubscribe links for email; disable push in device or app settings. Consent is not required to obtain services. We log all consent and opt-out events.</p>
+            </section>
+
+            <section>
+              <h3>Sharing</h3>
+              <p>We may share data with the agency responsible for your account, with vendors (hosting, messaging, analytics, payment), as required by law, or during a merger or acquisition with notice.</p>
+            </section>
+
+            <section>
+              <h3>Your choices</h3>
+              <p>Manage notification preferences in the app; opt out of SMS by replying STOP; request copies or deletion of data (subject to legal retention) via support@chainsoftwaregroup.com.</p>
+            </section>
+
+            <section>
+              <h3>Data security & retention</h3>
+              <p>We use industry safeguards such as encryption in transit and role-based access. Data is retained as long as needed for the purposes above or as required by law or agency contracts.</p>
+            </section>
+
+            <section>
+              <h3>Contact</h3>
+              <p>
+                Email: <a href="mailto:support@chainsoftwaregroup.com">support@chainsoftwaregroup.com</a><br />
+                Phone: (716) 534-3086<br />
+                Mail: 1845 Cleveland Ave, Niagara Falls, NY
+              </p>
+            </section>
+          </div>
+        </div>
       </div>
-    </div>
+    </PublicHeroLayout>
   );
 }

--- a/client/src/pages/terms-of-service.tsx
+++ b/client/src/pages/terms-of-service.tsx
@@ -1,114 +1,156 @@
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, FileText, Scale, Bell } from "lucide-react";
 import { useLocation } from "wouter";
+import PublicHeroLayout from "@/components/public-hero-layout";
 
 export default function TermsOfService() {
   const [, navigate] = useLocation();
 
   return (
-    <div className="min-h-screen bg-gray-50 py-8">
-      <div className="container mx-auto px-4 max-w-4xl">
-        <Button 
-          onClick={() => window.history.back()} 
-          variant="ghost" 
-          className="mb-4"
+    <PublicHeroLayout
+      badgeText="Policy center"
+      title="Consumer terms of service"
+      description="The rules that govern your use of the Chain consumer experience, including messaging, payments, and dispute resolution."
+      supportingContent={(
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="flex items-start gap-3 rounded-2xl border border-white/10 bg-white/5 p-4">
+            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-blue-500/20">
+              <FileText className="h-5 w-5 text-blue-200" />
+            </div>
+            <div className="space-y-1">
+              <p className="text-sm font-semibold text-white">Plain-language commitments</p>
+              <p className="text-sm text-blue-100/70">Know exactly what you can expect when using the consumer portal.</p>
+            </div>
+          </div>
+          <div className="flex items-start gap-3 rounded-2xl border border-white/10 bg-white/5 p-4">
+            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-blue-500/20">
+              <Scale className="h-5 w-5 text-blue-200" />
+            </div>
+            <div className="space-y-1">
+              <p className="text-sm font-semibold text-white">Fair use principles</p>
+              <p className="text-sm text-blue-100/70">Transparency around communications, payments, and dispute handling.</p>
+            </div>
+          </div>
+        </div>
+      )}
+      headerActions={(
+        <Button
+          variant="ghost"
+          className="text-blue-100 hover:bg-white/10"
+          onClick={() => navigate("/")}
+        >
+          Back to home
+        </Button>
+      )}
+      showDefaultHeaderActions={false}
+      contentClassName="p-8 sm:p-10"
+    >
+      <div className="space-y-8 text-left text-white">
+        <Button
+          onClick={() => window.history.back()}
+          variant="ghost"
+          className="w-fit text-blue-100 hover:bg-white/10"
           data-testid="button-back"
         >
           <ArrowLeft className="mr-2 h-4 w-4" />
           Back
         </Button>
-        
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-2xl">Consumer Terms of Service</CardTitle>
-            <p className="text-sm text-gray-600">Last updated: January 2025</p>
-          </CardHeader>
-          <CardContent className="prose prose-gray max-w-none">
-            <div className="space-y-6 text-gray-700">
-              <div>
-                <p className="mb-2">
-                  <strong>Company:</strong> Chain Software Group ("Chain", "we", "us")<br />
-                  <strong>Website/App:</strong> chainsoftwaregroup.com<br />
-                  <strong>Contact:</strong> support@chainsoftwaregroup.com | (716) 534-3086 | 1845 Cleveland Ave, Niagara Falls, NY
-                </p>
-              </div>
 
-              <div>
-                <h3 className="text-lg font-semibold mb-2">1. Acceptance</h3>
-                <p>By creating an account, accessing, or using the App, you agree to these Terms and our Privacy Notice. If you do not agree, do not use the App.</p>
-              </div>
-
-              <div>
-                <h3 className="text-lg font-semibold mb-2">2. The Service</h3>
-                <p>The App provides a communication portal where consumers can view account information provided by participating agency and receive messages/notifications. Payment options may be offered by agencies through integrated processors. Chain is a platform provider and does not itself originate or service consumer debts.</p>
-              </div>
-
-              <div>
-                <h3 className="text-lg font-semibold mb-2">3. Eligibility; Your Account</h3>
-                <p>You must be 18+ and reside in the United States to use the App. You are responsible for maintaining the confidentiality of your login and for all activity under your account.</p>
-              </div>
-
-              <div>
-                <h3 className="text-lg font-semibold mb-2">4. Consumer Communications & Consent</h3>
-                <p>You agree that Chain and participating agencies may send you automated and non-automated communications about your accounts by SMS/text, email, and push notifications.</p>
-                <ul className="list-disc pl-6 mt-2 space-y-2">
-                  <li><strong>SMS/Text:</strong> Message & data rates may apply. Message frequency varies. Reply STOP to stop, HELP for help.</li>
-                  <li><strong>Email:</strong> You may unsubscribe using the link in any email.</li>
-                  <li><strong>Push:</strong> You can disable push in your device or in-app settings.</li>
-                </ul>
-                <p className="mt-2"><strong>Consent Not Required:</strong> Your consent to automated messages is not required as a condition of any service, plan, or settlement.</p>
-                <p className="mt-2"><strong>Recordkeeping:</strong> We maintain consent and opt-out logs. You can manage preferences in the App or contact support@chainsoftwaregroup.com or (716) 534-3086.</p>
-              </div>
-
-              <div>
-                <h3 className="text-lg font-semibold mb-2">5. Payment Features</h3>
-                <p>Payments may be facilitated via third-party processors (e.g., card/ACH). You authorize the processor and the relevant agency to charge your selected payment method in accordance with any payment plan or one-time authorization you accept. Payment disputes, refunds, chargebacks, or payoff letters are handled by the agency responsible for your account.</p>
-              </div>
-
-              <div>
-                <h3 className="text-lg font-semibold mb-2">6. User Conduct; Prohibited Uses</h3>
-                <p>You agree not to: (a) use the App for unlawful purposes; (b) attempt to access data that is not yours; (c) interfere with security or integrity; (d) reverse engineer or scrape the Service; (e) impersonate others.</p>
-              </div>
-
-              <div>
-                <h3 className="text-lg font-semibold mb-2">7. Privacy</h3>
-                <p>Our collection and use of personal information is described in our Privacy Notice. Agencies are independent entities and may have their own privacy obligations as controllers of their consumer data.</p>
-              </div>
-
-              <div>
-                <h3 className="text-lg font-semibold mb-2">8. Disclaimers</h3>
-                <p>THE APP IS PROVIDED "AS IS." WE DISCLAIM ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT. We do not guarantee the accuracy of account data provided by agencies.</p>
-              </div>
-
-              <div>
-                <h3 className="text-lg font-semibold mb-2">9. Limitation of Liability</h3>
-                <p>TO THE MAXIMUM EXTENT PERMITTED BY LAW, CHAIN AND ITS AFFILIATES ARE NOT LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL OR PUNITIVE DAMAGES, OR ANY LOSS OF PROFITS, DATA, OR GOODWILL, ARISING FROM OR RELATING TO YOUR USE OF THE APP. OUR TOTAL LIABILITY SHALL NOT EXCEED THE GREATER OF $100 OR THE AMOUNT YOU PAID TO US IN THE 12 MONTHS BEFORE THE CLAIM.</p>
-              </div>
-
-              <div>
-                <h3 className="text-lg font-semibold mb-2">10. Dispute Resolution; Arbitration; Class Action Waiver</h3>
-                <p>Any dispute will be resolved by binding arbitration on an individual basis. You waive any right to participate in a class action or class-wide arbitration. You may opt out of arbitration within 30 days of account creation by emailing support@chainsoftwaregroup.com with your name and the subject "Arbitration Opt-Out."</p>
-              </div>
-
-              <div>
-                <h3 className="text-lg font-semibold mb-2">11. Changes</h3>
-                <p>We may update these Terms by posting the revised version with a new "Last updated" date. Your continued use constitutes acceptance. Material changes will be notified within the App or by email/SMS where appropriate.</p>
-              </div>
-
-              <div>
-                <h3 className="text-lg font-semibold mb-2">12. Termination</h3>
-                <p>We may suspend or terminate your access for any reason. Upon termination, sections intended to survive will survive.</p>
-              </div>
-
-              <div>
-                <h3 className="text-lg font-semibold mb-2">13. Contact</h3>
-                <p>Questions? support@chainsoftwaregroup.com | 1845 Cleveland Ave, Niagara Falls, NY</p>
-              </div>
+        <div className="rounded-3xl border border-white/10 bg-white/5 p-6 text-sm shadow-lg shadow-blue-900/20 backdrop-blur sm:p-8">
+          <div className="flex flex-wrap items-center justify-between gap-3 border-b border-white/10 pb-4">
+            <div>
+              <h2 className="text-2xl font-semibold text-white">Consumer Terms of Service</h2>
+              <p className="text-xs uppercase tracking-[0.2em] text-blue-200">Last updated January 2025</p>
             </div>
-          </CardContent>
-        </Card>
+            <div className="flex items-center gap-3 text-xs text-blue-100/60">
+              <Bell className="h-4 w-4" />
+              <span>Notifications & messaging guidelines</span>
+            </div>
+          </div>
+
+          <div className="prose prose-invert mt-6 max-w-none space-y-6 text-blue-100/80">
+            <section>
+              <p>
+                <strong>Company:</strong> Chain Software Group (“Chain”, “we”, “us”)<br />
+                <strong>Website/App:</strong> chainsoftwaregroup.com<br />
+                <strong>Contact:</strong> support@chainsoftwaregroup.com | (716) 534-3086 | 1845 Cleveland Ave, Niagara Falls, NY
+              </p>
+            </section>
+
+            <section>
+              <h3>1. Acceptance</h3>
+              <p>By creating an account, accessing, or using the app, you agree to these terms and our privacy notice. If you do not agree, please discontinue use.</p>
+            </section>
+
+            <section>
+              <h3>2. The service</h3>
+              <p>The app provides a communication portal where consumers can view account information supplied by participating agencies and receive messages or notifications. Payment options may be offered by agencies through integrated processors. Chain is the platform provider and does not originate or service consumer debts.</p>
+            </section>
+
+            <section>
+              <h3>3. Eligibility; your account</h3>
+              <p>You must be 18+ and reside in the United States to use the app. You are responsible for maintaining the confidentiality of your login and for all activity under your account.</p>
+            </section>
+
+            <section>
+              <h3>4. Consumer communications & consent</h3>
+              <p>You agree that Chain and participating agencies may send automated and non-automated communications about your accounts by SMS/text, email, and push notifications.</p>
+              <ul>
+                <li><strong>SMS/Text:</strong> Message and data rates may apply. Message frequency varies. Reply STOP to stop, HELP for help.</li>
+                <li><strong>Email:</strong> Unsubscribe using the link in any message.</li>
+                <li><strong>Push:</strong> Disable push in your device or app settings.</li>
+              </ul>
+              <p><strong>Consent not required:</strong> Consent to automated messages is not required as a condition of any service, plan, or settlement.</p>
+              <p><strong>Recordkeeping:</strong> We maintain consent and opt-out logs. Manage preferences in the app or contact support@chainsoftwaregroup.com or (716) 534-3086.</p>
+            </section>
+
+            <section>
+              <h3>5. Payment features</h3>
+              <p>Payments may be facilitated via third-party processors (e.g., card/ACH). You authorize the processor and the relevant agency to charge your selected payment method in line with any plan or one-time authorization you accept. Payment disputes, refunds, chargebacks, or payoff letters are handled by the agency responsible for your account.</p>
+            </section>
+
+            <section>
+              <h3>6. User conduct; prohibited uses</h3>
+              <p>You agree not to use the app for unlawful purposes, attempt to access data that is not yours, interfere with security or integrity, reverse engineer or scrape the service, or impersonate others.</p>
+            </section>
+
+            <section>
+              <h3>7. Privacy</h3>
+              <p>Our collection and use of personal information is described in our privacy notice. Agencies are independent entities and may have their own privacy obligations as controllers of their consumer data.</p>
+            </section>
+
+            <section>
+              <h3>8. Disclaimers</h3>
+              <p>The app is provided “as is.” We disclaim all warranties, express or implied, including merchantability, fitness for a particular purpose, and non-infringement. We do not guarantee the accuracy of account data provided by agencies.</p>
+            </section>
+
+            <section>
+              <h3>9. Limitation of liability</h3>
+              <p>To the maximum extent permitted by law, Chain and its affiliates are not liable for any indirect, incidental, special, consequential or punitive damages, or any loss of profits, data, or goodwill arising from or relating to your use of the app. Our total liability shall not exceed the greater of $100 or the amount you paid to us in the 12 months before the claim.</p>
+            </section>
+
+            <section>
+              <h3>10. Dispute resolution; arbitration; class action waiver</h3>
+              <p>Any dispute will be resolved by binding arbitration on an individual basis. You waive any right to participate in a class action or class-wide arbitration. You may opt out of arbitration within 30 days of account creation by emailing support@chainsoftwaregroup.com with your name and the subject “Arbitration Opt-Out.”</p>
+            </section>
+
+            <section>
+              <h3>11. Changes</h3>
+              <p>We may update these terms by posting the revised version with a new “last updated” date. Your continued use constitutes acceptance. Material changes will be notified within the app or by email/SMS where appropriate.</p>
+            </section>
+
+            <section>
+              <h3>12. Termination</h3>
+              <p>We may suspend or terminate your access for any reason. Sections intended to survive termination will continue in effect.</p>
+            </section>
+
+            <section>
+              <h3>13. Contact</h3>
+              <p>Questions? support@chainsoftwaregroup.com | 1845 Cleveland Ave, Niagara Falls, NY</p>
+            </section>
+          </div>
+        </div>
       </div>
-    </div>
+    </PublicHeroLayout>
   );
 }


### PR DESCRIPTION
## Summary
- add a shared `PublicHeroLayout` component that mirrors the landing hero styling
- restyle the consumer login and registration flows to render inside the new hero experience
- wrap the privacy and terms policy pages in the updated hero shell with refreshed typography

## Testing
- npm run check *(fails: existing TypeScript errors in unrelated pages and server files)*

------
https://chatgpt.com/codex/tasks/task_e_68d20a77b9e8832aa60cdf35ff262e99