### PR TITLE
Enforce tenant scoped arrangement option updates

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2625,8 +2625,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // Arrangement options routes
   app.get('/api/arrangement-options', authenticateUser, async (req: any, res) => {
     try {
-      const tenantId = req.user.tenantId;
-      
+      const tenantId = req.user?.tenantId;
+
       if (!tenantId) {
         return res.status(403).json({ message: "No tenant access" });
       }
@@ -2641,7 +2641,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   app.post('/api/arrangement-options', authenticateUser, async (req: any, res) => {
     try {
-      const tenantId = req.user.tenantId;
+      const tenantId = req.user?.tenantId;
 
       if (!tenantId) {
         return res.status(403).json({ message: "No tenant access" });
@@ -2665,7 +2665,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   app.put('/api/arrangement-options/:id', authenticateUser, async (req: any, res) => {
     try {
-      const tenantId = req.user.tenantId;
+      const tenantId = req.user?.tenantId;
 
       if (!tenantId) {
         return res.status(403).json({ message: "No tenant access" });
@@ -2693,7 +2693,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   app.delete('/api/arrangement-options/:id', authenticateUser, async (req: any, res) => {
     try {
-      const tenantId = req.user.tenantId;
+      const tenantId = req.user?.tenantId;
 
       if (!tenantId) {
         return res.status(403).json({ message: "No tenant access" });


### PR DESCRIPTION
## Summary
- guard arrangement option update/delete routes against missing tenant context and pass the tenant id through to the storage layer
- expose arrangement option storage mocks from the test helper and add API-level tests covering happy path and cross-tenant failure cases for updates and deletes

## Testing
- node --test --import tsx server/arrangements/__tests__/arrangement-options.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d2c5764550832abaa88fe053903333