### PR TITLE
Add Express bulk account deletion parity and fix automation toggle

### DIFF
--- a/client/src/pages/communications.tsx
+++ b/client/src/pages/communications.tsx
@@ -349,8 +349,8 @@ export default function Communications() {
   });
 
   const toggleAutomationMutation = useMutation({
-    mutationFn: ({ id, isActive }: { id: string; isActive: boolean }) => 
-      apiRequest(`/api/automations/${id}`, "PUT", { isActive }),
+    mutationFn: ({ id, isActive }: { id: string; isActive: boolean }) =>
+      apiRequest("PUT", `/api/automations/${id}`, { isActive }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/automations"] });
       toast({


### PR DESCRIPTION
## Summary
- add an Express handler for `/api/accounts/bulk-delete` so local development matches the serverless endpoint
- extend the storage layer with a helper that verifies and removes multiple tenant accounts in one call
- fix the communications automation toggle to call `apiRequest` with the correct argument order

## Testing
- npm run check *(fails: existing TypeScript errors in unrelated files)*
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68d2ffc62620832a868a237826a921bc