### PR TITLE
Fix case-insensitive consumer email lookup

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1017,10 +1017,15 @@ export class DatabaseStorage implements IStorage {
   async getConsumerByEmailAndTenant(email: string, tenantSlug: string): Promise<Consumer | undefined> {
     const tenant = await this.getTenantBySlug(tenantSlug);
     if (!tenant) return undefined;
-    
+
     const [consumer] = await db.select()
       .from(consumers)
-      .where(and(eq(consumers.email, email), eq(consumers.tenantId, tenant.id)));
+      .where(
+        and(
+          eq(consumers.tenantId, tenant.id),
+          sql`LOWER(${consumers.email}) = LOWER(${email})`
+        )
+      );
     return consumer || undefined;
   }
 
@@ -1028,8 +1033,8 @@ export class DatabaseStorage implements IStorage {
     // Get all consumers with this email
     const allConsumers = await db.select()
       .from(consumers)
-      .where(eq(consumers.email, email));
-    
+      .where(sql`LOWER(${consumers.email}) = LOWER(${email})`);
+
     // Prioritize consumers WITH a tenantId over those without
     // This ensures we return linked consumers first
     const linkedConsumer = allConsumers.find(c => c.tenantId);


### PR DESCRIPTION
## Summary
- update the storage consumer lookup queries to compare emails case-insensitively when retrieving a consumer by email
- ensure tenant-scoped consumer lookups also normalize email casing so registrations correctly match existing records

## Testing
- `npm run check` *(fails: existing type errors in unrelated client/server code)*

------
https://chatgpt.com/codex/tasks/task_e_68d1d828d11c832ab7ea33efb02ebafb