### PR TITLE
Support path-based IDs in API handlers

### DIFF
--- a/api/_lib/request-helpers.ts
+++ b/api/_lib/request-helpers.ts
@@ -1,0 +1,32 @@
+import type { VercelRequest } from '@vercel/node';
+
+export function resolveResourceId(req: VercelRequest, paramName: string = 'id'): string | undefined {
+  const queryValue = req.query?.[paramName];
+
+  if (Array.isArray(queryValue)) {
+    const firstValue = queryValue.find((value) => typeof value === 'string' && value.length > 0);
+    if (firstValue) {
+      return firstValue;
+    }
+  } else if (typeof queryValue === 'string' && queryValue.length > 0) {
+    return queryValue;
+  }
+
+  if (req.url) {
+    try {
+      const url = new URL(req.url, 'http://localhost');
+      const segments = url.pathname.split('/').filter(Boolean);
+
+      if (segments.length >= 3) {
+        const lastSegment = segments[segments.length - 1];
+        if (lastSegment) {
+          return lastSegment;
+        }
+      }
+    } catch (error) {
+      // Ignore URL parsing errors and fall through to undefined return value
+    }
+  }
+
+  return undefined;
+}

--- a/api/accounts.ts
+++ b/api/accounts.ts
@@ -4,6 +4,7 @@ import { withAuth, AuthenticatedRequest, JWT_SECRET } from './_lib/auth.js';
 import { accounts, consumers, folders } from './_lib/schema.js';
 import { eq, and } from 'drizzle-orm';
 import jwt from 'jsonwebtoken';
+import { resolveResourceId } from './_lib/request-helpers.js';
 
 async function handler(req: AuthenticatedRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') {
@@ -151,8 +152,8 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
 
       res.status(201).json(newAccount);
     } else if (req.method === 'DELETE') {
-      // Delete an account - expects /api/accounts?id=<accountId>
-      const accountId = req.query.id as string;
+      // Delete an account - accepts /api/accounts?id=<accountId> or /api/accounts/<accountId>
+      const accountId = resolveResourceId(req);
 
       if (!accountId) {
         res.status(400).json({ error: 'Account ID is required' });

--- a/api/automations.ts
+++ b/api/automations.ts
@@ -4,6 +4,7 @@ import { withAuth, AuthenticatedRequest, JWT_SECRET } from './_lib/auth.js';
 import { communicationAutomations, automationExecutions, emailTemplates, smsTemplates } from './_lib/schema.js';
 import { eq, and, desc, sql } from 'drizzle-orm';
 import jwt from 'jsonwebtoken';
+import { resolveResourceId } from './_lib/request-helpers.js';
 
 async function handler(req: AuthenticatedRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') {
@@ -153,7 +154,7 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
       res.status(201).json(newAutomation);
     } else if (req.method === 'PUT') {
       // Update automation (activate/deactivate or modify settings)
-      const automationId = req.query.id as string;
+      const automationId = resolveResourceId(req);
       const updates = req.body;
 
       if (!automationId) {
@@ -189,7 +190,7 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
       res.status(200).json(updatedAutomation);
     } else if (req.method === 'DELETE') {
       // Delete an automation
-      const automationId = req.query.id as string;
+      const automationId = resolveResourceId(req);
 
       if (!automationId) {
         res.status(400).json({ error: 'Automation ID is required' });

--- a/api/callback-requests.ts
+++ b/api/callback-requests.ts
@@ -4,6 +4,7 @@ import { withAuth, AuthenticatedRequest, JWT_SECRET } from './_lib/auth.js';
 import { callbackRequests, consumers } from './_lib/schema.js';
 import { eq, and, desc } from 'drizzle-orm';
 import jwt from 'jsonwebtoken';
+import { resolveResourceId } from './_lib/request-helpers.js';
 
 async function handler(req: AuthenticatedRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') {
@@ -64,8 +65,8 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
 
       res.status(200).json(requests);
     } else if (req.method === 'PATCH') {
-      // Update callback request - expects /api/callback-requests?id=<requestId>
-      const requestId = req.query.id as string;
+      // Update callback request - accepts /api/callback-requests?id=<requestId> or /api/callback-requests/<requestId>
+      const requestId = resolveResourceId(req);
       const updates = req.body;
 
       if (!requestId) {

--- a/api/email-campaigns.ts
+++ b/api/email-campaigns.ts
@@ -4,6 +4,7 @@ import { withAuth, AuthenticatedRequest, JWT_SECRET } from './_lib/auth.js';
 import { emailCampaigns, emailTemplates, consumers, emailTracking } from './_lib/schema.js';
 import { eq, and, desc, sql } from 'drizzle-orm';
 import jwt from 'jsonwebtoken';
+import { resolveResourceId } from './_lib/request-helpers.js';
 
 async function handler(req: AuthenticatedRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') {
@@ -155,7 +156,7 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
       res.status(200).json(updatedCampaign);
     } else if (req.method === 'DELETE') {
       // Delete a campaign
-      const campaignId = req.query.id as string;
+      const campaignId = resolveResourceId(req);
 
       if (!campaignId) {
         res.status(400).json({ error: 'Campaign ID is required' });

--- a/api/email-templates.ts
+++ b/api/email-templates.ts
@@ -4,6 +4,7 @@ import { withAuth, AuthenticatedRequest, JWT_SECRET } from './_lib/auth.js';
 import { emailTemplates } from './_lib/schema.js';
 import { eq, and, desc } from 'drizzle-orm';
 import jwt from 'jsonwebtoken';
+import { resolveResourceId } from './_lib/request-helpers.js';
 
 async function handler(req: AuthenticatedRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') {
@@ -62,8 +63,8 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
 
       res.status(201).json(newTemplate);
     } else if (req.method === 'DELETE') {
-      // Delete an email template - expects /api/email-templates?id=<templateId>
-      const templateId = req.query.id as string;
+      // Delete an email template - accepts /api/email-templates?id=<templateId> or /api/email-templates/<templateId>
+      const templateId = resolveResourceId(req);
 
       if (!templateId) {
         res.status(400).json({ error: 'Template ID is required' });

--- a/api/folders.ts
+++ b/api/folders.ts
@@ -4,6 +4,7 @@ import { withAuth, AuthenticatedRequest, JWT_SECRET } from './_lib/auth.js';
 import { folders, accounts } from './_lib/schema.js';
 import { eq, and } from 'drizzle-orm';
 import jwt from 'jsonwebtoken';
+import { resolveResourceId } from './_lib/request-helpers.js';
 
 async function handler(req: AuthenticatedRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') {
@@ -61,8 +62,8 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
 
       res.status(201).json(newFolder);
     } else if (req.method === 'DELETE') {
-      // Delete a folder - expects /api/folders?id=<folderId>
-      const folderId = req.query.id as string;
+      // Delete a folder - accepts /api/folders?id=<folderId> or /api/folders/<folderId>
+      const folderId = resolveResourceId(req);
 
       if (!folderId) {
         res.status(400).json({ error: 'Folder ID is required' });

--- a/api/sms-campaigns.ts
+++ b/api/sms-campaigns.ts
@@ -4,6 +4,7 @@ import { withAuth, AuthenticatedRequest, JWT_SECRET } from './_lib/auth.js';
 import { smsCampaigns, smsTemplates, consumers, smsTracking } from './_lib/schema.js';
 import { eq, and, desc, sql } from 'drizzle-orm';
 import jwt from 'jsonwebtoken';
+import { resolveResourceId } from './_lib/request-helpers.js';
 
 async function handler(req: AuthenticatedRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') {
@@ -150,7 +151,7 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
       res.status(200).json(updatedCampaign);
     } else if (req.method === 'DELETE') {
       // Delete a campaign
-      const campaignId = req.query.id as string;
+      const campaignId = resolveResourceId(req);
 
       if (!campaignId) {
         res.status(400).json({ error: 'Campaign ID is required' });

--- a/api/sms-templates.ts
+++ b/api/sms-templates.ts
@@ -4,6 +4,7 @@ import { withAuth, AuthenticatedRequest, JWT_SECRET } from './_lib/auth.js';
 import { smsTemplates } from './_lib/schema.js';
 import { eq, and, desc } from 'drizzle-orm';
 import jwt from 'jsonwebtoken';
+import { resolveResourceId } from './_lib/request-helpers.js';
 
 async function handler(req: AuthenticatedRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') {
@@ -60,8 +61,8 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
 
       res.status(201).json(newTemplate);
     } else if (req.method === 'DELETE') {
-      // Delete an SMS template - expects /api/sms-templates?id=<templateId>
-      const templateId = req.query.id as string;
+      // Delete an SMS template - accepts /api/sms-templates?id=<templateId> or /api/sms-templates/<templateId>
+      const templateId = resolveResourceId(req);
 
       if (!templateId) {
         res.status(400).json({ error: 'Template ID is required' });


### PR DESCRIPTION
## Summary
- add a shared helper to resolve resource identifiers from either query strings or trailing path segments
- update account, folder, template, campaign, automation, and callback request handlers to use the helper so DELETE/PATCH routes accept both syntaxes

## Testing
- npm run check *(fails: existing TypeScript errors in unrelated client and server files)*

------
https://chatgpt.com/codex/tasks/task_e_68d33ebeaabc832aa7b8c6854dc9c481