### PR TITLE
Enable dynamic merge fields in campaigns

### DIFF
--- a/client/src/pages/communications.tsx
+++ b/client/src/pages/communications.tsx
@@ -844,10 +844,33 @@ export default function Communications() {
                             data-testid="textarea-html"
                             value={emailTemplateForm.html}
                             onChange={(e) => setEmailTemplateForm({ ...emailTemplateForm, html: e.target.value })}
-                            placeholder="Enter your email content (HTML supported)"
+                            placeholder="Enter your email content. Use {{firstName}} or {balance}."
                             rows={8}
                             required
                           />
+                        </div>
+                        <div className="bg-blue-50 border border-blue-200 rounded-md p-3">
+                          <h4 className="font-medium text-blue-900 text-sm mb-1">Available Variables</h4>
+                          <p className="text-xs text-blue-700 mb-2">
+                            Use <code className="font-mono">{"{{variable}}"}</code> or <code className="font-mono">{"{variable}"}</code> syntax to personalize each message.
+                          </p>
+                          <div className="text-xs text-blue-800 grid grid-cols-2 md:grid-cols-3 gap-1">
+                            <div>• {"{{firstName}}"}</div>
+                            <div>• {"{{lastName}}"}</div>
+                            <div>• {"{{fullName}}"}</div>
+                            <div>• {"{{email}}"}</div>
+                            <div>• {"{{phone}}"}</div>
+                            <div>• {"{{accountNumber}}"}</div>
+                            <div>• {"{{creditor}}"}</div>
+                            <div>• {"{{balance}}"}</div>
+                            <div>• {"{{dueDate}}"}</div>
+                            <div>• {"{{consumerPortalLink}}"}</div>
+                            <div>• {"{{appDownloadLink}}"}</div>
+                            <div>• {"{{agencyName}}"}</div>
+                            <div>• {"{{agencyEmail}}"}</div>
+                            <div>• {"{{agencyPhone}}"}</div>
+                            <div className="col-span-full">• Plus any additional CSV columns</div>
+                          </div>
                         </div>
                       </>
                     ) : (
@@ -858,7 +881,7 @@ export default function Communications() {
                           data-testid="textarea-message"
                           value={smsTemplateForm.message}
                           onChange={(e) => setSmsTemplateForm({ ...smsTemplateForm, message: e.target.value })}
-                          placeholder="Enter your SMS message (160 characters recommended)"
+                          placeholder="Enter your SMS message. Use {{firstName}} or {balance}."
                           rows={6}
                           maxLength={1600}
                           required
@@ -866,6 +889,27 @@ export default function Communications() {
                         <p className="text-sm text-gray-500 mt-1">
                           {smsTemplateForm.message.length}/1600 characters
                         </p>
+                        <div className="mt-3 bg-blue-50 border border-blue-200 rounded-md p-3">
+                          <h4 className="font-medium text-blue-900 text-sm mb-1">Available Variables</h4>
+                          <p className="text-xs text-blue-700 mb-2">
+                            Use <code className="font-mono">{"{{variable}}"}</code> or <code className="font-mono">{"{variable}"}</code> syntax to personalize each message.
+                          </p>
+                          <div className="text-xs text-blue-800 grid grid-cols-2 gap-1">
+                            <div>• {"{{firstName}}"}</div>
+                            <div>• {"{{lastName}}"}</div>
+                            <div>• {"{{fullName}}"}</div>
+                            <div>• {"{{phone}}"}</div>
+                            <div>• {"{{accountNumber}}"}</div>
+                            <div>• {"{{creditor}}"}</div>
+                            <div>• {"{{balance}}"}</div>
+                            <div>• {"{{dueDate}}"}</div>
+                            <div>• {"{{consumerPortalLink}}"}</div>
+                            <div>• {"{{appDownloadLink}}"}</div>
+                            <div>• {"{{agencyName}}"}</div>
+                            <div>• {"{{agencyPhone}}"}</div>
+                            <div className="col-span-full">• Plus any additional CSV columns</div>
+                          </div>
+                        </div>
                       </div>
                     )}
                     

--- a/client/src/pages/emails.tsx
+++ b/client/src/pages/emails.tsx
@@ -207,25 +207,35 @@ export default function Emails() {
                         rows={10}
                         value={templateForm.html}
                         onChange={(e) => setTemplateForm({...templateForm, html: e.target.value})}
-                        placeholder="Enter your HTML email content. Use variables like {{firstName}}, {{balance}}, etc."
+                        placeholder="Enter your HTML email content. Use variables like {{firstName}} or {balance}."
                         className="font-mono text-sm"
                         data-testid="input-template-html"
                       />
                     </div>
-                    
+
                     <div className="bg-blue-50 border border-blue-200 rounded-md p-3">
-                      <h4 className="font-medium text-blue-900 text-sm mb-2">Available Variables:</h4>
-                      <div className="text-xs text-blue-800 grid grid-cols-2 gap-1">
+                      <h4 className="font-medium text-blue-900 text-sm mb-1">Available Variables:</h4>
+                      <p className="text-xs text-blue-700 mb-2">
+                        Use either <code className="font-mono">{"{{variable}}"}</code> or <code className="font-mono">{"{variable}"}</code> syntax.
+                      </p>
+                      <div className="text-xs text-blue-800 grid grid-cols-2 md:grid-cols-3 gap-1">
                         <div>• {"{{firstName}}"}</div>
                         <div>• {"{{lastName}}"}</div>
+                        <div>• {"{{fullName}}"}</div>
                         <div>• {"{{email}}"}</div>
+                        <div>• {"{{phone}}"}</div>
                         <div>• {"{{accountNumber}}"}</div>
                         <div>• {"{{creditor}}"}</div>
                         <div>• {"{{balance}}"}</div>
+                        <div>• {"{{balanceCents}}"}</div>
                         <div>• {"{{dueDate}}"}</div>
+                        <div>• {"{{dueDateIso}}"}</div>
                         <div>• {"{{consumerPortalLink}}"}</div>
                         <div>• {"{{appDownloadLink}}"}</div>
-                        <div>• Plus any additional CSV columns</div>
+                        <div>• {"{{agencyName}}"}</div>
+                        <div>• {"{{agencyEmail}}"}</div>
+                        <div>• {"{{agencyPhone}}"}</div>
+                        <div className="col-span-full">• Plus any additional CSV columns</div>
                       </div>
                     </div>
                   </div>

--- a/client/src/pages/sms.tsx
+++ b/client/src/pages/sms.tsx
@@ -332,7 +332,7 @@ export default function SMS() {
                         data-testid="textarea-message"
                         value={templateForm.message}
                         onChange={(e) => setTemplateForm({ ...templateForm, message: e.target.value })}
-                        placeholder="Enter your SMS message (160 characters recommended)"
+                        placeholder="Enter your SMS message. Use {{firstName}} or {balance} to personalize."
                         rows={6}
                         maxLength={1600}
                         required
@@ -340,6 +340,27 @@ export default function SMS() {
                       <p className="text-sm text-gray-500 mt-1">
                         {templateForm.message.length}/1600 characters
                       </p>
+                      <div className="mt-3 bg-blue-50 border border-blue-200 rounded-md p-3">
+                        <h4 className="font-medium text-blue-900 text-sm mb-1">Available Variables:</h4>
+                        <p className="text-xs text-blue-700 mb-2">
+                          Use <code className="font-mono">{"{{variable}}"}</code> or <code className="font-mono">{"{variable}"}</code> syntax to insert data.
+                        </p>
+                        <div className="text-xs text-blue-800 grid grid-cols-2 gap-1">
+                          <div>• {"{{firstName}}"}</div>
+                          <div>• {"{{lastName}}"}</div>
+                          <div>• {"{{fullName}}"}</div>
+                          <div>• {"{{phone}}"}</div>
+                          <div>• {"{{accountNumber}}"}</div>
+                          <div>• {"{{creditor}}"}</div>
+                          <div>• {"{{balance}}"}</div>
+                          <div>• {"{{dueDate}}"}</div>
+                          <div>• {"{{consumerPortalLink}}"}</div>
+                          <div>• {"{{appDownloadLink}}"}</div>
+                          <div>• {"{{agencyName}}"}</div>
+                          <div>• {"{{agencyPhone}}"}</div>
+                          <div className="col-span-full">• Plus any additional CSV columns</div>
+                        </div>
+                      </div>
                     </div>
                     <div className="flex justify-end gap-2">
                       <Button


### PR DESCRIPTION
## Summary
- add a shared template variable replacement helper that supports both `{{variable}}` and `{variable}` syntax, richer merge fields, and consumer/account CSV data when sending
- update email and SMS campaign handlers to personalize outgoing messages, update recipient totals, and queue SMS sends
- surface the available merge fields in the email, SMS, and communications template dialogs so admins know how to personalize content

## Testing
- npm run check *(fails: repo contains pre-existing TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d2934a69b8832a93ad3195bc266109