### PR TITLE
Add PATCH support to update accounts and consumers

### DIFF
--- a/api/accounts.ts
+++ b/api/accounts.ts
@@ -68,9 +68,9 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
       res.status(200).json(tenantAccounts);
     } else if (req.method === 'POST') {
       // Create a new account
-      const { 
-        firstName, lastName, email, phone, 
-        accountNumber, creditor, balanceCents, folderId, 
+      const {
+        firstName, lastName, email, phone,
+        accountNumber, creditor, balanceCents, folderId,
         dateOfBirth, address, city, state, zipCode,
         additionalData, dueDate
       } = req.body;
@@ -150,6 +150,168 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
         .returning();
 
       res.status(201).json(newAccount);
+    } else if (req.method === 'PATCH') {
+      const queryId = req.query.id;
+      let accountId: string | undefined;
+
+      if (typeof queryId === 'string') {
+        accountId = queryId;
+      } else if (Array.isArray(queryId) && queryId.length > 0) {
+        accountId = queryId[0];
+      } else if (req.url) {
+        const urlPath = req.url.split('?')[0];
+        const segments = urlPath.split('/').filter(Boolean);
+        const lastSegment = segments[segments.length - 1];
+        if (lastSegment && lastSegment !== 'accounts') {
+          accountId = lastSegment;
+        }
+      }
+
+      if (!accountId) {
+        res.status(400).json({ error: 'Account ID is required' });
+        return;
+      }
+
+      const [existingAccount] = await db
+        .select({
+          id: accounts.id,
+          tenantId: accounts.tenantId,
+          consumerId: accounts.consumerId,
+        })
+        .from(accounts)
+        .where(and(
+          eq(accounts.id, accountId),
+          eq(accounts.tenantId, tenantId)
+        ))
+        .limit(1);
+
+      if (!existingAccount) {
+        res.status(404).json({ error: 'Account not found' });
+        return;
+      }
+
+      const {
+        firstName,
+        lastName,
+        email,
+        phone,
+        accountNumber,
+        creditor,
+        balanceCents,
+        folderId,
+        dateOfBirth,
+        address,
+        city,
+        state,
+        zipCode,
+        dueDate,
+        status,
+        additionalData,
+        consumerAdditionalData,
+      } = req.body || {};
+
+      const accountUpdates: Record<string, any> = {};
+      if (accountNumber !== undefined) accountUpdates.accountNumber = accountNumber ?? '';
+      if (creditor !== undefined) accountUpdates.creditor = creditor;
+      if (balanceCents !== undefined) accountUpdates.balanceCents = balanceCents;
+      if (dueDate !== undefined) accountUpdates.dueDate = dueDate || null;
+      if (status !== undefined) accountUpdates.status = status;
+      if (additionalData !== undefined) accountUpdates.additionalData = additionalData;
+      if (folderId !== undefined) accountUpdates.folderId = folderId || null;
+
+      const consumerUpdates: Record<string, any> = {};
+      if (firstName !== undefined) consumerUpdates.firstName = firstName;
+      if (lastName !== undefined) consumerUpdates.lastName = lastName;
+      if (email !== undefined) consumerUpdates.email = email;
+      if (phone !== undefined) consumerUpdates.phone = phone;
+      if (folderId !== undefined) consumerUpdates.folderId = folderId || null;
+      if (dateOfBirth !== undefined) consumerUpdates.dateOfBirth = dateOfBirth;
+      if (address !== undefined) consumerUpdates.address = address;
+      if (city !== undefined) consumerUpdates.city = city;
+      if (state !== undefined) consumerUpdates.state = state;
+      if (zipCode !== undefined) consumerUpdates.zipCode = zipCode;
+      if (consumerAdditionalData !== undefined) consumerUpdates.additionalData = consumerAdditionalData;
+
+      // Validate that provided folder belongs to tenant
+      if (folderId) {
+        const [folder] = await db
+          .select({ id: folders.id })
+          .from(folders)
+          .where(and(
+            eq(folders.id, folderId),
+            eq(folders.tenantId, tenantId)
+          ))
+          .limit(1);
+
+        if (!folder) {
+          res.status(400).json({ error: 'Invalid folder for tenant' });
+          return;
+        }
+      }
+
+      if (Object.keys(accountUpdates).length > 0) {
+        await db
+          .update(accounts)
+          .set(accountUpdates)
+          .where(and(
+            eq(accounts.id, accountId),
+            eq(accounts.tenantId, tenantId)
+          ));
+      }
+
+      if (Object.keys(consumerUpdates).length > 0) {
+        await db
+          .update(consumers)
+          .set(consumerUpdates)
+          .where(and(
+            eq(consumers.id, existingAccount.consumerId),
+            eq(consumers.tenantId, tenantId)
+          ));
+      }
+
+      const [updatedAccount] = await db
+        .select({
+          id: accounts.id,
+          accountNumber: accounts.accountNumber,
+          creditor: accounts.creditor,
+          balanceCents: accounts.balanceCents,
+          dueDate: accounts.dueDate,
+          status: accounts.status,
+          additionalData: accounts.additionalData,
+          consumerId: accounts.consumerId,
+          tenantId: accounts.tenantId,
+          createdAt: accounts.createdAt,
+          consumer: {
+            id: consumers.id,
+            firstName: consumers.firstName,
+            lastName: consumers.lastName,
+            email: consumers.email,
+            phone: consumers.phone,
+            folderId: consumers.folderId,
+            dateOfBirth: consumers.dateOfBirth,
+            address: consumers.address,
+            city: consumers.city,
+            state: consumers.state,
+            zipCode: consumers.zipCode,
+            additionalData: consumers.additionalData,
+          },
+          folder: {
+            id: folders.id,
+            name: folders.name,
+            color: folders.color,
+            isDefault: folders.isDefault,
+          },
+        })
+        .from(accounts)
+        .leftJoin(consumers, eq(accounts.consumerId, consumers.id))
+        .leftJoin(folders, eq(consumers.folderId, folders.id))
+        .where(and(
+          eq(accounts.id, accountId),
+          eq(accounts.tenantId, tenantId)
+        ))
+        .limit(1);
+
+      res.status(200).json(updatedAccount);
     } else if (req.method === 'DELETE') {
       // Delete an account - expects /api/accounts?id=<accountId>
       const accountId = req.query.id as string;


### PR DESCRIPTION
## Summary
- add PATCH handling to the accounts API for updating account and consumer records
- validate tenant ownership before modifying data and refresh related folder info
- return the updated account with nested consumer and folder details

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d306008970832a80bb13ca6b2d87b6