### PR TITLE
Add arrangement plan context and placeholder support

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "test": "node --test --import tsx ./client/src/pages/__tests__/agency-policy-utils.test.ts",
+    "test": "node --test --import tsx ./client/src/pages/__tests__/agency-policy-utils.test.ts ./server/__tests__/template-placeholders.test.ts",
     "db:push": "drizzle-kit push"
   },
   "dependencies": {

--- a/server/__tests__/template-placeholders.test.ts
+++ b/server/__tests__/template-placeholders.test.ts
@@ -1,0 +1,73 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { ArrangementOption } from "@shared/schema";
+import {
+  buildArrangementSummary,
+  enrichArrangement,
+  replaceTemplateVariables,
+} from "../templatePlaceholders";
+
+const baseArrangement: ArrangementOption = {
+  id: "plan-123",
+  tenantId: "tenant-001",
+  name: "Flexible Plan",
+  description: "A flexible option for qualifying balances.",
+  minBalance: 10000,
+  maxBalance: 750000,
+  monthlyPaymentMin: 5000,
+  monthlyPaymentMax: 25000,
+  maxTermMonths: 18,
+  isActive: true,
+  createdAt: new Date("2024-01-01T00:00:00Z"),
+  updatedAt: new Date("2024-01-01T00:00:00Z"),
+};
+
+test("buildArrangementSummary generates a friendly overview", () => {
+  const summary = buildArrangementSummary(baseArrangement);
+  assert.equal(
+    summary,
+    "Monthly payments between $50.00 - $250.00 for balances $100.00 - $7500.00 up to 18 months.",
+  );
+});
+
+test("enrichArrangement derives formatted fields", () => {
+  const enriched = enrichArrangement(baseArrangement);
+  assert.ok(enriched);
+  assert.equal(enriched?.monthlyRange, "$50.00 - $250.00");
+  assert.equal(enriched?.balanceRange, "$100.00 - $7500.00");
+  assert.equal(enriched?.maxTermLabel, "18 months");
+  assert.ok(enriched?.details?.includes("Plan: Flexible Plan"));
+  assert.ok(enriched?.details?.includes("Maximum term: 18 months"));
+});
+
+test("replaceTemplateVariables injects arrangement placeholders", () => {
+  const arrangementContext = enrichArrangement(baseArrangement);
+  assert.ok(arrangementContext, "Arrangement context should be available");
+
+  const template = [
+    "{{arrangementName}}",
+    "{{arrangementSummary}}",
+    "{{arrangementMonthlyRange}}",
+    "{{arrangementBalanceRange}}",
+    "{{arrangementMaxTermLabel}}",
+    "{{arrangementDetails}}",
+  ].join("|");
+
+  const output = replaceTemplateVariables(
+    template,
+    { firstName: "Avery" },
+    null,
+    { slug: "demo-agency" },
+    { arrangement: arrangementContext },
+  );
+
+  const [name, summary, monthlyRange, balanceRange, maxTermLabel, details] = output.split("|");
+
+  assert.equal(name, "Flexible Plan");
+  assert.match(summary, /Monthly payments between/);
+  assert.equal(monthlyRange, "$50.00 - $250.00");
+  assert.equal(balanceRange, "$100.00 - $7500.00");
+  assert.equal(maxTermLabel, "18 months");
+  assert.ok(details.includes("Flexible Plan"));
+  assert.ok(details.includes("Maximum term: 18 months"));
+});

--- a/server/templatePlaceholders.ts
+++ b/server/templatePlaceholders.ts
@@ -1,0 +1,191 @@
+import type { ArrangementOption } from "@shared/schema";
+
+type Primitive = string | number | null | undefined;
+
+export type ArrangementReplacement = ArrangementOption & {
+  summary?: string;
+  details?: string;
+  balanceRange?: string;
+  monthlyRange?: string;
+  maxTermLabel?: string;
+};
+
+export interface TemplateReplacementOptions {
+  baseUrl?: string;
+  arrangement?: ArrangementReplacement;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function formatCurrency(cents: Primitive): string {
+  if (cents === null || cents === undefined) return "";
+  const numericValue = typeof cents === "number" ? cents : Number(cents);
+  if (Number.isNaN(numericValue)) return "";
+  return `$${(numericValue / 100).toFixed(2)}`;
+}
+
+export function formatCurrencyRange(min?: Primitive, max?: Primitive): string {
+  const minFormatted = formatCurrency(min ?? null);
+  const maxFormatted = formatCurrency(max ?? null);
+
+  if (minFormatted && maxFormatted) {
+    if (minFormatted === maxFormatted) return minFormatted;
+    return `${minFormatted} - ${maxFormatted}`;
+  }
+
+  return minFormatted || maxFormatted || "";
+}
+
+export function buildArrangementSummary(arrangement?: ArrangementOption | null): string {
+  if (!arrangement) return "";
+
+  const monthlyRange = formatCurrencyRange(arrangement.monthlyPaymentMin, arrangement.monthlyPaymentMax);
+  const balanceRange = formatCurrencyRange(arrangement.minBalance, arrangement.maxBalance);
+  const parts: string[] = [];
+
+  if (monthlyRange) {
+    parts.push(`Monthly payments between ${monthlyRange}`);
+  }
+
+  if (balanceRange) {
+    parts.push(`for balances ${balanceRange}`);
+  }
+
+  if (arrangement.maxTermMonths) {
+    parts.push(`up to ${arrangement.maxTermMonths} months`);
+  }
+
+  return parts.length ? `${parts.join(" ")}.` : "";
+}
+
+export function buildArrangementDetails(arrangement?: ArrangementOption | null): string {
+  if (!arrangement) return "";
+
+  const summary = buildArrangementSummary(arrangement);
+  const balanceRange = formatCurrencyRange(arrangement.minBalance, arrangement.maxBalance);
+  const monthlyRange = formatCurrencyRange(arrangement.monthlyPaymentMin, arrangement.monthlyPaymentMax);
+
+  const lines = [
+    arrangement.name ? `Plan: ${arrangement.name}` : null,
+    arrangement.description || null,
+    summary || null,
+    balanceRange ? `Eligible balances: ${balanceRange}` : null,
+    monthlyRange ? `Estimated monthly payment: ${monthlyRange}` : null,
+    arrangement.maxTermMonths ? `Maximum term: ${arrangement.maxTermMonths} months` : null,
+  ].filter(Boolean) as string[];
+
+  return lines.join("\n");
+}
+
+export function enrichArrangement(option?: ArrangementOption | null): ArrangementReplacement | undefined {
+  if (!option) return undefined;
+
+  return {
+    ...option,
+    summary: buildArrangementSummary(option),
+    details: buildArrangementDetails(option),
+    balanceRange: formatCurrencyRange(option.minBalance, option.maxBalance),
+    monthlyRange: formatCurrencyRange(option.monthlyPaymentMin, option.monthlyPaymentMax),
+    maxTermLabel: option.maxTermMonths ? `${option.maxTermMonths} months` : "",
+  };
+}
+
+function applyTemplateReplacement(template: string, key: string, value: string): string {
+  if (!template) return template;
+  const sanitizedValue = value ?? "";
+  const regex = new RegExp(`{{\\s*${escapeRegExp(key)}\\s*}}`, "gi");
+  return template.replace(regex, sanitizedValue);
+}
+
+export function replaceTemplateVariables(
+  template: string,
+  consumer: any,
+  account: any,
+  tenant: any,
+  options: TemplateReplacementOptions = {},
+): string {
+  if (!template) return template;
+
+  const baseUrl = (options.baseUrl ?? process.env.REPLIT_DOMAINS) || "localhost:5000";
+  const sanitizedBaseUrl = (baseUrl || "localhost:5000").replace(/^https?:\/\//, "").replace(/\/$/, "");
+  const consumerEmail = consumer?.email || "";
+  const consumerSlug = tenant?.slug;
+
+  let consumerPortalUrl = "";
+  if (sanitizedBaseUrl && consumerSlug) {
+    const emailPath = consumerEmail ? `/${encodeURIComponent(consumerEmail)}` : "";
+    consumerPortalUrl = `https://${sanitizedBaseUrl}/consumer/${consumerSlug}${emailPath}`;
+  }
+
+  const appDownloadUrl = sanitizedBaseUrl ? `https://${sanitizedBaseUrl}/download` : "";
+
+  const firstName = consumer?.firstName || "";
+  const lastName = consumer?.lastName || "";
+  const fullName = [firstName, lastName].filter(Boolean).join(" ").trim();
+  const consumerPhone = consumer?.phone || "";
+
+  const balanceCents = account?.balanceCents;
+  const formattedBalance = formatCurrency(balanceCents);
+  const formattedDueDate = account?.dueDate ? new Date(account.dueDate).toLocaleDateString() : "";
+  const dueDateIso = account?.dueDate ? new Date(account.dueDate).toISOString().split("T")[0] : "";
+
+  const arrangement = options.arrangement;
+  const arrangementSummary = arrangement ? arrangement.summary ?? buildArrangementSummary(arrangement) : "";
+  const arrangementDetails = arrangement ? arrangement.details ?? buildArrangementDetails(arrangement) : "";
+  const arrangementBalanceRange = arrangement
+    ? arrangement.balanceRange ?? formatCurrencyRange(arrangement.minBalance, arrangement.maxBalance)
+    : "";
+  const arrangementMonthlyRange = arrangement
+    ? arrangement.monthlyRange ?? formatCurrencyRange(arrangement.monthlyPaymentMin, arrangement.monthlyPaymentMax)
+    : "";
+  const arrangementMaxTermLabel = arrangement
+    ? arrangement.maxTermLabel ?? (arrangement.maxTermMonths ? `${arrangement.maxTermMonths} months` : "")
+    : "";
+
+  const replacements: Record<string, string> = {
+    firstName,
+    lastName,
+    fullName,
+    consumerName: fullName,
+    email: consumerEmail,
+    phone: consumerPhone,
+    consumerId: consumer?.id || "",
+    accountId: account?.id || "",
+    accountNumber: account?.accountNumber || "",
+    creditor: account?.creditor || "",
+    balance: formattedBalance,
+    balence: formattedBalance,
+    balanceCents: balanceCents !== undefined && balanceCents !== null ? String(balanceCents) : "",
+    dueDate: formattedDueDate,
+    dueDateIso,
+    consumerPortalLink: consumerPortalUrl,
+    consumerPortalUrl,
+    appDownloadLink: appDownloadUrl,
+    agencyName: tenant?.name || "",
+    agencyEmail: tenant?.email || "",
+    agencyPhone: tenant?.phoneNumber || tenant?.twilioPhoneNumber || "",
+    arrangementId: arrangement?.id || "",
+    arrangementName: arrangement?.name || "",
+    arrangementDescription: arrangement?.description || "",
+    arrangementSummary,
+    arrangementDetails,
+    arrangementBalanceRange,
+    arrangementMonthlyRange,
+    arrangementMonthlyPaymentMin: arrangement ? formatCurrency(arrangement.monthlyPaymentMin) : "",
+    arrangementMonthlyPaymentMax: arrangement ? formatCurrency(arrangement.monthlyPaymentMax) : "",
+    arrangementMinBalance: arrangement ? formatCurrency(arrangement.minBalance) : "",
+    arrangementMaxBalance: arrangement ? formatCurrency(arrangement.maxBalance) : "",
+    arrangementMaxTerm: arrangement?.maxTermMonths ? String(arrangement.maxTermMonths) : "",
+    arrangementMaxTermMonths: arrangement?.maxTermMonths ? String(arrangement.maxTermMonths) : "",
+    arrangementMaxTermLabel,
+  };
+
+  let processedTemplate = template;
+  for (const [key, value] of Object.entries(replacements)) {
+    processedTemplate = applyTemplateReplacement(processedTemplate, key, value || "");
+  }
+
+  return processedTemplate;
+}

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -166,6 +166,7 @@ export const emailTemplates = pgTable("email_templates", {
   subject: text("subject").notNull(),
   html: text("html").notNull(),
   status: text("status").default("draft"),
+  defaultArrangementOptionId: uuid("default_arrangement_option_id").references(() => arrangementOptions.id, { onDelete: "set null" }),
   createdAt: timestamp("created_at").defaultNow(),
 });
 
@@ -184,6 +185,7 @@ export const emailCampaigns = pgTable("email_campaigns", {
   totalClicked: bigint("total_clicked", { mode: "number" }).default(0),
   totalErrors: bigint("total_errors", { mode: "number" }).default(0),
   totalOptOuts: bigint("total_opt_outs", { mode: "number" }).default(0),
+  arrangementOptionId: uuid("arrangement_option_id").references(() => arrangementOptions.id, { onDelete: "set null" }),
   createdAt: timestamp("created_at").defaultNow(),
   completedAt: timestamp("completed_at"),
 });
@@ -210,6 +212,7 @@ export const smsTemplates = pgTable("sms_templates", {
   name: text("name").notNull(),
   message: text("message").notNull(), // SMS message content (160 char limit recommended)
   status: text("status").default("draft"),
+  defaultArrangementOptionId: uuid("default_arrangement_option_id").references(() => arrangementOptions.id, { onDelete: "set null" }),
   createdAt: timestamp("created_at").defaultNow(),
 });
 
@@ -226,6 +229,7 @@ export const smsCampaigns = pgTable("sms_campaigns", {
   totalDelivered: bigint("total_delivered", { mode: "number" }).default(0),
   totalErrors: bigint("total_errors", { mode: "number" }).default(0),
   totalOptOuts: bigint("total_opt_outs", { mode: "number" }).default(0),
+  arrangementOptionId: uuid("arrangement_option_id").references(() => arrangementOptions.id, { onDelete: "set null" }),
   createdAt: timestamp("created_at").defaultNow(),
   completedAt: timestamp("completed_at"),
 });

--- a/shared/schema.ts.backup
+++ b/shared/schema.ts.backup
@@ -114,6 +114,7 @@ export const emailTemplates = pgTable("email_templates", {
   subject: text("subject").notNull(),
   html: text("html").notNull(),
   status: text("status").default("draft"),
+  defaultArrangementOptionId: uuid("default_arrangement_option_id").references(() => arrangementOptions.id, { onDelete: "set null" }),
   createdAt: timestamp("created_at").defaultNow(),
 });
 
@@ -132,6 +133,7 @@ export const emailCampaigns = pgTable("email_campaigns", {
   totalClicked: bigint("total_clicked", { mode: "number" }).default(0),
   totalErrors: bigint("total_errors", { mode: "number" }).default(0),
   totalOptOuts: bigint("total_opt_outs", { mode: "number" }).default(0),
+  arrangementOptionId: uuid("arrangement_option_id").references(() => arrangementOptions.id, { onDelete: "set null" }),
   createdAt: timestamp("created_at").defaultNow(),
   completedAt: timestamp("completed_at"),
 });


### PR DESCRIPTION
## Summary
- add arrangement option tracking columns for email/SMS templates and campaigns and expose arrangement metadata through storage
- split template placeholder helpers into a reusable module, extend replacement logic for arrangement fields, and expose an authenticated API for communications to list available plans
- wire campaign/template creation routes and the communications UI to choose, preview, and submit arrangement options while documenting available placeholders and adding targeted tests

## Testing
- npm run check *(fails: existing TypeScript errors in unrelated modules)*
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2a12cc964832abc71da2181fa2a0b