### PR TITLE
Handle missing campaign targeting columns

### DIFF
--- a/api/_lib/db.ts
+++ b/api/_lib/db.ts
@@ -2,26 +2,40 @@ import postgres from 'postgres';
 import { drizzle } from 'drizzle-orm/postgres-js';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 
-let db: PostgresJsDatabase | null = null;
-let client: ReturnType<typeof postgres> | null = null;
+type SqlClient = ReturnType<typeof postgres>;
 
-export function getDb() {
+let db: PostgresJsDatabase | null = null;
+let client: SqlClient | null = null;
+
+function initConnection() {
   if (!process.env.DATABASE_URL) {
     throw new Error('DATABASE_URL environment variable is not set');
   }
-  
-  // Reuse connection in serverless environment
-  if (!db) {
+
+  if (!db || !client) {
     client = postgres(process.env.DATABASE_URL, {
       max: 1,
       ssl: 'require',
       idle_timeout: 20,
       max_lifetime: 60 * 2,
-      connect_timeout: 10
+      connect_timeout: 10,
     });
-    
+
     db = drizzle(client);
   }
-  
-  return db;
+
+  return { db, client };
+}
+
+export function getDb(): PostgresJsDatabase {
+  return initConnection().db!;
+}
+
+export function getSqlClient(): SqlClient {
+  const { client: sqlClient } = initConnection();
+  if (!sqlClient) {
+    throw new Error('Failed to initialize database client');
+  }
+
+  return sqlClient;
 }

--- a/api/_lib/schema.ts
+++ b/api/_lib/schema.ts
@@ -152,6 +152,14 @@ export const smsCampaigns = pgTable("sms_campaigns", {
   templateId: uuid("template_id").references(() => smsTemplates.id, { onDelete: "cascade" }).notNull(),
   name: text("name").notNull(),
   targetGroup: text("target_group").notNull(), // "all", "with-balance", "decline", "recent-upload"
+  targetType: text("target_type").default('all').notNull(),
+  targetFolderIds: jsonb("target_folder_ids").$type<string[]>().default(sql`'[]'::jsonb`),
+  customFilters: jsonb("custom_filters").$type<{
+    balanceMin?: string;
+    balanceMax?: string;
+    status?: string;
+    lastContactDays?: string;
+  }>().default(sql`'{}'::jsonb`),
   status: text("status").default("pending"), // "pending", "sending", "completed", "failed"
   totalRecipients: bigint("total_recipients", { mode: "number" }).default(0),
   totalSent: bigint("total_sent", { mode: "number" }).default(0),
@@ -256,6 +264,14 @@ export const emailCampaigns = pgTable("email_campaigns", {
   templateId: uuid("template_id").references(() => emailTemplates.id, { onDelete: "cascade" }).notNull(),
   name: text("name").notNull(),
   targetGroup: text("target_group").notNull(), // "all", "with-balance", "overdue"
+  targetType: text("target_type").default('all').notNull(),
+  targetFolderIds: jsonb("target_folder_ids").$type<string[]>().default(sql`'[]'::jsonb`),
+  customFilters: jsonb("custom_filters").$type<{
+    balanceMin?: string;
+    balanceMax?: string;
+    status?: string;
+    lastContactDays?: string;
+  }>().default(sql`'{}'::jsonb`),
   status: text("status").default("pending"), // "pending", "sending", "completed", "failed"
   totalRecipients: bigint("total_recipients", { mode: "number" }).default(0),
   totalSent: bigint("total_sent", { mode: "number" }).default(0),

--- a/api/email-campaigns.ts
+++ b/api/email-campaigns.ts
@@ -1,9 +1,118 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
-import { getDb } from './_lib/db.js';
+import { getDb, getSqlClient } from './_lib/db.js';
 import { withAuth, AuthenticatedRequest } from './_lib/auth.js';
-import { emailCampaigns, emailTemplates, consumers, emailTracking } from './_lib/schema.js';
-import { eq, and, desc, sql } from 'drizzle-orm';
+import { emailCampaigns, emailTemplates, consumers, accounts } from './_lib/schema.js';
+import { eq, and, desc } from 'drizzle-orm';
+import { z } from 'zod';
+import { filterConsumersForCampaign, sanitizeTargetingInput } from '@shared/utils/campaignTargeting.js';
 import jwt from 'jsonwebtoken';
+
+type RawRecord = Record<string, unknown>;
+
+function ensureStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const result: string[] = [];
+  for (const entry of value) {
+    if (typeof entry === 'string') {
+      const trimmed = entry.trim();
+      if (trimmed) {
+        result.push(trimmed);
+      }
+    }
+  }
+
+  return result;
+}
+
+function ensureCustomFilters(value: unknown) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+
+  const record = value as RawRecord;
+  const result: RawRecord = {};
+
+  const keys: Array<keyof typeof record> = ['balanceMin', 'balanceMax', 'status', 'lastContactDays'];
+  for (const key of keys) {
+    const entry = record[key];
+    if (typeof entry === 'string') {
+      const trimmed = entry.trim();
+      if (trimmed) {
+        result[key] = trimmed;
+      }
+    }
+  }
+
+  return result;
+}
+
+function ensureDate(value: unknown): Date | null {
+  if (!value) {
+    return null;
+  }
+
+  if (value instanceof Date) {
+    return value;
+  }
+
+  const parsed = new Date(value as string | number);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function mapLegacyCampaignRow(row: RawRecord, templateNameKey: string) {
+  const templateNameValue = row[templateNameKey];
+
+  return {
+    id: row.id,
+    tenantId: row.tenant_id,
+    templateId: row.template_id,
+    name: row.name,
+    targetGroup: (row.target_group as string) ?? 'all',
+    targetType: ((row.target_type as string) ?? 'all') as 'all' | 'folder' | 'custom',
+    targetFolderIds: ensureStringArray(row.target_folder_ids),
+    customFilters: ensureCustomFilters(row.custom_filters),
+    status: (row.status as string) ?? 'pending',
+    totalRecipients: Number((row.total_recipients as string | number | null) ?? 0),
+    totalSent: Number((row.total_sent as string | number | null) ?? 0),
+    totalDelivered: Number((row.total_delivered as string | number | null) ?? 0),
+    totalOpened: Number((row.total_opened as string | number | null) ?? 0),
+    totalClicked: Number((row.total_clicked as string | number | null) ?? 0),
+    totalErrors: Number((row.total_errors as string | number | null) ?? 0),
+    totalOptOuts: Number((row.total_opt_outs as string | number | null) ?? 0),
+    createdAt: ensureDate(row.created_at),
+    completedAt: ensureDate(row.completed_at),
+    templateName: typeof templateNameValue === 'string' ? templateNameValue : null,
+  };
+}
+
+let emailCampaignTargetingSupported: boolean | null = null;
+async function supportsEmailCampaignTargeting(): Promise<boolean> {
+  if (emailCampaignTargetingSupported !== null) {
+    return emailCampaignTargetingSupported;
+  }
+
+  try {
+    const sql = getSqlClient();
+    const result = await sql`
+      SELECT 1
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = ${'email_campaigns'}
+        AND column_name = ${'target_type'}
+      LIMIT 1
+    `;
+
+    emailCampaignTargetingSupported = result.length > 0;
+  } catch (error) {
+    console.error('Failed to inspect email_campaigns columns', error);
+    emailCampaignTargetingSupported = false;
+  }
+
+  return emailCampaignTargetingSupported;
+}
 
 const JWT_SECRET = process.env.JWT_SECRET || 'your-jwt-secret-key-change-this-in-production';
 
@@ -34,29 +143,81 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
     }
 
     if (req.method === 'GET') {
-      // Get all email campaigns for the tenant
-      const campaigns = await db
-        .select()
-        .from(emailCampaigns)
-        .where(eq(emailCampaigns.tenantId, tenantId))
-        .orderBy(desc(emailCampaigns.createdAt));
+      if (await supportsEmailCampaignTargeting()) {
+        const [campaigns, templates] = await Promise.all([
+          db
+            .select()
+            .from(emailCampaigns)
+            .where(eq(emailCampaigns.tenantId, tenantId))
+            .orderBy(desc(emailCampaigns.createdAt)),
+          db
+            .select()
+            .from(emailTemplates)
+            .where(eq(emailTemplates.tenantId, tenantId)),
+        ]);
 
-      res.status(200).json(campaigns);
-    } else if (req.method === 'POST') {
-      // Create a new email campaign
-      const { templateId, name, targetGroup } = req.body;
+        const templateNameMap = new Map(templates.map((template) => [template.id, template.name]));
 
-      if (!templateId || !name || !targetGroup) {
-        res.status(400).json({ error: 'Template ID, name, and target group are required' });
+        const normalizedCampaigns = campaigns.map((campaign) => ({
+          ...campaign,
+          targetFolderIds: ensureStringArray(campaign.targetFolderIds),
+          customFilters: ensureCustomFilters(campaign.customFilters),
+          templateName: templateNameMap.get(campaign.templateId) ?? null,
+        }));
+
+        res.status(200).json(normalizedCampaigns);
         return;
       }
 
-      // Verify template exists and belongs to tenant
+      const sql = getSqlClient();
+      const campaigns = await sql`
+        SELECT ec.*, et.name AS template_name
+        FROM email_campaigns ec
+        LEFT JOIN email_templates et ON ec.template_id = et.id
+        WHERE ec.tenant_id = ${tenantId}
+        ORDER BY ec.created_at DESC
+      `;
+
+      const normalizedCampaigns = campaigns.map((campaign) => {
+        const normalized = mapLegacyCampaignRow(campaign as RawRecord, 'template_name');
+        return normalized;
+      });
+
+      res.status(200).json(normalizedCampaigns);
+    } else if (req.method === 'POST') {
+      const campaignSchema = z.object({
+        templateId: z.string().uuid(),
+        name: z.string().min(1),
+        targetGroup: z.enum(['all', 'with-balance', 'decline', 'recent-upload']).default('all'),
+        targetType: z.enum(['all', 'folder', 'custom']).optional(),
+        targetFolderIds: z.array(z.string().uuid()).optional(),
+        customFilters: z.object({
+          balanceMin: z.string().optional(),
+          balanceMax: z.string().optional(),
+          status: z.string().optional(),
+          lastContactDays: z.string().optional(),
+        }).optional(),
+      });
+
+      const parsedBody = campaignSchema.parse(req.body);
+
+      const targeting = sanitizeTargetingInput({
+        targetGroup: parsedBody.targetGroup,
+        targetType: parsedBody.targetType,
+        targetFolderIds: parsedBody.targetFolderIds,
+        customFilters: parsedBody.customFilters,
+      });
+
+      if (targeting.targetType === 'folder' && targeting.targetFolderIds.length === 0) {
+        res.status(400).json({ error: 'Please select at least one folder' });
+        return;
+      }
+
       const [template] = await db
         .select()
         .from(emailTemplates)
         .where(and(
-          eq(emailTemplates.id, templateId),
+          eq(emailTemplates.id, parsedBody.templateId),
           eq(emailTemplates.tenantId, tenantId)
         ))
         .limit(1);
@@ -66,57 +227,78 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
         return;
       }
 
-      // Count target recipients based on targetGroup
-      let recipientCount = 0;
-      
-      if (targetGroup === 'all') {
-        const result = await db
-          .select({ count: sql<number>`count(*)` })
-          .from(consumers)
-          .where(eq(consumers.tenantId, tenantId));
-        recipientCount = Number(result[0]?.count || 0);
-      } else if (targetGroup === 'with-balance') {
-        // This would need to join with accounts table and check balance > 0
-        // For now, using a simplified query
-        const result = await db
-          .select({ count: sql<number>`count(*)` })
-          .from(consumers)
-          .where(and(
-            eq(consumers.tenantId, tenantId),
-            sql`EXISTS (SELECT 1 FROM accounts WHERE accounts.consumer_id = consumers.id AND accounts.balance > 0)`
-          ));
-        recipientCount = Number(result[0]?.count || 0);
-      } else if (targetGroup === 'overdue') {
-        // This would check for overdue accounts
-        const result = await db
-          .select({ count: sql<number>`count(*)` })
-          .from(consumers)
-          .where(and(
-            eq(consumers.tenantId, tenantId),
-            sql`EXISTS (SELECT 1 FROM accounts WHERE accounts.consumer_id = consumers.id AND accounts.due_date < NOW())`
-          ));
-        recipientCount = Number(result[0]?.count || 0);
+      const consumersList = await db
+        .select()
+        .from(consumers)
+        .where(eq(consumers.tenantId, tenantId));
+
+      const accountsList = await db
+        .select()
+        .from(accounts)
+        .where(eq(accounts.tenantId, tenantId));
+
+      const targetedConsumers = filterConsumersForCampaign(consumersList, accountsList, targeting);
+      const recipientCount = targetedConsumers.filter((consumer) => !!consumer.email).length;
+
+      if (await supportsEmailCampaignTargeting()) {
+        const [newCampaign] = await db
+          .insert(emailCampaigns)
+          .values({
+            tenantId,
+            templateId: parsedBody.templateId,
+            name: parsedBody.name,
+            targetGroup: targeting.targetGroup,
+            targetType: targeting.targetType,
+            targetFolderIds: targeting.targetFolderIds,
+            customFilters: targeting.customFilters,
+            status: 'pending',
+            totalRecipients: recipientCount,
+            totalSent: 0,
+            totalDelivered: 0,
+            totalOpened: 0,
+            totalClicked: 0,
+            totalErrors: 0,
+            totalOptOuts: 0,
+          })
+          .returning();
+
+        res.status(201).json({
+          ...newCampaign,
+          targetFolderIds: ensureStringArray(newCampaign.targetFolderIds),
+          customFilters: ensureCustomFilters(newCampaign.customFilters),
+          templateName: template.name,
+        });
+        return;
       }
 
-      const [newCampaign] = await db
-        .insert(emailCampaigns)
-        .values({
-          tenantId,
-          templateId,
+      const sql = getSqlClient();
+      const legacyInsert = await sql`
+        INSERT INTO email_campaigns (
+          tenant_id,
+          template_id,
           name,
-          targetGroup,
-          status: 'pending',
-          totalRecipients: recipientCount,
-          totalSent: 0,
-          totalDelivered: 0,
-          totalOpened: 0,
-          totalClicked: 0,
-          totalErrors: 0,
-          totalOptOuts: 0,
-        })
-        .returning();
+          target_group,
+          status,
+          total_recipients
+        )
+        VALUES (${tenantId}, ${parsedBody.templateId}, ${parsedBody.name}, ${targeting.targetGroup}, ${'pending'}, ${recipientCount})
+        RETURNING *
+      `;
 
-      res.status(201).json(newCampaign);
+      const legacyCampaign = legacyInsert[0] as RawRecord | undefined;
+      if (!legacyCampaign) {
+        res.status(500).json({ error: 'Failed to create email campaign' });
+        return;
+      }
+
+      const normalized = mapLegacyCampaignRow(legacyCampaign, 'template_name');
+      res.status(201).json({
+        ...normalized,
+        targetType: 'all',
+        targetFolderIds: [],
+        customFilters: {},
+        templateName: template.name,
+      });
     } else if (req.method === 'PUT') {
       // Update campaign status (start/pause/cancel)
       const { campaignId, status } = req.body;

--- a/api/sms-campaigns.ts
+++ b/api/sms-campaigns.ts
@@ -1,9 +1,116 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
-import { getDb } from './_lib/db.js';
+import { getDb, getSqlClient } from './_lib/db.js';
 import { withAuth, AuthenticatedRequest } from './_lib/auth.js';
-import { smsCampaigns, smsTemplates, consumers, smsTracking } from './_lib/schema.js';
-import { eq, and, desc, sql } from 'drizzle-orm';
+import { smsCampaigns, smsTemplates, consumers, accounts } from './_lib/schema.js';
+import { eq, and, desc } from 'drizzle-orm';
+import { z } from 'zod';
+import { filterConsumersForCampaign, sanitizeTargetingInput } from '@shared/utils/campaignTargeting.js';
 import jwt from 'jsonwebtoken';
+
+type RawRecord = Record<string, unknown>;
+
+function ensureStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const result: string[] = [];
+  for (const entry of value) {
+    if (typeof entry === 'string') {
+      const trimmed = entry.trim();
+      if (trimmed) {
+        result.push(trimmed);
+      }
+    }
+  }
+
+  return result;
+}
+
+function ensureCustomFilters(value: unknown) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+
+  const record = value as RawRecord;
+  const result: RawRecord = {};
+
+  const keys: Array<keyof typeof record> = ['balanceMin', 'balanceMax', 'status', 'lastContactDays'];
+  for (const key of keys) {
+    const entry = record[key];
+    if (typeof entry === 'string') {
+      const trimmed = entry.trim();
+      if (trimmed) {
+        result[key] = trimmed;
+      }
+    }
+  }
+
+  return result;
+}
+
+function ensureDate(value: unknown): Date | null {
+  if (!value) {
+    return null;
+  }
+
+  if (value instanceof Date) {
+    return value;
+  }
+
+  const parsed = new Date(value as string | number);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function mapLegacySmsCampaignRow(row: RawRecord, templateNameKey: string) {
+  const templateNameValue = row[templateNameKey];
+
+  return {
+    id: row.id,
+    tenantId: row.tenant_id,
+    templateId: row.template_id,
+    name: row.name,
+    targetGroup: (row.target_group as string) ?? 'all',
+    targetType: ((row.target_type as string) ?? 'all') as 'all' | 'folder' | 'custom',
+    targetFolderIds: ensureStringArray(row.target_folder_ids),
+    customFilters: ensureCustomFilters(row.custom_filters),
+    status: (row.status as string) ?? 'pending',
+    totalRecipients: Number((row.total_recipients as string | number | null) ?? 0),
+    totalSent: Number((row.total_sent as string | number | null) ?? 0),
+    totalDelivered: Number((row.total_delivered as string | number | null) ?? 0),
+    totalErrors: Number((row.total_errors as string | number | null) ?? 0),
+    totalOptOuts: Number((row.total_opt_outs as string | number | null) ?? 0),
+    createdAt: ensureDate(row.created_at),
+    completedAt: ensureDate(row.completed_at),
+    templateName: typeof templateNameValue === 'string' ? templateNameValue : null,
+  };
+}
+
+let smsCampaignTargetingSupported: boolean | null = null;
+async function supportsSmsCampaignTargeting(): Promise<boolean> {
+  if (smsCampaignTargetingSupported !== null) {
+    return smsCampaignTargetingSupported;
+  }
+
+  try {
+    const sql = getSqlClient();
+    const result = await sql`
+      SELECT 1
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = ${'sms_campaigns'}
+        AND column_name = ${'target_type'}
+      LIMIT 1
+    `;
+
+    smsCampaignTargetingSupported = result.length > 0;
+  } catch (error) {
+    console.error('Failed to inspect sms_campaigns columns', error);
+    smsCampaignTargetingSupported = false;
+  }
+
+  return smsCampaignTargetingSupported;
+}
 
 const JWT_SECRET = process.env.JWT_SECRET || 'your-jwt-secret-key-change-this-in-production';
 
@@ -34,29 +141,80 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
     }
 
     if (req.method === 'GET') {
-      // Get all SMS campaigns for the tenant
-      const campaigns = await db
-        .select()
-        .from(smsCampaigns)
-        .where(eq(smsCampaigns.tenantId, tenantId))
-        .orderBy(desc(smsCampaigns.createdAt));
+      if (await supportsSmsCampaignTargeting()) {
+        const [campaigns, templates] = await Promise.all([
+          db
+            .select()
+            .from(smsCampaigns)
+            .where(eq(smsCampaigns.tenantId, tenantId))
+            .orderBy(desc(smsCampaigns.createdAt)),
+          db
+            .select()
+            .from(smsTemplates)
+            .where(eq(smsTemplates.tenantId, tenantId)),
+        ]);
 
-      res.status(200).json(campaigns);
-    } else if (req.method === 'POST') {
-      // Create a new SMS campaign
-      const { templateId, name, targetGroup, throttleRate } = req.body;
+        const templateNameMap = new Map(templates.map((template) => [template.id, template.name]));
 
-      if (!templateId || !name || !targetGroup) {
-        res.status(400).json({ error: 'Template ID, name, and target group are required' });
+        const normalizedCampaigns = campaigns.map((campaign) => ({
+          ...campaign,
+          targetFolderIds: ensureStringArray(campaign.targetFolderIds),
+          customFilters: ensureCustomFilters(campaign.customFilters),
+          templateName: templateNameMap.get(campaign.templateId) ?? null,
+        }));
+
+        res.status(200).json(normalizedCampaigns);
         return;
       }
 
-      // Verify template exists and belongs to tenant
+      const sql = getSqlClient();
+      const campaigns = await sql`
+        SELECT sc.*, st.name AS template_name
+        FROM sms_campaigns sc
+        LEFT JOIN sms_templates st ON sc.template_id = st.id
+        WHERE sc.tenant_id = ${tenantId}
+        ORDER BY sc.created_at DESC
+      `;
+
+      const normalizedCampaigns = campaigns.map((campaign) =>
+        mapLegacySmsCampaignRow(campaign as RawRecord, 'template_name'),
+      );
+
+      res.status(200).json(normalizedCampaigns);
+    } else if (req.method === 'POST') {
+      const smsCampaignSchema = z.object({
+        templateId: z.string().uuid(),
+        name: z.string().min(1),
+        targetGroup: z.enum(['all', 'with-balance', 'decline', 'recent-upload']).default('all'),
+        targetType: z.enum(['all', 'folder', 'custom']).optional(),
+        targetFolderIds: z.array(z.string().uuid()).optional(),
+        customFilters: z.object({
+          balanceMin: z.string().optional(),
+          balanceMax: z.string().optional(),
+          status: z.string().optional(),
+          lastContactDays: z.string().optional(),
+        }).optional(),
+      });
+
+      const parsedBody = smsCampaignSchema.parse(req.body);
+
+      const targeting = sanitizeTargetingInput({
+        targetGroup: parsedBody.targetGroup,
+        targetType: parsedBody.targetType,
+        targetFolderIds: parsedBody.targetFolderIds,
+        customFilters: parsedBody.customFilters,
+      });
+
+      if (targeting.targetType === 'folder' && targeting.targetFolderIds.length === 0) {
+        res.status(400).json({ error: 'Please select at least one folder' });
+        return;
+      }
+
       const [template] = await db
         .select()
         .from(smsTemplates)
         .where(and(
-          eq(smsTemplates.id, templateId),
+          eq(smsTemplates.id, parsedBody.templateId),
           eq(smsTemplates.tenantId, tenantId)
         ))
         .limit(1);
@@ -66,52 +224,76 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
         return;
       }
 
-      // Count target recipients based on targetGroup
-      let recipientCount = 0;
-      
-      if (targetGroup === 'all') {
-        const result = await db
-          .select({ count: sql<number>`count(*)` })
-          .from(consumers)
-          .where(eq(consumers.tenantId, tenantId));
-        recipientCount = Number(result[0]?.count || 0);
-      } else if (targetGroup === 'with-balance') {
-        const result = await db
-          .select({ count: sql<number>`count(*)` })
-          .from(consumers)
-          .where(and(
-            eq(consumers.tenantId, tenantId),
-            sql`EXISTS (SELECT 1 FROM accounts WHERE accounts.consumer_id = consumers.id AND accounts.balance > 0)`
-          ));
-        recipientCount = Number(result[0]?.count || 0);
-      } else if (targetGroup === 'overdue') {
-        const result = await db
-          .select({ count: sql<number>`count(*)` })
-          .from(consumers)
-          .where(and(
-            eq(consumers.tenantId, tenantId),
-            sql`EXISTS (SELECT 1 FROM accounts WHERE accounts.consumer_id = consumers.id AND accounts.due_date < NOW())`
-          ));
-        recipientCount = Number(result[0]?.count || 0);
+      const consumersList = await db
+        .select()
+        .from(consumers)
+        .where(eq(consumers.tenantId, tenantId));
+
+      const accountsList = await db
+        .select()
+        .from(accounts)
+        .where(eq(accounts.tenantId, tenantId));
+
+      const targetedConsumers = filterConsumersForCampaign(consumersList, accountsList, targeting);
+      const recipientCount = targetedConsumers.filter((consumer) => !!consumer.phone).length;
+
+      if (await supportsSmsCampaignTargeting()) {
+        const [newCampaign] = await db
+          .insert(smsCampaigns)
+          .values({
+            tenantId,
+            templateId: parsedBody.templateId,
+            name: parsedBody.name,
+            targetGroup: targeting.targetGroup,
+            targetType: targeting.targetType,
+            targetFolderIds: targeting.targetFolderIds,
+            customFilters: targeting.customFilters,
+            status: 'pending',
+            totalRecipients: recipientCount,
+            totalSent: 0,
+            totalDelivered: 0,
+            totalErrors: 0,
+            totalOptOuts: 0,
+          })
+          .returning();
+
+        res.status(201).json({
+          ...newCampaign,
+          targetFolderIds: ensureStringArray(newCampaign.targetFolderIds),
+          customFilters: ensureCustomFilters(newCampaign.customFilters),
+          templateName: template.name,
+        });
+        return;
       }
 
-      const [newCampaign] = await db
-        .insert(smsCampaigns)
-        .values({
-          tenantId,
-          templateId,
+      const sql = getSqlClient();
+      const legacyInsert = await sql`
+        INSERT INTO sms_campaigns (
+          tenant_id,
+          template_id,
           name,
-          targetGroup,
-          status: 'pending',
-          totalRecipients: recipientCount,
-          totalSent: 0,
-          totalDelivered: 0,
-          totalErrors: 0,
-          totalOptOuts: 0,
-        })
-        .returning();
+          target_group,
+          status,
+          total_recipients
+        )
+        VALUES (${tenantId}, ${parsedBody.templateId}, ${parsedBody.name}, ${targeting.targetGroup}, ${'pending'}, ${recipientCount})
+        RETURNING *
+      `;
 
-      res.status(201).json(newCampaign);
+      const legacyCampaign = legacyInsert[0] as RawRecord | undefined;
+      if (!legacyCampaign) {
+        res.status(500).json({ error: 'Failed to create SMS campaign' });
+        return;
+      }
+
+      const normalized = mapLegacySmsCampaignRow(legacyCampaign, 'template_name');
+      res.status(201).json({
+        ...normalized,
+        targetType: 'all',
+        targetFolderIds: [],
+        customFilters: {},
+        templateName: template.name,
+      });
     } else if (req.method === 'PUT') {
       // Update campaign status (start/pause/cancel)
       const { campaignId, status } = req.body;

--- a/migrations/20240329_add_campaign_targeting.sql
+++ b/migrations/20240329_add_campaign_targeting.sql
@@ -1,0 +1,13 @@
+ALTER TABLE email_campaigns
+  ADD COLUMN IF NOT EXISTS target_type text NOT NULL DEFAULT 'all';
+ALTER TABLE email_campaigns
+  ADD COLUMN IF NOT EXISTS target_folder_ids jsonb NOT NULL DEFAULT '[]'::jsonb;
+ALTER TABLE email_campaigns
+  ADD COLUMN IF NOT EXISTS custom_filters jsonb NOT NULL DEFAULT '{}'::jsonb;
+
+ALTER TABLE sms_campaigns
+  ADD COLUMN IF NOT EXISTS target_type text NOT NULL DEFAULT 'all';
+ALTER TABLE sms_campaigns
+  ADD COLUMN IF NOT EXISTS target_folder_ids jsonb NOT NULL DEFAULT '[]'::jsonb;
+ALTER TABLE sms_campaigns
+  ADD COLUMN IF NOT EXISTS custom_filters jsonb NOT NULL DEFAULT '{}'::jsonb;

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -176,6 +176,14 @@ export const emailCampaigns = pgTable("email_campaigns", {
   templateId: uuid("template_id").references(() => emailTemplates.id, { onDelete: "cascade" }).notNull(),
   name: text("name").notNull(),
   targetGroup: text("target_group").notNull(), // "all", "with-balance", "overdue"
+  targetType: text("target_type", { enum: ['all', 'folder', 'custom'] }).default('all').notNull(),
+  targetFolderIds: jsonb("target_folder_ids").$type<string[]>().default(sql`'[]'::jsonb`),
+  customFilters: jsonb("custom_filters").$type<{
+    balanceMin?: string;
+    balanceMax?: string;
+    status?: string;
+    lastContactDays?: string;
+  }>().default(sql`'{}'::jsonb`),
   status: text("status").default("pending"), // "pending", "sending", "completed", "failed"
   totalRecipients: bigint("total_recipients", { mode: "number" }).default(0),
   totalSent: bigint("total_sent", { mode: "number" }).default(0),
@@ -220,6 +228,14 @@ export const smsCampaigns = pgTable("sms_campaigns", {
   templateId: uuid("template_id").references(() => smsTemplates.id, { onDelete: "cascade" }).notNull(),
   name: text("name").notNull(),
   targetGroup: text("target_group").notNull(), // "all", "with-balance", "decline", "recent-upload"
+  targetType: text("target_type", { enum: ['all', 'folder', 'custom'] }).default('all').notNull(),
+  targetFolderIds: jsonb("target_folder_ids").$type<string[]>().default(sql`'[]'::jsonb`),
+  customFilters: jsonb("custom_filters").$type<{
+    balanceMin?: string;
+    balanceMax?: string;
+    status?: string;
+    lastContactDays?: string;
+  }>().default(sql`'{}'::jsonb`),
   status: text("status").default("pending"), // "pending", "sending", "completed", "failed"
   totalRecipients: bigint("total_recipients", { mode: "number" }).default(0),
   totalSent: bigint("total_sent", { mode: "number" }).default(0),

--- a/shared/utils/campaignTargeting.ts
+++ b/shared/utils/campaignTargeting.ts
@@ -1,0 +1,301 @@
+import type { Account, Consumer } from "@shared/schema";
+
+export type CampaignTargetGroup = "all" | "with-balance" | "decline" | "recent-upload";
+export type CampaignTargetType = "all" | "folder" | "custom";
+
+export type CampaignCustomFilters = {
+  balanceMin?: string;
+  balanceMax?: string;
+  status?: string;
+  lastContactDays?: string;
+};
+
+export interface CampaignTargetingInput {
+  targetGroup: CampaignTargetGroup;
+  targetType: CampaignTargetType;
+  targetFolderIds: string[];
+  customFilters: CampaignCustomFilters;
+}
+
+export interface CampaignConsumerLike
+  extends Pick<Consumer, "id" | "folderId" | "additionalData" | "registrationDate" | "createdAt"> {}
+
+export interface CampaignAccountLike
+  extends Pick<Account, "consumerId" | "folderId" | "balanceCents" | "status"> {}
+
+const allowedTargetGroups: readonly CampaignTargetGroup[] = [
+  "all",
+  "with-balance",
+  "decline",
+  "recent-upload",
+];
+
+const allowedTargetTypes: readonly CampaignTargetType[] = ["all", "folder", "custom"];
+
+function parseCurrencyToCents(value?: string): number | null {
+  if (!value) {
+    return null;
+  }
+
+  const cleaned = value.replace(/[^0-9.-]/g, "");
+  if (!cleaned) {
+    return null;
+  }
+
+  const parsed = Number.parseFloat(cleaned);
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+
+  return Math.round(parsed * 100);
+}
+
+function parseInteger(value?: string): number | null {
+  if (!value) {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const parsed = Number.parseInt(trimmed, 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function matchesAdditionalStatus(additionalData: Consumer["additionalData"], status: string): boolean {
+  if (!additionalData || typeof additionalData !== "object") {
+    return false;
+  }
+
+  const data = additionalData as Record<string, unknown>;
+
+  const statusValue = data.status;
+  if (typeof statusValue === "string" && statusValue.toLowerCase() === status) {
+    return true;
+  }
+
+  const folderValue = data.folder;
+  if (typeof folderValue === "string" && folderValue.toLowerCase() === status) {
+    return true;
+  }
+
+  return false;
+}
+
+function getLastContactDate(consumer: CampaignConsumerLike): Date | null {
+  const potentialValues: Array<unknown> = [];
+
+  if (consumer.additionalData && typeof consumer.additionalData === "object") {
+    const additional = consumer.additionalData as Record<string, unknown>;
+    potentialValues.push(additional.lastContactAt, additional.lastContactDate, additional.lastInteractionAt);
+  }
+
+  potentialValues.push(consumer.registrationDate, consumer.createdAt);
+
+  for (const value of potentialValues) {
+    if (!value) {
+      continue;
+    }
+
+    const date = new Date(value as string | number | Date);
+    if (!Number.isNaN(date.getTime())) {
+      return date;
+    }
+  }
+
+  return null;
+}
+
+export function sanitizeFolderIds(raw: unknown): string[] {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+
+  const ids = new Set<string>();
+  for (const value of raw) {
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (trimmed) {
+        ids.add(trimmed);
+      }
+    }
+  }
+
+  return Array.from(ids);
+}
+
+export function sanitizeCustomFilters(raw: unknown): CampaignCustomFilters {
+  if (!raw || typeof raw !== "object") {
+    return {};
+  }
+
+  const result: CampaignCustomFilters = {};
+  const data = raw as Record<string, unknown>;
+
+  const entries: Array<keyof CampaignCustomFilters> = [
+    "balanceMin",
+    "balanceMax",
+    "status",
+    "lastContactDays",
+  ];
+
+  for (const key of entries) {
+    const value = data[key];
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (trimmed) {
+        result[key] = trimmed;
+      }
+    }
+  }
+
+  return result;
+}
+
+export function sanitizeTargetingInput(
+  raw: Partial<CampaignTargetingInput> | undefined | null,
+): CampaignTargetingInput {
+  const targetGroup =
+    raw?.targetGroup && allowedTargetGroups.includes(raw.targetGroup)
+      ? raw.targetGroup
+      : "all";
+
+  const targetType =
+    raw?.targetType && allowedTargetTypes.includes(raw.targetType)
+      ? raw.targetType
+      : "all";
+
+  const targetFolderIds = sanitizeFolderIds(raw?.targetFolderIds);
+  const customFilters = sanitizeCustomFilters(raw?.customFilters);
+
+  return {
+    targetGroup,
+    targetType,
+    targetFolderIds,
+    customFilters,
+  };
+}
+
+export function filterConsumersForCampaign<
+  TConsumer extends CampaignConsumerLike,
+  TAccount extends CampaignAccountLike,
+>(
+  consumers: TConsumer[],
+  accounts: TAccount[],
+  targeting: CampaignTargetingInput,
+): TConsumer[] {
+  const folderIdSet = new Set(targeting.targetFolderIds);
+  const accountsByConsumer = new Map<string, TAccount[]>();
+
+  for (const account of accounts) {
+    if (!account.consumerId) {
+      continue;
+    }
+
+    const existing = accountsByConsumer.get(account.consumerId);
+    if (existing) {
+      existing.push(account);
+    } else {
+      accountsByConsumer.set(account.consumerId, [account]);
+    }
+  }
+
+  const balanceMinCents = parseCurrencyToCents(targeting.customFilters.balanceMin);
+  const balanceMaxCents = parseCurrencyToCents(targeting.customFilters.balanceMax);
+  const statusFilter = targeting.customFilters.status?.toLowerCase();
+  const lastContactDays = parseInteger(targeting.customFilters.lastContactDays);
+
+  const recentCutoff = new Date();
+  recentCutoff.setDate(recentCutoff.getDate() - 1);
+
+  return consumers.filter((consumer) => {
+    const consumerAccounts = accountsByConsumer.get(consumer.id) ?? [];
+
+    if (targeting.targetType === "folder") {
+      if (!folderIdSet.size) {
+        return false;
+      }
+
+      const folderMatch =
+        (consumer.folderId && folderIdSet.has(consumer.folderId)) ||
+        consumerAccounts.some((account) => account.folderId && folderIdSet.has(account.folderId));
+
+      return folderMatch;
+    }
+
+    if (targeting.targetType === "custom") {
+      if (balanceMinCents !== null) {
+        const totalBalance = consumerAccounts.reduce(
+          (sum, account) => sum + (account.balanceCents ?? 0),
+          0,
+        );
+        if (totalBalance < balanceMinCents) {
+          return false;
+        }
+      }
+
+      if (balanceMaxCents !== null) {
+        const totalBalance = consumerAccounts.reduce(
+          (sum, account) => sum + (account.balanceCents ?? 0),
+          0,
+        );
+        if (totalBalance > balanceMaxCents) {
+          return false;
+        }
+      }
+
+      if (statusFilter) {
+        const hasStatusMatch =
+          consumerAccounts.some(
+            (account) => (account.status ?? "").toLowerCase() === statusFilter,
+          ) || matchesAdditionalStatus(consumer.additionalData, statusFilter);
+
+        if (!hasStatusMatch) {
+          return false;
+        }
+      }
+
+      if (lastContactDays !== null) {
+        const lastContact = getLastContactDate(consumer);
+        if (!lastContact) {
+          return false;
+        }
+
+        const diffDays = Math.floor(
+          (Date.now() - lastContact.getTime()) / (1000 * 60 * 60 * 24),
+        );
+        if (diffDays < lastContactDays) {
+          return false;
+        }
+      }
+
+      return true;
+    }
+
+    switch (targeting.targetGroup) {
+      case "with-balance":
+        return consumerAccounts.some((account) => (account.balanceCents ?? 0) > 0);
+      case "decline":
+        if (matchesAdditionalStatus(consumer.additionalData, "decline")) {
+          return true;
+        }
+        return consumerAccounts.some(
+          (account) => (account.status ?? "").toLowerCase() === "decline",
+        );
+      case "recent-upload":
+        if (!consumer.createdAt) {
+          return false;
+        }
+        const createdAtDate = new Date(consumer.createdAt as string | number | Date);
+        if (Number.isNaN(createdAtDate.getTime())) {
+          return false;
+        }
+        return createdAtDate > recentCutoff;
+      default:
+        return true;
+    }
+  });
+}
+


### PR DESCRIPTION
## Summary
- detect whether the new campaign targeting columns exist before using them in the storage layer and API handlers, and fall back to raw SQL queries when they are absent so the communications pages keep working against older databases
- expose the postgres-js client in the serverless DB helper to support the new fallback queries
- add the shared targeting helper/schema/migration files so the newer targeting functionality is fully tracked in the repository

## Testing
- npm run test
- npm run check *(fails: existing TypeScript errors in unrelated areas)*

------
https://chatgpt.com/codex/tasks/task_e_68d291383034832aad77ffa0088f0c6d