### PR TITLE
fix: import drizzle helpers

### DIFF
--- a/api/arrangement-options/[id].ts
+++ b/api/arrangement-options/[id].ts
@@ -3,6 +3,7 @@ import jwt from 'jsonwebtoken';
 import { getDb } from '../_lib/db.js';
 import { arrangementOptions } from '../_lib/schema.js';
 import { JWT_SECRET } from '../_lib/auth.js';
+import { eq, and } from 'drizzle-orm';
 
 interface AuthenticatedRequest extends VercelRequest {
   method: string;


### PR DESCRIPTION
## Summary
- import the drizzle `eq` and `and` helpers used in the arrangement option API route

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2b305ce54832ab3d8a721c659e5dd