### PR TITLE
Expose agency policies on public landing page

### DIFF
--- a/api/public/agency-branding.ts
+++ b/api/public/agency-branding.ts
@@ -32,6 +32,7 @@ async function handler(req: VercelRequest, res: VercelResponse) {
         name: tenants.name,
         slug: tenants.slug,
         brand: tenants.brand,
+        isActive: tenants.isActive,
       })
       .from(tenants)
       .where(eq(tenants.slug, slug))
@@ -39,6 +40,11 @@ async function handler(req: VercelRequest, res: VercelResponse) {
 
     if (!tenant) {
       res.status(404).json({ error: 'Agency not found' });
+      return;
+    }
+
+    if (!tenant.isActive) {
+      res.status(403).json({ error: 'Agency is not active' });
       return;
     }
 
@@ -67,6 +73,8 @@ async function handler(req: VercelRequest, res: VercelResponse) {
       contactPhone: settings?.contactPhone || null,
       hasPrivacyPolicy: !!settings?.privacyPolicy,
       hasTermsOfService: !!settings?.termsOfService,
+      privacyPolicy: settings?.privacyPolicy || null,
+      termsOfService: settings?.termsOfService || null,
     };
 
     res.status(200).json(branding);

--- a/client/src/pages/__tests__/agency-policy-utils.test.ts
+++ b/client/src/pages/__tests__/agency-policy-utils.test.ts
@@ -1,0 +1,49 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { resolvePolicyContent } from "../agency-policy-utils";
+
+test("uses agency-provided policy text when available", () => {
+  const result = resolvePolicyContent({
+    primary: {
+      termsOfService: "Agency Terms",
+      privacyPolicy: "Agency Privacy",
+    },
+  });
+
+  assert.equal(result.termsContent, "Agency Terms");
+  assert.equal(result.privacyContent, "Agency Privacy");
+  assert.equal(result.hasTermsContent, true);
+  assert.equal(result.hasPrivacyContent, true);
+});
+
+test("falls back to agency defaults when policies are missing", () => {
+  const result = resolvePolicyContent({
+    primary: {
+      termsOfService: null,
+      privacyPolicy: undefined,
+    },
+    fallback: {
+      termsOfService: "Fallback Terms",
+      privacyPolicy: "Fallback Privacy",
+    },
+  });
+
+  assert.equal(result.termsContent, "Fallback Terms");
+  assert.equal(result.privacyContent, "Fallback Privacy");
+  assert.equal(result.hasTermsContent, true);
+  assert.equal(result.hasPrivacyContent, true);
+});
+
+test("treats whitespace-only policy text as empty for display controls", () => {
+  const result = resolvePolicyContent({
+    primary: {
+      termsOfService: "   ",
+      privacyPolicy: "\n\t",
+    },
+  });
+
+  assert.equal(result.termsContent, "   ");
+  assert.equal(result.privacyContent, "\n\t");
+  assert.equal(result.hasTermsContent, false);
+  assert.equal(result.hasPrivacyContent, false);
+});

--- a/client/src/pages/agency-policy-utils.ts
+++ b/client/src/pages/agency-policy-utils.ts
@@ -1,0 +1,37 @@
+export interface PolicySource {
+  termsOfService?: string | null;
+  privacyPolicy?: string | null;
+}
+
+export interface PolicyResolution {
+  termsContent: string;
+  privacyContent: string;
+  hasTermsContent: boolean;
+  hasPrivacyContent: boolean;
+}
+
+function toText(value: string | null | undefined): string {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  return value == null ? "" : String(value);
+}
+
+export function resolvePolicyContent({
+  primary,
+  fallback,
+}: {
+  primary?: PolicySource | null;
+  fallback?: PolicySource | null;
+}): PolicyResolution {
+  const termsContent = toText(primary?.termsOfService ?? fallback?.termsOfService ?? "");
+  const privacyContent = toText(primary?.privacyPolicy ?? fallback?.privacyPolicy ?? "");
+
+  return {
+    termsContent,
+    privacyContent,
+    hasTermsContent: termsContent.trim().length > 0,
+    hasPrivacyContent: privacyContent.trim().length > 0,
+  };
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
+    "test": "node --test --import tsx ./client/src/pages/__tests__/agency-policy-utils.test.ts",
     "db:push": "drizzle-kit push"
   },
   "dependencies": {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1247,16 +1247,20 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // Public agency branding endpoint
   app.get('/api/public/agency-branding', async (req, res) => {
     const { slug } = req.query;
-    
+
     if (!slug || typeof slug !== 'string') {
       return res.status(400).json({ error: 'Agency slug is required' });
     }
 
     try {
       const tenant = await storage.getTenantBySlug(slug);
-      
+
       if (!tenant) {
         return res.status(404).json({ error: 'Agency not found' });
+      }
+
+      if (!tenant.isActive) {
+        return res.status(403).json({ error: 'Agency is not active' });
       }
 
       // Get tenant settings for additional branding
@@ -1274,6 +1278,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
         contactPhone: settings?.contactPhone || null,
         hasPrivacyPolicy: !!settings?.privacyPolicy,
         hasTermsOfService: !!settings?.termsOfService,
+        privacyPolicy: settings?.privacyPolicy || null,
+        termsOfService: settings?.termsOfService || null,
       };
 
       res.status(200).json(branding);


### PR DESCRIPTION
## Summary
- ensure the agency-branding API handlers only serve active tenants and include the published policy text in their responses
- keep agency landing page policy copy in component state, render it in the dialogs, and hide the buttons when no text is available via a small helper
- add a node-based unit test that exercises the policy resolution helper to confirm agency-authored content is surfaced

## Testing
- npm run test
- npm run check *(fails: existing type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d2095fc090832a9c229d460c43c0cb