### PR TITLE
Fix email template API auth and deletion issues

### DIFF
--- a/api/_lib/auth.ts
+++ b/api/_lib/auth.ts
@@ -4,7 +4,7 @@ import { platformUsers, users } from '../../shared/schema.js';
 import { eq } from 'drizzle-orm';
 import jwt from 'jsonwebtoken';
 
-const JWT_SECRET = process.env.JWT_SECRET || 'your-jwt-secret-key-change-this-in-production';
+export const JWT_SECRET = process.env.JWT_SECRET || 'your-secret-key';
 
 export interface AuthenticatedRequest extends VercelRequest {
   user?: any;

--- a/api/accounts.ts
+++ b/api/accounts.ts
@@ -1,11 +1,9 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { getDb } from './_lib/db.js';
-import { withAuth, AuthenticatedRequest } from './_lib/auth.js';
+import { withAuth, AuthenticatedRequest, JWT_SECRET } from './_lib/auth.js';
 import { accounts, consumers, folders } from './_lib/schema.js';
 import { eq, and } from 'drizzle-orm';
 import jwt from 'jsonwebtoken';
-
-const JWT_SECRET = process.env.JWT_SECRET || 'your-jwt-secret-key-change-this-in-production';
 
 async function handler(req: AuthenticatedRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') {

--- a/api/accounts/[id].ts
+++ b/api/accounts/[id].ts
@@ -1,11 +1,9 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { getDb } from '../_lib/db.js';
-import { withAuth, AuthenticatedRequest } from '../_lib/auth.js';
+import { withAuth, AuthenticatedRequest, JWT_SECRET } from '../_lib/auth.js';
 import { accounts } from '../_lib/schema.js';
 import { eq, and } from 'drizzle-orm';
 import jwt from 'jsonwebtoken';
-
-const JWT_SECRET = process.env.JWT_SECRET || 'your-jwt-secret-key-change-this-in-production';
 
 async function handler(req: AuthenticatedRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') {

--- a/api/accounts/bulk-delete.ts
+++ b/api/accounts/bulk-delete.ts
@@ -1,11 +1,9 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { getDb } from '../_lib/db.js';
-import { withAuth, AuthenticatedRequest } from '../_lib/auth.js';
+import { withAuth, AuthenticatedRequest, JWT_SECRET } from '../_lib/auth.js';
 import { accounts } from '../_lib/schema.js';
 import { eq, and, inArray } from 'drizzle-orm';
 import jwt from 'jsonwebtoken';
-
-const JWT_SECRET = process.env.JWT_SECRET || 'your-jwt-secret-key-change-this-in-production';
 
 async function handler(req: AuthenticatedRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') {

--- a/api/arrangement-options.ts
+++ b/api/arrangement-options.ts
@@ -3,8 +3,7 @@ import jwt from 'jsonwebtoken';
 import { getDb } from './_lib/db.js';
 import { arrangementOptions } from './_lib/schema.js';
 import { eq, and } from 'drizzle-orm';
-
-const JWT_SECRET = process.env.JWT_SECRET || 'your-secret-key';
+import { JWT_SECRET } from './_lib/auth.js';
 
 interface AuthenticatedRequest extends VercelRequest {
   method: string;

--- a/api/arrangement-options/[id].ts
+++ b/api/arrangement-options/[id].ts
@@ -2,9 +2,7 @@ import { VercelRequest, VercelResponse } from '@vercel/node';
 import jwt from 'jsonwebtoken';
 import { getDb } from '../_lib/db.js';
 import { arrangementOptions } from '../_lib/schema.js';
-import { eq, and } from 'drizzle-orm';
-
-const JWT_SECRET = process.env.JWT_SECRET || 'your-secret-key';
+import { JWT_SECRET } from '../_lib/auth.js';
 
 interface AuthenticatedRequest extends VercelRequest {
   method: string;

--- a/api/automations.ts
+++ b/api/automations.ts
@@ -1,11 +1,9 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { getDb } from './_lib/db.js';
-import { withAuth, AuthenticatedRequest } from './_lib/auth.js';
+import { withAuth, AuthenticatedRequest, JWT_SECRET } from './_lib/auth.js';
 import { communicationAutomations, automationExecutions, emailTemplates, smsTemplates } from './_lib/schema.js';
 import { eq, and, desc, sql } from 'drizzle-orm';
 import jwt from 'jsonwebtoken';
-
-const JWT_SECRET = process.env.JWT_SECRET || 'your-jwt-secret-key-change-this-in-production';
 
 async function handler(req: AuthenticatedRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') {

--- a/api/callback-requests.ts
+++ b/api/callback-requests.ts
@@ -1,11 +1,9 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { getDb } from './_lib/db.js';
-import { withAuth, AuthenticatedRequest } from './_lib/auth.js';
+import { withAuth, AuthenticatedRequest, JWT_SECRET } from './_lib/auth.js';
 import { callbackRequests, consumers } from './_lib/schema.js';
 import { eq, and, desc } from 'drizzle-orm';
 import jwt from 'jsonwebtoken';
-
-const JWT_SECRET = process.env.JWT_SECRET || 'your-jwt-secret-key-change-this-in-production';
 
 async function handler(req: AuthenticatedRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') {

--- a/api/consumer/login.ts
+++ b/api/consumer/login.ts
@@ -4,13 +4,12 @@ import { consumers, tenants } from '../../shared/schema.js';
 import { eq, and } from 'drizzle-orm';
 import { z } from 'zod';
 import jwt from 'jsonwebtoken';
+import { JWT_SECRET } from '../_lib/auth.js';
 
 const loginSchema = z.object({
   email: z.string().email(),
   dateOfBirth: z.string()  // Consumer verifies with DOB
 });
-
-const JWT_SECRET = process.env.JWT_SECRET || 'your-jwt-secret-key-change-this-in-production';
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'POST') {

--- a/api/consumers.ts
+++ b/api/consumers.ts
@@ -1,11 +1,9 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { getDb } from './_lib/db.js';
-import { withAuth, AuthenticatedRequest } from './_lib/auth.js';
+import { withAuth, AuthenticatedRequest, JWT_SECRET } from './_lib/auth.js';
 import { consumers, accounts, folders } from './_lib/schema.js';
 import { eq, and, sql, inArray } from 'drizzle-orm';
 import jwt from 'jsonwebtoken';
-
-const JWT_SECRET = process.env.JWT_SECRET || 'your-jwt-secret-key-change-this-in-production';
 
 async function handler(req: AuthenticatedRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') {

--- a/api/documents.ts
+++ b/api/documents.ts
@@ -3,8 +3,7 @@ import jwt from 'jsonwebtoken';
 import { getDb } from './_lib/db.js';
 import { documents } from './_lib/schema.js';
 import { eq, and } from 'drizzle-orm';
-
-const JWT_SECRET = process.env.JWT_SECRET || 'your-secret-key';
+import { JWT_SECRET } from './_lib/auth.js';
 
 interface AuthenticatedRequest extends VercelRequest {
   method: string;

--- a/api/documents/[id].ts
+++ b/api/documents/[id].ts
@@ -3,8 +3,7 @@ import jwt from 'jsonwebtoken';
 import { getDb } from '../_lib/db.js';
 import { documents } from '../_lib/schema.js';
 import { eq, and } from 'drizzle-orm';
-
-const JWT_SECRET = process.env.JWT_SECRET || 'your-secret-key';
+import { JWT_SECRET } from '../_lib/auth.js';
 
 interface AuthenticatedRequest extends VercelRequest {
   method: string;

--- a/api/email-campaigns.ts
+++ b/api/email-campaigns.ts
@@ -1,11 +1,9 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { getDb } from './_lib/db.js';
-import { withAuth, AuthenticatedRequest } from './_lib/auth.js';
+import { withAuth, AuthenticatedRequest, JWT_SECRET } from './_lib/auth.js';
 import { emailCampaigns, emailTemplates, consumers, emailTracking } from './_lib/schema.js';
 import { eq, and, desc, sql } from 'drizzle-orm';
 import jwt from 'jsonwebtoken';
-
-const JWT_SECRET = process.env.JWT_SECRET || 'your-jwt-secret-key-change-this-in-production';
 
 async function handler(req: AuthenticatedRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') {

--- a/api/email-templates.ts
+++ b/api/email-templates.ts
@@ -1,11 +1,9 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { getDb } from './_lib/db.js';
-import { withAuth, AuthenticatedRequest } from './_lib/auth.js';
+import { withAuth, AuthenticatedRequest, JWT_SECRET } from './_lib/auth.js';
 import { emailTemplates } from './_lib/schema.js';
 import { eq, and, desc } from 'drizzle-orm';
 import jwt from 'jsonwebtoken';
-
-const JWT_SECRET = process.env.JWT_SECRET || 'your-jwt-secret-key-change-this-in-production';
 
 async function handler(req: AuthenticatedRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') {

--- a/api/email-templates/[id].ts
+++ b/api/email-templates/[id].ts
@@ -1,0 +1,73 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { getDb } from '../_lib/db.js';
+import { withAuth, AuthenticatedRequest, JWT_SECRET } from '../_lib/auth.js';
+import { emailTemplates } from '../_lib/schema.js';
+import { eq, and } from 'drizzle-orm';
+import jwt from 'jsonwebtoken';
+
+async function handler(req: AuthenticatedRequest, res: VercelResponse) {
+  if (req.method === 'OPTIONS') {
+    res.status(200).end();
+    return;
+  }
+
+  if (req.method !== 'DELETE') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  try {
+    const db = getDb();
+    const templateIdParam = req.query.id;
+    const templateId = Array.isArray(templateIdParam) ? templateIdParam[0] : templateIdParam;
+
+    if (!templateId || typeof templateId !== 'string') {
+      res.status(400).json({ error: 'Template ID is required' });
+      return;
+    }
+
+    const token = req.headers.authorization?.replace('Bearer ', '') ||
+                  req.headers.cookie?.split(';').find(c => c.trim().startsWith('authToken='))?.split('=')[1];
+
+    if (!token) {
+      res.status(401).json({ error: 'No token provided' });
+      return;
+    }
+
+    const decoded = jwt.verify(token, JWT_SECRET) as any;
+    const tenantId = decoded.tenantId;
+
+    if (!tenantId) {
+      res.status(403).json({ error: 'No tenant access' });
+      return;
+    }
+
+    const [template] = await db
+      .select()
+      .from(emailTemplates)
+      .where(and(
+        eq(emailTemplates.id, templateId),
+        eq(emailTemplates.tenantId, tenantId)
+      ))
+      .limit(1);
+
+    if (!template) {
+      res.status(404).json({ error: 'Template not found' });
+      return;
+    }
+
+    await db
+      .delete(emailTemplates)
+      .where(eq(emailTemplates.id, templateId));
+
+    res.status(200).json({ success: true, message: 'Template deleted successfully' });
+  } catch (error: any) {
+    console.error('Error deleting email template:', error);
+    res.status(500).json({
+      error: 'Failed to delete email template',
+      message: error.message,
+    });
+  }
+}
+
+export default withAuth(handler);

--- a/api/folders.ts
+++ b/api/folders.ts
@@ -1,11 +1,9 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { getDb } from './_lib/db.js';
-import { withAuth, AuthenticatedRequest } from './_lib/auth.js';
+import { withAuth, AuthenticatedRequest, JWT_SECRET } from './_lib/auth.js';
 import { folders, accounts } from './_lib/schema.js';
 import { eq, and } from 'drizzle-orm';
 import jwt from 'jsonwebtoken';
-
-const JWT_SECRET = process.env.JWT_SECRET || 'your-jwt-secret-key-change-this-in-production';
 
 async function handler(req: AuthenticatedRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') {

--- a/api/import/csv.ts
+++ b/api/import/csv.ts
@@ -1,11 +1,9 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { getDb } from '../_lib/db.js';
-import { withAuth, AuthenticatedRequest } from '../_lib/auth.js';
+import { withAuth, AuthenticatedRequest, JWT_SECRET } from '../_lib/auth.js';
 import { consumers, accounts, folders } from '../../shared/schema.js';
 import { eq, and, sql } from 'drizzle-orm';
 import jwt from 'jsonwebtoken';
-
-const JWT_SECRET = process.env.JWT_SECRET || 'your-jwt-secret-key-change-this-in-production';
 
 async function handler(req: AuthenticatedRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') {

--- a/api/settings.ts
+++ b/api/settings.ts
@@ -1,11 +1,9 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { getDb } from './_lib/db.js';
-import { withAuth, AuthenticatedRequest } from './_lib/auth.js';
+import { withAuth, AuthenticatedRequest, JWT_SECRET } from './_lib/auth.js';
 import { tenantSettings, tenants } from './_lib/schema.js';
 import { eq, and } from 'drizzle-orm';
 import jwt from 'jsonwebtoken';
-
-const JWT_SECRET = process.env.JWT_SECRET || 'your-jwt-secret-key-change-this-in-production';
 
 async function handler(req: AuthenticatedRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') {

--- a/api/sms-campaigns.ts
+++ b/api/sms-campaigns.ts
@@ -1,11 +1,9 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { getDb } from './_lib/db.js';
-import { withAuth, AuthenticatedRequest } from './_lib/auth.js';
+import { withAuth, AuthenticatedRequest, JWT_SECRET } from './_lib/auth.js';
 import { smsCampaigns, smsTemplates, consumers, smsTracking } from './_lib/schema.js';
 import { eq, and, desc, sql } from 'drizzle-orm';
 import jwt from 'jsonwebtoken';
-
-const JWT_SECRET = process.env.JWT_SECRET || 'your-jwt-secret-key-change-this-in-production';
 
 async function handler(req: AuthenticatedRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') {

--- a/api/sms-templates.ts
+++ b/api/sms-templates.ts
@@ -1,11 +1,9 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { getDb } from './_lib/db.js';
-import { withAuth, AuthenticatedRequest } from './_lib/auth.js';
+import { withAuth, AuthenticatedRequest, JWT_SECRET } from './_lib/auth.js';
 import { smsTemplates } from './_lib/schema.js';
 import { eq, and, desc } from 'drizzle-orm';
 import jwt from 'jsonwebtoken';
-
-const JWT_SECRET = process.env.JWT_SECRET || 'your-jwt-secret-key-change-this-in-production';
 
 async function handler(req: AuthenticatedRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') {

--- a/api/stats.ts
+++ b/api/stats.ts
@@ -1,11 +1,9 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { getDb } from './_lib/db.js';
-import { withAuth, AuthenticatedRequest } from './_lib/auth.js';
+import { withAuth, AuthenticatedRequest, JWT_SECRET } from './_lib/auth.js';
 import { consumers, accounts, folders } from './_lib/schema.js';
 import { eq, and, sql } from 'drizzle-orm';
 import jwt from 'jsonwebtoken';
-
-const JWT_SECRET = process.env.JWT_SECRET || 'your-jwt-secret-key-change-this-in-production';
 
 async function handler(req: AuthenticatedRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') {

--- a/api/upload/logo.ts
+++ b/api/upload/logo.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { getDb } from '../_lib/db.js';
-import { withAuth, AuthenticatedRequest } from '../_lib/auth.js';
+import { withAuth, AuthenticatedRequest, JWT_SECRET } from '../_lib/auth.js';
 import { tenants, tenantSettings } from '../_lib/schema.js';
 import { eq } from 'drizzle-orm';
 import jwt from 'jsonwebtoken';
@@ -8,7 +8,6 @@ import { createClient } from '@supabase/supabase-js';
 import { writeFile } from 'fs/promises';
 import { join } from 'path';
 
-const JWT_SECRET = process.env.JWT_SECRET || 'your-jwt-secret-key-change-this-in-production';
 const SUPABASE_URL = process.env.SUPABASE_URL!;
 const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
 


### PR DESCRIPTION
## Summary
- export a shared JWT secret constant and update the Vercel API routes to consume it so JWT verification matches the issued tokens
- add a dynamic `/api/email-templates/[id]` handler to support path-based template deletion used by the dashboard

## Testing
- `npm run check` *(fails: existing TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d2908af878832a97a84f458f26837a