### PR TITLE
Enforce tenant scoping for arrangement option mutations

### DIFF
--- a/server/arrangements/__tests__/arrangement-options.test.ts
+++ b/server/arrangements/__tests__/arrangement-options.test.ts
@@ -1,0 +1,232 @@
+import test, { mock } from "node:test";
+import assert from "node:assert/strict";
+
+process.env.DATABASE_URL ??= "postgres://user:pass@localhost:5432/db";
+
+const [{ DatabaseStorage }, { db }] = await Promise.all([
+  import("../../storage"),
+  import("../../db"),
+]);
+
+type ArrangementOptionRecord = {
+  id: string;
+  tenantId: string;
+  name: string;
+  updatedAt?: Date;
+  [key: string]: unknown;
+};
+
+type WhereParams = {
+  id?: string;
+  tenantId?: string;
+};
+
+type FakeDbState = {
+  data: ArrangementOptionRecord[];
+  lastSet?: Record<string, unknown>;
+  lastUpdateParams?: WhereParams;
+  lastDeleteParams?: WhereParams;
+};
+
+function extractWhereParams(condition: unknown): WhereParams {
+  const params: WhereParams = {};
+  const visited = new Set<object>();
+
+  const visit = (node: unknown) => {
+    if (!node || typeof node !== "object" || visited.has(node)) {
+      return;
+    }
+
+    visited.add(node);
+
+    if (
+      node.constructor?.name === "Param" &&
+      typeof (node as any).encoder?.name === "string"
+    ) {
+      const columnName = (node as any).encoder.name as string;
+      const value = (node as any).value as string | undefined;
+
+      if (columnName === "id") {
+        params.id = value;
+        return;
+      }
+
+      if (columnName === "tenant_id") {
+        params.tenantId = value;
+        return;
+      }
+    }
+
+    for (const key of Object.keys(node)) {
+      if (key === "encoder" || key === "table" || key === "columns") {
+        continue;
+      }
+
+      visit((node as any)[key]);
+    }
+  };
+
+  visit(condition);
+  return params;
+}
+
+function createFakeArrangementDb(initialData: ArrangementOptionRecord[]): {
+  update: typeof db.update;
+  delete: typeof db.delete;
+  state: FakeDbState;
+} {
+  const state: FakeDbState = {
+    data: initialData.map((option) => ({ ...option })),
+  };
+
+  const update = (() => ({
+    set: (updates: Record<string, unknown>) => ({
+      where: (condition: unknown) => ({
+        returning: async () => {
+          state.lastSet = { ...updates };
+          const params = extractWhereParams(condition);
+          state.lastUpdateParams = params;
+
+          const matchIndex = state.data.findIndex(
+            (option) => option.id === params.id && option.tenantId === params.tenantId,
+          );
+
+          if (matchIndex === -1) {
+            return [];
+          }
+
+          const updatedOption: ArrangementOptionRecord = {
+            ...state.data[matchIndex],
+            ...updates,
+            tenantId: state.data[matchIndex].tenantId,
+          };
+
+          state.data[matchIndex] = updatedOption;
+          return [updatedOption];
+        },
+      }),
+    }),
+  })) as typeof db.update;
+
+  const remove = (() => ({
+    where: (condition: unknown) => ({
+      returning: async () => {
+        const params = extractWhereParams(condition);
+        state.lastDeleteParams = params;
+
+        const matchIndex = state.data.findIndex(
+          (option) => option.id === params.id && option.tenantId === params.tenantId,
+        );
+
+        if (matchIndex === -1) {
+          return [];
+        }
+
+        const [removed] = state.data.splice(matchIndex, 1);
+        return [removed];
+      },
+    }),
+  })) as typeof db.delete;
+
+  return { update, delete: remove, state };
+}
+
+test("updateArrangementOption updates matching tenant and ignores tenantId", async () => {
+  const initial = [
+    {
+      id: "option-1",
+      tenantId: "tenant-1",
+      name: "Option 1",
+      updatedAt: new Date("2024-01-01T00:00:00Z"),
+    },
+  ];
+  const { update, delete: remove, state } = createFakeArrangementDb(initial);
+  mock.method(db, "update", update);
+  mock.method(db, "delete", remove);
+
+  const storage = new DatabaseStorage();
+
+  try {
+    const result = await storage.updateArrangementOption("option-1", "tenant-1", {
+      name: "Updated Option",
+      tenantId: "tenant-2",
+    });
+
+    assert.ok(result);
+    assert.strictEqual(result.name, "Updated Option");
+    assert.strictEqual(result.tenantId, "tenant-1");
+    assert.ok(state.lastSet);
+    assert.strictEqual(Object.prototype.hasOwnProperty.call(state.lastSet, "tenantId"), false);
+    assert.ok(state.lastSet?.updatedAt instanceof Date);
+    assert.deepStrictEqual(state.lastUpdateParams, { id: "option-1", tenantId: "tenant-1" });
+  } finally {
+    mock.restoreAll();
+  }
+});
+
+test("updateArrangementOption returns undefined for mismatched tenant", async () => {
+  const initial = [
+    { id: "option-1", tenantId: "tenant-1", name: "Option 1" },
+    { id: "option-2", tenantId: "tenant-2", name: "Option 2" },
+  ];
+  const { update, delete: remove, state } = createFakeArrangementDb(initial);
+  mock.method(db, "update", update);
+  mock.method(db, "delete", remove);
+
+  const storage = new DatabaseStorage();
+
+  try {
+    const result = await storage.updateArrangementOption("option-1", "tenant-2", {
+      name: "Should Not Update",
+    });
+
+    assert.strictEqual(result, undefined);
+    assert.strictEqual(state.data.find((option) => option.id === "option-1")?.name, "Option 1");
+  } finally {
+    mock.restoreAll();
+  }
+});
+
+test("deleteArrangementOption removes records for matching tenant", async () => {
+  const initial = [
+    { id: "option-1", tenantId: "tenant-1", name: "Option 1" },
+    { id: "option-2", tenantId: "tenant-2", name: "Option 2" },
+  ];
+  const { update, delete: remove, state } = createFakeArrangementDb(initial);
+  mock.method(db, "update", update);
+  mock.method(db, "delete", remove);
+
+  const storage = new DatabaseStorage();
+
+  try {
+    const result = await storage.deleteArrangementOption("option-2", "tenant-2");
+
+    assert.strictEqual(result, true);
+    assert.strictEqual(state.data.some((option) => option.id === "option-2"), false);
+    assert.deepStrictEqual(state.lastDeleteParams, { id: "option-2", tenantId: "tenant-2" });
+  } finally {
+    mock.restoreAll();
+  }
+});
+
+test("deleteArrangementOption returns false when tenant does not match", async () => {
+  const initial = [
+    { id: "option-1", tenantId: "tenant-1", name: "Option 1" },
+    { id: "option-2", tenantId: "tenant-2", name: "Option 2" },
+  ];
+  const { update, delete: remove, state } = createFakeArrangementDb(initial);
+  mock.method(db, "update", update);
+  mock.method(db, "delete", remove);
+
+  const storage = new DatabaseStorage();
+
+  try {
+    const result = await storage.deleteArrangementOption("option-1", "tenant-2");
+
+    assert.strictEqual(result, false);
+    assert.strictEqual(state.data.length, 2);
+    assert.strictEqual(state.data.find((option) => option.id === "option-1")?.tenantId, "tenant-1");
+  } finally {
+    mock.restoreAll();
+  }
+});

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2672,7 +2672,12 @@ export async function registerRoutes(app: Express): Promise<Server> {
       }
 
       const payload = buildArrangementOptionPayload(req.body, tenantId);
-      const option = await storage.updateArrangementOption(req.params.id, payload);
+      const option = await storage.updateArrangementOption(req.params.id, tenantId, payload);
+
+      if (!option) {
+        return res.status(404).json({ message: "Arrangement option not found" });
+      }
+
       res.json(option);
     } catch (error) {
       console.error("Error updating arrangement option:", error);
@@ -2688,7 +2693,18 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   app.delete('/api/arrangement-options/:id', authenticateUser, async (req: any, res) => {
     try {
-      await storage.deleteArrangementOption(req.params.id);
+      const tenantId = req.user.tenantId;
+
+      if (!tenantId) {
+        return res.status(403).json({ message: "No tenant access" });
+      }
+
+      const deleted = await storage.deleteArrangementOption(req.params.id, tenantId);
+
+      if (!deleted) {
+        return res.status(404).json({ message: "Arrangement option not found" });
+      }
+
       res.json({ message: "Arrangement option deleted successfully" });
     } catch (error) {
       console.error("Error deleting arrangement option:", error);


### PR DESCRIPTION
## Summary
- require tenant context on arrangement option PUT/DELETE endpoints and return proper 403/404 responses when tenant access is missing or mismatched
- update storage logic to scope arrangement option updates/deletes by tenant and ignore tenantId fields in payloads
- add tests covering same-tenant success and cross-tenant failure for arrangement option updates and deletes

## Testing
- node --test --import tsx server/arrangements/__tests__/arrangement-options.test.ts
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2b8985c24832aafc48b0685b90bd0