### PR TITLE
Add plan type support to arrangement options

### DIFF
--- a/api/_lib/schema.ts
+++ b/api/_lib/schema.ts
@@ -215,6 +215,13 @@ export const documents = pgTable("documents", {
 });
 
 // Payment arrangement options
+export const arrangementPlanTypes = [
+  "range",
+  "fixed_monthly",
+  "pay_in_full",
+  "custom_terms",
+] as const;
+
 export const arrangementOptions = pgTable("arrangement_options", {
   id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
   tenantId: uuid("tenant_id").references(() => tenants.id, { onDelete: "cascade" }).notNull(),
@@ -222,9 +229,14 @@ export const arrangementOptions = pgTable("arrangement_options", {
   description: text("description"),
   minBalance: bigint("min_balance", { mode: "number" }).notNull(),
   maxBalance: bigint("max_balance", { mode: "number" }).notNull(),
-  monthlyPaymentMin: bigint("monthly_payment_min", { mode: "number" }).notNull(),
-  monthlyPaymentMax: bigint("monthly_payment_max", { mode: "number" }).notNull(),
-  maxTermMonths: integer("max_term_months").notNull().default(12),
+  planType: text("plan_type", { enum: arrangementPlanTypes }).default("range").notNull(),
+  monthlyPaymentMin: bigint("monthly_payment_min", { mode: "number" }),
+  monthlyPaymentMax: bigint("monthly_payment_max", { mode: "number" }),
+  fixedMonthlyPayment: bigint("fixed_monthly_payment", { mode: "number" }),
+  payInFullAmount: bigint("pay_in_full_amount", { mode: "number" }),
+  payoffText: text("payoff_text"),
+  customTermsText: text("custom_terms_text"),
+  maxTermMonths: integer("max_term_months"),
   isActive: boolean("is_active").default(true),
   createdAt: timestamp("created_at").defaultNow(),
   updatedAt: timestamp("updated_at").defaultNow(),

--- a/client/src/lib/arrangements.ts
+++ b/client/src/lib/arrangements.ts
@@ -1,0 +1,107 @@
+export interface ArrangementLike {
+  planType?: string | null;
+  monthlyPaymentMin?: number | null;
+  monthlyPaymentMax?: number | null;
+  fixedMonthlyPayment?: number | null;
+  payInFullAmount?: number | null;
+  payoffText?: string | null;
+  customTermsText?: string | null;
+  maxTermMonths?: number | null;
+}
+
+const currencyFormatter = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  minimumFractionDigits: 2,
+});
+
+export const formatCurrencyFromCents = (value?: number | null): string => {
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  return currencyFormatter.format(value / 100);
+};
+
+export const getPlanTypeLabel = (planType?: string | null): string => {
+  switch (planType) {
+    case 'fixed_monthly':
+      return 'Fixed monthly';
+    case 'pay_in_full':
+      return 'Pay in full';
+    case 'custom_terms':
+      return 'Custom terms';
+    case 'range':
+    case undefined:
+    case null:
+      return 'Range';
+    default:
+      return planType as string;
+  }
+};
+
+export const getArrangementSummary = (arrangement: ArrangementLike) => {
+  const planType = arrangement.planType ?? 'range';
+  const maxTerm = typeof arrangement.maxTermMonths === 'number' && arrangement.maxTermMonths > 0
+    ? arrangement.maxTermMonths
+    : null;
+
+  switch (planType) {
+    case 'range': {
+      const min = typeof arrangement.monthlyPaymentMin === 'number' ? arrangement.monthlyPaymentMin : null;
+      const max = typeof arrangement.monthlyPaymentMax === 'number' ? arrangement.monthlyPaymentMax : null;
+      let headline = '';
+      if (min !== null && max !== null) {
+        headline = `${formatCurrencyFromCents(min)} - ${formatCurrencyFromCents(max)} per month`;
+      } else if (min !== null) {
+        headline = `${formatCurrencyFromCents(min)} per month`;
+      } else if (max !== null) {
+        headline = `${formatCurrencyFromCents(max)} per month`;
+      } else {
+        headline = 'Monthly payment plan';
+      }
+
+      const detail = maxTerm ? `Up to ${maxTerm} months` : undefined;
+      return { planType, headline, detail };
+    }
+    case 'fixed_monthly': {
+      const amount = typeof arrangement.fixedMonthlyPayment === 'number' ? arrangement.fixedMonthlyPayment : null;
+      const headline = amount !== null
+        ? `${formatCurrencyFromCents(amount)} per month`
+        : 'Fixed monthly payment';
+      const detail = maxTerm ? `Up to ${maxTerm} months` : 'Until paid in full';
+      return { planType, headline, detail };
+    }
+    case 'pay_in_full': {
+      const amount = typeof arrangement.payInFullAmount === 'number' ? arrangement.payInFullAmount : null;
+      const payoffText = arrangement.payoffText?.trim();
+      const headline = amount !== null
+        ? `Pay ${formatCurrencyFromCents(amount)} today`
+        : payoffText || 'Pay in full';
+      const detail = amount !== null && payoffText ? payoffText : undefined;
+      return { planType, headline, detail };
+    }
+    case 'custom_terms': {
+      const customText = arrangement.customTermsText?.trim();
+      return {
+        planType,
+        headline: customText || 'Contact us to discuss terms',
+      };
+    }
+    default: {
+      const min = typeof arrangement.monthlyPaymentMin === 'number' ? arrangement.monthlyPaymentMin : null;
+      const max = typeof arrangement.monthlyPaymentMax === 'number' ? arrangement.monthlyPaymentMax : null;
+      if (min !== null || max !== null) {
+        return {
+          planType,
+          headline: `${formatCurrencyFromCents(min ?? max ?? 0)} - ${formatCurrencyFromCents(max ?? min ?? 0)} per month`,
+          detail: maxTerm ? `Up to ${maxTerm} months` : undefined,
+        };
+      }
+      return {
+        planType,
+        headline: 'Payment arrangement available',
+      };
+    }
+  }
+};

--- a/client/src/pages/consumer-dashboard.tsx
+++ b/client/src/pages/consumer-dashboard.tsx
@@ -13,6 +13,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from 
 import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Bell, Phone, Mail, MessageSquare, Download, Building2, CreditCard, FileText, AlertCircle, LogOut, User } from "lucide-react";
+import { getArrangementSummary, getPlanTypeLabel, formatCurrencyFromCents } from "@/lib/arrangements";
 
 export default function ConsumerDashboard() {
   const [, setLocation] = useLocation();
@@ -220,7 +221,7 @@ export default function ConsumerDashboard() {
   };
 
   const formatCurrency = (cents: number) => {
-    return `$${(cents / 100).toLocaleString('en-US', { minimumFractionDigits: 2 })}`;
+    return formatCurrencyFromCents(cents);
   };
 
   const formatDate = (dateString: string) => {
@@ -587,24 +588,24 @@ export default function ConsumerDashboard() {
                         <div className="flex-1">
                           <h3 className="text-lg font-semibold text-gray-900">{arrangement.name}</h3>
                           <p className="text-gray-600 mt-2">{arrangement.description}</p>
-                          <div className="mt-4 space-y-2">
-                            <div className="flex justify-between text-sm">
-                              <span className="text-gray-600">Monthly Payment:</span>
-                              <span className="font-medium">
-                                {formatCurrency(arrangement.monthlyPaymentMin || 0)} - {formatCurrency(arrangement.monthlyPaymentMax || 0)}
-                              </span>
-                            </div>
-                            <div className="flex justify-between text-sm">
-                              <span className="text-gray-600">Maximum Term:</span>
-                              <span className="font-medium">{arrangement.maxTermMonths} months</span>
-                            </div>
-                            <div className="flex justify-between text-sm">
-                              <span className="text-gray-600">Eligible Balance Range:</span>
-                              <span className="font-medium">
-                                {formatCurrency(arrangement.minBalance)} - {formatCurrency(arrangement.maxBalance)}
-                              </span>
-                            </div>
-                          </div>
+                          {(() => {
+                            const summary = getArrangementSummary(arrangement);
+                            return (
+                              <div className="mt-4 space-y-2">
+                                <div className="flex items-center gap-2 text-sm">
+                                  <Badge variant="secondary">{getPlanTypeLabel(arrangement.planType)}</Badge>
+                                  <span className="font-medium text-gray-700">{summary.headline}</span>
+                                </div>
+                                {summary.detail && <p className="text-sm text-gray-500">{summary.detail}</p>}
+                                <div className="flex justify-between text-sm">
+                                  <span className="text-gray-600">Eligible Balance Range:</span>
+                                  <span className="font-medium">
+                                    {formatCurrencyFromCents(arrangement.minBalance)} - {formatCurrencyFromCents(arrangement.maxBalance)}
+                                  </span>
+                                </div>
+                              </div>
+                            );
+                          })()}
                         </div>
                         <div className="ml-6">
                           <Button onClick={() => setShowCallbackModal(true)}>

--- a/client/src/pages/consumer-portal.tsx
+++ b/client/src/pages/consumer-portal.tsx
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useParams } from "wouter";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { getArrangementSummary, formatCurrencyFromCents } from "@/lib/arrangements";
 
 export default function ConsumerPortal() {
   const { tenantSlug, email } = useParams();
@@ -64,7 +65,7 @@ export default function ConsumerPortal() {
   };
 
   const formatCurrency = (cents: number) => {
-    return `$${(cents / 100).toLocaleString('en-US', { minimumFractionDigits: 2 })}`;
+    return formatCurrencyFromCents(cents);
   };
 
   const formatDate = (dateString: string) => {
@@ -211,10 +212,18 @@ export default function ConsumerPortal() {
                     <div>
                       <h3 className="font-medium text-gray-900">{arrangement.name}</h3>
                       <p className="text-sm text-gray-500 mt-1">{arrangement.description}</p>
-                      <div className="text-sm text-blue-600 mt-2">
-                        {formatCurrency(arrangement.monthlyPaymentMin)} - {formatCurrency(arrangement.monthlyPaymentMax)} per month
-                        <span className="text-gray-500 ml-2">• Up to {arrangement.maxTermMonths} months</span>
-                      </div>
+                      {(() => {
+                        const summary = getArrangementSummary(arrangement);
+                        return (
+                          <div className="text-sm text-blue-600 mt-2 space-y-1">
+                            <div>{summary.headline}</div>
+                            {summary.detail && <div className="text-gray-500">{summary.detail}</div>}
+                            <div className="text-gray-500">
+                              Eligible balance: {formatCurrencyFromCents(arrangement.minBalance)} - {formatCurrencyFromCents(arrangement.maxBalance)}
+                            </div>
+                          </div>
+                        );
+                      })()}
                     </div>
                     <Button className="bg-blue-600 hover:bg-blue-700">
                       Select Plan

--- a/client/src/pages/enhanced-consumer-portal.tsx
+++ b/client/src/pages/enhanced-consumer-portal.tsx
@@ -13,6 +13,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from 
 import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Bell, Phone, Mail, MessageSquare, Download, Building2, CreditCard, FileText, AlertCircle } from "lucide-react";
+import { getArrangementSummary, getPlanTypeLabel, formatCurrencyFromCents } from "@/lib/arrangements";
 
 export default function EnhancedConsumerPortal() {
   const { tenantSlug, email } = useParams();
@@ -161,7 +162,7 @@ export default function EnhancedConsumerPortal() {
   };
 
   const formatCurrency = (cents: number) => {
-    return `$${(cents / 100).toLocaleString('en-US', { minimumFractionDigits: 2 })}`;
+    return formatCurrencyFromCents(cents);
   };
 
   const formatDate = (dateString: string) => {
@@ -520,24 +521,24 @@ export default function EnhancedConsumerPortal() {
                         <div className="flex-1">
                           <h3 className="text-lg font-semibold text-gray-900">{arrangement.name}</h3>
                           <p className="text-gray-600 mt-2">{arrangement.description}</p>
-                          <div className="mt-4 space-y-2">
-                            <div className="flex justify-between text-sm">
-                              <span className="text-gray-600">Monthly Payment:</span>
-                              <span className="font-medium">
-                                {formatCurrency(arrangement.monthlyPaymentMin)} - {formatCurrency(arrangement.monthlyPaymentMax)}
-                              </span>
-                            </div>
-                            <div className="flex justify-between text-sm">
-                              <span className="text-gray-600">Maximum Term:</span>
-                              <span className="font-medium">{arrangement.maxTermMonths} months</span>
-                            </div>
-                            <div className="flex justify-between text-sm">
-                              <span className="text-gray-600">Eligible Balance Range:</span>
-                              <span className="font-medium">
-                                {formatCurrency(arrangement.minBalance)} - {formatCurrency(arrangement.maxBalance)}
-                              </span>
-                            </div>
-                          </div>
+                          {(() => {
+                            const summary = getArrangementSummary(arrangement);
+                            return (
+                              <div className="mt-4 space-y-2">
+                                <div className="flex items-center gap-2 text-sm">
+                                  <Badge variant="secondary">{getPlanTypeLabel(arrangement.planType)}</Badge>
+                                  <span className="font-medium text-gray-700">{summary.headline}</span>
+                                </div>
+                                {summary.detail && <p className="text-sm text-gray-500">{summary.detail}</p>}
+                                <div className="flex justify-between text-sm">
+                                  <span className="text-gray-600">Eligible Balance Range:</span>
+                                  <span className="font-medium">
+                                    {formatCurrencyFromCents(arrangement.minBalance)} - {formatCurrencyFromCents(arrangement.maxBalance)}
+                                  </span>
+                                </div>
+                              </div>
+                            );
+                          })()}
                         </div>
                         <div className="ml-6">
                           <Button onClick={() => setShowCallbackModal(true)}>

--- a/migrations/20250219120000_arrangement_plan_types.sql
+++ b/migrations/20250219120000_arrangement_plan_types.sql
@@ -1,0 +1,8 @@
+ALTER TABLE "arrangement_options" ADD COLUMN "plan_type" text NOT NULL DEFAULT 'range';
+ALTER TABLE "arrangement_options" ADD COLUMN "fixed_monthly_payment" bigint;
+ALTER TABLE "arrangement_options" ADD COLUMN "pay_in_full_amount" bigint;
+ALTER TABLE "arrangement_options" ADD COLUMN "payoff_text" text;
+ALTER TABLE "arrangement_options" ADD COLUMN "custom_terms_text" text;
+ALTER TABLE "arrangement_options" ALTER COLUMN "monthly_payment_min" DROP NOT NULL;
+ALTER TABLE "arrangement_options" ALTER COLUMN "monthly_payment_max" DROP NOT NULL;
+ALTER TABLE "arrangement_options" ALTER COLUMN "max_term_months" DROP NOT NULL;

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -3,7 +3,18 @@ import { createServer, type Server } from "http";
 import { storage, type IStorage } from "./storage";
 import { authenticateUser, authenticateConsumer, getCurrentUser } from "./authMiddleware";
 import { postmarkServerService } from "./postmarkServerService";
-import { insertConsumerSchema, insertAccountSchema, agencyTrialRegistrationSchema, platformUsers, tenants, consumers, agencyCredentials } from "@shared/schema";
+import {
+  insertConsumerSchema,
+  insertAccountSchema,
+  insertArrangementOptionSchema,
+  arrangementPlanTypes,
+  agencyTrialRegistrationSchema,
+  platformUsers,
+  tenants,
+  consumers,
+  agencyCredentials,
+  type InsertArrangementOption,
+} from "@shared/schema";
 import { db } from "./db";
 import { eq, sql } from "drizzle-orm";
 import { z } from "zod";
@@ -2386,6 +2397,136 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  const planTypeSet = new Set(arrangementPlanTypes);
+
+  const parseCurrencyInput = (value: unknown): number | null => {
+    if (value === null || value === undefined) {
+      return null;
+    }
+
+    if (typeof value === "number") {
+      if (!Number.isFinite(value)) {
+        return null;
+      }
+      return Math.round(value);
+    }
+
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (!trimmed) {
+        return null;
+      }
+      const numeric = Number(trimmed);
+      if (Number.isNaN(numeric)) {
+        return null;
+      }
+      if (trimmed.includes('.')) {
+        return Math.round(numeric * 100);
+      }
+      return Math.round(numeric);
+    }
+
+    return null;
+  };
+
+  const parseOptionalInteger = (value: unknown): number | null => {
+    if (value === null || value === undefined || value === "") {
+      return null;
+    }
+
+    if (typeof value === "number") {
+      if (!Number.isFinite(value)) {
+        return null;
+      }
+      return Math.trunc(value);
+    }
+
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (!trimmed) {
+        return null;
+      }
+      const numeric = Number(trimmed);
+      if (Number.isNaN(numeric)) {
+        return null;
+      }
+      return Math.trunc(numeric);
+    }
+
+    return null;
+  };
+
+  const sanitizeOptionalText = (value: unknown): string | null => {
+    if (typeof value !== "string") {
+      return null;
+    }
+    const trimmed = value.trim();
+    return trimmed ? trimmed : null;
+  };
+
+  const buildArrangementOptionPayload = (body: any, tenantId: string): InsertArrangementOption => {
+    const planTypeRaw = typeof body.planType === "string" ? body.planType : "range";
+    const planType = planTypeSet.has(planTypeRaw as any) ? (planTypeRaw as InsertArrangementOption["planType"]) : "range";
+
+    const minBalance = parseCurrencyInput(body.minBalance);
+    const maxBalance = parseCurrencyInput(body.maxBalance);
+
+    if (minBalance === null || maxBalance === null) {
+      const error = new Error("Minimum and maximum balances must be valid numbers");
+      (error as any).statusCode = 400;
+      throw error;
+    }
+
+    const name = typeof body.name === "string" ? body.name.trim() : "";
+    if (!name) {
+      const error = new Error("Plan name is required");
+      (error as any).statusCode = 400;
+      throw error;
+    }
+
+    const monthlyPaymentMin = parseCurrencyInput(body.monthlyPaymentMin);
+    const monthlyPaymentMax = parseCurrencyInput(body.monthlyPaymentMax);
+    const fixedMonthlyPayment = parseCurrencyInput(body.fixedMonthlyPayment ?? body.fixedMonthlyAmount);
+    const payInFullAmount = parseCurrencyInput(body.payInFullAmount ?? body.payoffAmount);
+    const payoffText = sanitizeOptionalText(body.payoffText ?? body.payInFullText ?? body.payoffCopy);
+    const customTermsText = sanitizeOptionalText(body.customTermsText ?? body.customCopy);
+    const maxTermMonths = parseOptionalInteger(body.maxTermMonths);
+    const description = sanitizeOptionalText(body.description);
+    const isActive = body.isActive === undefined ? true : Boolean(body.isActive);
+
+    const candidate = {
+      tenantId,
+      name,
+      description,
+      minBalance,
+      maxBalance,
+      planType,
+      monthlyPaymentMin: planType === "range" ? monthlyPaymentMin : null,
+      monthlyPaymentMax: planType === "range" ? monthlyPaymentMax : null,
+      fixedMonthlyPayment: planType === "fixed_monthly" ? fixedMonthlyPayment : null,
+      payInFullAmount: planType === "pay_in_full" ? payInFullAmount : null,
+      payoffText: planType === "pay_in_full" ? payoffText : null,
+      customTermsText: planType === "custom_terms" ? customTermsText : null,
+      maxTermMonths:
+        planType === "pay_in_full" || planType === "custom_terms"
+          ? null
+          : planType === "range"
+            ? maxTermMonths ?? 12
+            : maxTermMonths,
+      isActive,
+    } satisfies Partial<InsertArrangementOption> as InsertArrangementOption;
+
+    const parsed = insertArrangementOptionSchema.safeParse(candidate);
+    if (!parsed.success) {
+      const message = parsed.error.errors[0]?.message ?? "Invalid arrangement option";
+      const error = new Error(message);
+      (error as any).statusCode = 400;
+      throw error;
+    }
+
+    return parsed.data;
+  };
+
   // Arrangement options routes
   app.get('/api/arrangement-options', authenticateUser, async (req: any, res) => {
     try {
@@ -2406,30 +2547,47 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.post('/api/arrangement-options', authenticateUser, async (req: any, res) => {
     try {
       const tenantId = req.user.tenantId;
-      
+
       if (!tenantId) {
         return res.status(403).json({ message: "No tenant access" });
       }
 
-      const option = await storage.createArrangementOption({
-        ...req.body,
-        tenantId: tenantId,
-      });
-      
+      const payload = buildArrangementOptionPayload(req.body, tenantId);
+      const option = await storage.createArrangementOption(payload);
+
       res.json(option);
     } catch (error) {
       console.error("Error creating arrangement option:", error);
-      res.status(500).json({ message: "Failed to create arrangement option" });
+      const statusCode = error instanceof z.ZodError || (error as any)?.statusCode === 400 ? 400 : 500;
+      res.status(statusCode).json({
+        message:
+          statusCode === 400
+            ? (error as any)?.message || "Invalid arrangement option payload"
+            : "Failed to create arrangement option",
+      });
     }
   });
 
   app.put('/api/arrangement-options/:id', authenticateUser, async (req: any, res) => {
     try {
-      const option = await storage.updateArrangementOption(req.params.id, req.body);
+      const tenantId = req.user.tenantId;
+
+      if (!tenantId) {
+        return res.status(403).json({ message: "No tenant access" });
+      }
+
+      const payload = buildArrangementOptionPayload(req.body, tenantId);
+      const option = await storage.updateArrangementOption(req.params.id, payload);
       res.json(option);
     } catch (error) {
       console.error("Error updating arrangement option:", error);
-      res.status(500).json({ message: "Failed to update arrangement option" });
+      const statusCode = error instanceof z.ZodError || (error as any)?.statusCode === 400 ? 400 : 500;
+      res.status(statusCode).json({
+        message:
+          statusCode === 400
+            ? (error as any)?.message || "Invalid arrangement option payload"
+            : "Failed to update arrangement option",
+      });
     }
   });
 


### PR DESCRIPTION
## Summary
- extend the arrangement options schema and validation to support explicit plan types and related fields
- update server and API handlers to normalize new payloads and accept optional max terms for until-paid plans
- refresh admin and consumer UIs with plan-type-aware forms and summaries plus shared formatting helpers
- add a migration to backfill plan types and allow nullable payment range fields

## Testing
- npm run check *(fails: existing type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d2a129d7d0832a8afe7775dda161fe