### PR TITLE
Add consumer arrangement persistence and UI

### DIFF
--- a/client/src/pages/consumer-dashboard.tsx
+++ b/client/src/pages/consumer-dashboard.tsx
@@ -79,7 +79,7 @@ export default function ConsumerDashboard() {
   });
 
   // Fetch payment arrangements
-  const { data: arrangements } = useQuery({
+  const { data: arrangementData } = useQuery({
     queryKey: [`/api/consumer/arrangements/${consumerSession?.email}`],
     queryFn: async () => {
       const balance = (data as any)?.accounts?.reduce((sum: number, acc: any) => sum + (acc.balanceCents || 0), 0) || 0;
@@ -88,6 +88,10 @@ export default function ConsumerDashboard() {
     },
     enabled: !!(data as any)?.accounts && !!consumerSession?.email,
   });
+
+  const assignedArrangement = (arrangementData as any)?.assigned;
+  const availableArrangements = ((arrangementData as any)?.available as any[]) || [];
+  const totalArrangements = availableArrangements.length + (assignedArrangement ? 1 : 0);
 
   // Submit callback request mutation
   const callbackRequestMutation = useMutation({
@@ -451,7 +455,7 @@ export default function ConsumerDashboard() {
               <Card>
                 <CardContent className="pt-6 text-center">
                   <div className="text-2xl font-bold text-green-600">
-                    {(arrangements as any)?.length || 0}
+                    {totalArrangements}
                   </div>
                   <div className="text-sm text-gray-500">Payment Plans Available</div>
                 </CardContent>
@@ -500,7 +504,7 @@ export default function ConsumerDashboard() {
                         </div>
                         <div>
                           <div className="text-lg font-medium text-blue-600">
-                            {(arrangements as any[])?.length || 0}
+                            {totalArrangements}
                           </div>
                           <div className="text-xs text-gray-500">Plans Available</div>
                         </div>
@@ -565,7 +569,7 @@ export default function ConsumerDashboard() {
           </TabsContent>
 
           <TabsContent value="payments" className="mt-6">
-            {!arrangements || (arrangements as any).length === 0 ? (
+            {totalArrangements === 0 ? (
               <Card>
                 <CardContent className="pt-6 text-center">
                   <CreditCard className="h-12 w-12 text-gray-400 mx-auto mb-4" />
@@ -580,7 +584,47 @@ export default function ConsumerDashboard() {
               </Card>
             ) : (
               <div className="space-y-4">
-                {(arrangements as any).map((arrangement: any) => (
+                {assignedArrangement && (
+                  <Card className="border-blue-200 bg-blue-50">
+                    <CardContent className="pt-6">
+                      <div className="flex justify-between items-start">
+                        <div className="flex-1">
+                          <h3 className="text-lg font-semibold text-gray-900">{assignedArrangement.option?.name || 'Custom plan'}</h3>
+                          <p className="text-gray-600 mt-2">{assignedArrangement.option?.description || 'This plan was tailored for you.'}</p>
+                          <div className="mt-4 space-y-2">
+                            <div className="flex justify-between text-sm">
+                              <span className="text-gray-600">Monthly Payment:</span>
+                              <span className="font-medium">
+                                {assignedArrangement.customMonthlyPaymentCents
+                                  ? formatCurrency(assignedArrangement.customMonthlyPaymentCents)
+                                  : `${formatCurrency(assignedArrangement.option?.monthlyPaymentMin || 0)} - ${formatCurrency(assignedArrangement.option?.monthlyPaymentMax || 0)}`}
+                              </span>
+                            </div>
+                            <div className="flex justify-between text-sm">
+                              <span className="text-gray-600">Term:</span>
+                              <span className="font-medium">
+                                {assignedArrangement.customTermMonths || assignedArrangement.option?.maxTermMonths || 'Flexible'} months
+                              </span>
+                            </div>
+                            {assignedArrangement.notes && (
+                              <div className="text-sm text-gray-600">{assignedArrangement.notes}</div>
+                            )}
+                          </div>
+                        </div>
+                        <div className="ml-6 text-right">
+                          <Badge variant="secondary" className="uppercase mb-3">
+                            {assignedArrangement.status}
+                          </Badge>
+                          <Button onClick={() => setShowCallbackModal(true)}>
+                            Portion Plan
+                          </Button>
+                        </div>
+                      </div>
+                    </CardContent>
+                  </Card>
+                )}
+
+                {availableArrangements.map((arrangement: any) => (
                   <Card key={arrangement.id}>
                     <CardContent className="pt-6">
                       <div className="flex justify-between items-start">

--- a/migrations/0000_consumer_arrangements.sql
+++ b/migrations/0000_consumer_arrangements.sql
@@ -1,0 +1,25 @@
+CREATE TABLE IF NOT EXISTS "consumer_arrangements" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "tenant_id" uuid NOT NULL REFERENCES "tenants"("id") ON DELETE CASCADE,
+  "consumer_id" uuid NOT NULL REFERENCES "consumers"("id") ON DELETE CASCADE,
+  "account_id" uuid NOT NULL REFERENCES "accounts"("id") ON DELETE CASCADE,
+  "arrangement_option_id" uuid REFERENCES "arrangement_options"("id") ON DELETE SET NULL,
+  "custom_monthly_payment_cents" bigint,
+  "custom_term_months" bigint,
+  "custom_down_payment_cents" bigint,
+  "status" text NOT NULL DEFAULT 'active' CHECK ("status" IN ('active','pending','paused','completed','cancelled')),
+  "notes" text,
+  "assigned_at" timestamp DEFAULT now(),
+  "activated_at" timestamp,
+  "completed_at" timestamp,
+  "cancelled_at" timestamp,
+  "status_changed_at" timestamp DEFAULT now(),
+  "created_at" timestamp DEFAULT now(),
+  "updated_at" timestamp DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "consumer_arrangements_account_unique"
+  ON "consumer_arrangements" ("account_id");
+
+CREATE INDEX IF NOT EXISTS "consumer_arrangements_tenant_idx"
+  ON "consumer_arrangements" ("tenant_id");

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "test": "node --test --import tsx ./client/src/pages/__tests__/agency-policy-utils.test.ts",
+    "test": "node --test --import tsx ./client/src/pages/__tests__/agency-policy-utils.test.ts ./server/arrangements/__tests__/helpers.test.ts",
     "db:push": "drizzle-kit push"
   },
   "dependencies": {

--- a/server/arrangements/__tests__/helpers.test.ts
+++ b/server/arrangements/__tests__/helpers.test.ts
@@ -1,0 +1,123 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildConsumerArrangementVisibility,
+  ensureTenantAccountOwnership,
+  type AccountWithArrangement,
+} from "../helpers";
+import type { ArrangementOption, ConsumerArrangement } from "@shared/schema";
+
+function makeArrangement(overrides: Partial<ConsumerArrangement> = {}): ConsumerArrangement {
+  return {
+    id: "arr-1",
+    tenantId: "tenant-1",
+    consumerId: "consumer-1",
+    accountId: "account-1",
+    arrangementOptionId: "opt-1",
+    customMonthlyPaymentCents: 25000,
+    customTermMonths: 12,
+    customDownPaymentCents: null,
+    status: "active",
+    notes: "Preferred terms",
+    assignedAt: new Date("2024-01-01T00:00:00.000Z"),
+    activatedAt: new Date("2024-01-02T00:00:00.000Z"),
+    completedAt: null,
+    cancelledAt: null,
+    statusChangedAt: new Date("2024-01-02T00:00:00.000Z"),
+    createdAt: new Date("2024-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2024-01-02T00:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+function makeOption(overrides: Partial<ArrangementOption> = {}): ArrangementOption {
+  return {
+    id: "opt-1",
+    tenantId: "tenant-1",
+    name: "Standard Plan",
+    description: "Structured payments",
+    minBalance: 0,
+    maxBalance: 100_000,
+    monthlyPaymentMin: 10_000,
+    monthlyPaymentMax: 30_000,
+    maxTermMonths: 24,
+    isActive: true,
+    createdAt: new Date("2024-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2024-01-01T00:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+test("ensureTenantAccountOwnership allows matching tenants", () => {
+  assert.doesNotThrow(() => ensureTenantAccountOwnership("tenant-1", "tenant-1"));
+});
+
+test("ensureTenantAccountOwnership rejects mismatched tenants", () => {
+  assert.throws(
+    () => ensureTenantAccountOwnership("tenant-1", "tenant-2"),
+    /Account does not belong to tenant/
+  );
+});
+
+test("buildConsumerArrangementVisibility surfaces the active assignment and filters remaining options", () => {
+  const activeArrangement = makeArrangement();
+  const optionOne = makeOption();
+  const optionTwo = makeOption({ id: "opt-2", name: "Extended Plan" });
+
+  const accounts: AccountWithArrangement[] = [
+    {
+      id: "account-1",
+      tenantId: "tenant-1",
+      balanceCents: 75_000,
+      creditor: "Atlas Bank",
+      accountNumber: "ACC-001",
+      arrangement: { ...activeArrangement, option: optionOne },
+    },
+    {
+      id: "account-2",
+      tenantId: "tenant-1",
+      balanceCents: 12_000,
+      creditor: "Metro Finance",
+      accountNumber: "ACC-002",
+      arrangement: null,
+    },
+  ];
+
+  const result = buildConsumerArrangementVisibility(accounts, [optionOne, optionTwo]);
+
+  assert.ok(result.assigned, "expected an assigned arrangement to be returned");
+  assert.equal(result.assigned?.account.id, "account-1");
+  assert.equal(result.assigned?.option?.id, "opt-1");
+  assert.equal(result.available.length, 1);
+  assert.equal(result.available[0].id, "opt-2");
+});
+
+test("buildConsumerArrangementVisibility hides cancelled assignments and keeps all options available", () => {
+  const cancelledArrangement = makeArrangement({
+    id: "arr-2",
+    status: "cancelled",
+    cancelledAt: new Date("2024-02-01T00:00:00.000Z"),
+  });
+  const optionOne = makeOption();
+  const optionTwo = makeOption({ id: "opt-2", name: "Deferred Plan" });
+
+  const accounts: AccountWithArrangement[] = [
+    {
+      id: "account-3",
+      tenantId: "tenant-1",
+      balanceCents: 42_000,
+      creditor: "Summit Lending",
+      accountNumber: "ACC-003",
+      arrangement: { ...cancelledArrangement, option: optionOne },
+    },
+  ];
+
+  const result = buildConsumerArrangementVisibility(accounts, [optionOne, optionTwo]);
+
+  assert.equal(result.assigned, null);
+  assert.equal(result.available.length, 2);
+  assert.deepEqual(
+    result.available.map(option => option.id).sort(),
+    ["opt-1", "opt-2"].sort()
+  );
+});

--- a/server/arrangements/helpers.ts
+++ b/server/arrangements/helpers.ts
@@ -1,0 +1,57 @@
+import type { ArrangementOption, ConsumerArrangement } from "@shared/schema";
+
+type AccountWithArrangement = {
+  id: string;
+  tenantId?: string | null;
+  balanceCents?: number | null;
+  creditor?: string | null;
+  accountNumber?: string | null;
+  arrangement?: (ConsumerArrangement & { option?: ArrangementOption | null }) | null;
+};
+
+export const ACTIVE_ARRANGEMENT_STATUSES = new Set(["active", "pending", "paused"]);
+
+export function ensureTenantAccountOwnership(accountTenantId: string, tenantId: string) {
+  if (accountTenantId !== tenantId) {
+    throw new Error("Account does not belong to tenant");
+  }
+}
+
+export function buildConsumerArrangementVisibility(
+  accounts: AccountWithArrangement[],
+  options: ArrangementOption[],
+) {
+  const assignedAccount = accounts.find((account) => {
+    const arrangement = account.arrangement;
+    if (!arrangement) {
+      return false;
+    }
+
+    const status = arrangement.status || "active";
+    return ACTIVE_ARRANGEMENT_STATUSES.has(status);
+  });
+
+  const assigned = assignedAccount?.arrangement
+    ? {
+        ...assignedAccount.arrangement,
+        account: {
+          id: assignedAccount.id,
+          creditor: assignedAccount.creditor ?? null,
+          balanceCents: assignedAccount.balanceCents ?? null,
+          accountNumber: assignedAccount.accountNumber ?? null,
+        },
+        option: assignedAccount.arrangement.option ?? null,
+      }
+    : null;
+
+  const available = options.filter((option) => {
+    if (!assignedAccount?.arrangement?.arrangementOptionId) {
+      return true;
+    }
+    return option.id !== assignedAccount.arrangement.arrangementOptionId;
+  });
+
+  return { assigned, available };
+}
+
+export type { AccountWithArrangement };


### PR DESCRIPTION
## Summary
- add a `consumer_arrangements` table to the shared schema plus a migration and types
- extend storage with CRUD helpers for account arrangements and expose REST routes for assigning/removing plans
- surface assigned plans in the admin account modal and consumer portals, showing the active plan separate from available options
- introduce helpers and tests for tenant ownership checks and consumer arrangement visibility

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2a12f0b74832abdd94055f6a9274f