### PR TITLE
Update existing consumer data before account creation

### DIFF
--- a/api/__tests__/accounts-existing-consumer.test.ts
+++ b/api/__tests__/accounts-existing-consumer.test.ts
@@ -1,0 +1,137 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mock } from 'node:test';
+import jwt from 'jsonwebtoken';
+
+const TEST_SECRET = 'test-secret';
+
+interface TestRequest {
+  method: string;
+  headers: Record<string, string>;
+  body: any;
+}
+
+interface TestResponse {
+  status(code: number): TestResponse;
+  json(payload: any): TestResponse;
+  end(): TestResponse;
+}
+
+test('updates existing consumer details before linking account', async () => {
+  process.env.JWT_SECRET = TEST_SECRET;
+
+  const existingConsumer = {
+    id: 'consumer-1',
+    tenantId: 'tenant-1',
+    firstName: 'Jane',
+    lastName: 'Doe',
+    email: 'jane@example.com',
+    phone: '555-0000',
+    dateOfBirth: '1990-01-01',
+    address: '1 Old St',
+    city: 'Oldtown',
+    state: 'NY',
+    zipCode: '10001',
+    additionalData: {},
+    folderId: null,
+    isRegistered: false,
+    createdAt: new Date(),
+  };
+
+  const updateCalls: Array<{ data: Record<string, unknown> }> = [];
+  const insertCalls: Array<Record<string, unknown>> = [];
+
+  const fakeDb = {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => [existingConsumer],
+        }),
+      }),
+    }),
+    update: () => ({
+      set: (data: Record<string, unknown>) => {
+        updateCalls.push({ data });
+        return {
+          where: () => ({
+            returning: async () => [{ ...existingConsumer, ...data }],
+          }),
+        };
+      },
+    }),
+    insert: () => ({
+      values: (vals: Record<string, unknown>) => {
+        insertCalls.push(vals);
+        return {
+          returning: async () => [{ id: 'account-1', ...vals }],
+        };
+      },
+    }),
+  };
+
+  const { handler, __setTestDb } = await import('../accounts.ts');
+  __setTestDb(fakeDb as any);
+
+  const token = jwt.sign({ tenantId: 'tenant-1' }, TEST_SECRET);
+
+  const req: TestRequest = {
+    method: 'POST',
+    headers: { authorization: `Bearer ${token}` },
+    body: {
+      firstName: 'Jane',
+      lastName: 'Doe',
+      email: 'jane@example.com',
+      phone: '555-1111',
+      accountNumber: 'ACC-1',
+      creditor: 'Creditor Inc',
+      balanceCents: 10000,
+      folderId: null,
+      dateOfBirth: '1991-02-02',
+      address: '123 New St',
+      city: 'Newville',
+      state: 'CA',
+      zipCode: '90210',
+      additionalData: { note: 'test' },
+      dueDate: null,
+    },
+  };
+
+  let statusCode: number | undefined;
+  let jsonResponse: any;
+
+  const res: TestResponse = {
+    status(code: number) {
+      statusCode = code;
+      return this;
+    },
+    json(payload: any) {
+      jsonResponse = payload;
+      return this;
+    },
+    end() {
+      return this;
+    },
+  };
+
+  await handler(req as any, res as any);
+
+  assert.equal(statusCode, 201);
+  assert.ok(jsonResponse);
+  assert.equal(jsonResponse.consumerId, existingConsumer.id);
+
+  assert.equal(updateCalls.length, 1);
+  assert.deepEqual(updateCalls[0].data, {
+    dateOfBirth: '1991-02-02',
+    address: '123 New St',
+    city: 'Newville',
+    state: 'CA',
+    zipCode: '90210',
+    phone: '555-1111',
+  });
+
+  assert.equal(insertCalls.length, 1);
+  assert.equal(insertCalls[0].consumerId, existingConsumer.id);
+
+  __setTestDb(null);
+  mock.restoreAll();
+});

--- a/api/__tests__/accounts-existing-consumer.test.ts
+++ b/api/__tests__/accounts-existing-consumer.test.ts
@@ -138,3 +138,106 @@ test('updates existing consumer details before linking account', async () => {
     process.env.JWT_SECRET = originalSecret;
   }
 });
+
+test('preserves existing consumer fields when no overrides are provided', async () => {
+  const originalSecret = process.env.JWT_SECRET;
+  process.env.JWT_SECRET = TEST_SECRET;
+
+  const existingConsumer = {
+    id: 'consumer-2',
+    tenantId: 'tenant-1',
+    firstName: 'Sam',
+    lastName: 'Smith',
+    email: 'sam@example.com',
+    phone: '555-2222',
+    dateOfBirth: '1985-05-05',
+    address: '456 Old Rd',
+    city: 'Townsville',
+    state: 'TX',
+    zipCode: '73301',
+    additionalData: {},
+    folderId: null,
+    isRegistered: false,
+    createdAt: new Date(),
+  };
+
+  let updateCalled = false;
+  const insertCalls: Array<Record<string, unknown>> = [];
+
+  const fakeDb = {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => [existingConsumer],
+        }),
+      }),
+    }),
+    update: () => {
+      updateCalled = true;
+      return {
+        set: () => ({
+          where: () => ({
+            returning: async () => [existingConsumer],
+          }),
+        }),
+      };
+    },
+    insert: () => ({
+      values: (vals: Record<string, unknown>) => {
+        insertCalls.push(vals);
+        return {
+          returning: async () => [{ id: 'account-2', ...vals }],
+        };
+      },
+    }),
+  };
+
+  const { createAccountsHandler } = await import('../accounts.ts');
+  const handler = createAccountsHandler(() => fakeDb as any);
+
+  const token = jwt.sign({ tenantId: 'tenant-1' }, TEST_SECRET);
+
+  const req: TestRequest = {
+    method: 'POST',
+    headers: { authorization: `Bearer ${token}` },
+    body: {
+      firstName: 'Sam',
+      lastName: 'Smith',
+      email: 'sam@example.com',
+      accountNumber: 'ACC-2',
+      creditor: 'Creditor Inc',
+      balanceCents: 5000,
+      folderId: null,
+      additionalData: { note: 'no overrides' },
+      dueDate: null,
+    },
+  };
+
+  let statusCode: number | undefined;
+
+  const res: TestResponse = {
+    status(code: number) {
+      statusCode = code;
+      return this;
+    },
+    json() {
+      return this;
+    },
+    end() {
+      return this;
+    },
+  };
+
+  await handler(req as any, res as any);
+
+  assert.equal(statusCode, 201);
+  assert.equal(updateCalled, false);
+  assert.equal(insertCalls.length, 1);
+  assert.equal(insertCalls[0].consumerId, existingConsumer.id);
+
+  if (originalSecret === undefined) {
+    delete process.env.JWT_SECRET;
+  } else {
+    process.env.JWT_SECRET = originalSecret;
+  }
+});

--- a/api/accounts.ts
+++ b/api/accounts.ts
@@ -1,242 +1,239 @@
-import type { VercelRequest, VercelResponse } from '@vercel/node';
+import type { VercelResponse } from '@vercel/node';
 import { getDb } from './_lib/db.js';
 import { withAuth, AuthenticatedRequest, JWT_SECRET } from './_lib/auth.js';
 import { accounts, consumers, folders } from './_lib/schema.js';
 import { eq, and } from 'drizzle-orm';
 import jwt from 'jsonwebtoken';
 
-let testDbOverride: ReturnType<typeof getDb> | null = null;
-
-function resolveDb() {
-  return testDbOverride ?? getDb();
-}
-
-async function handler(req: AuthenticatedRequest, res: VercelResponse) {
-  if (req.method === 'OPTIONS') {
-    res.status(200).end();
-    return;
-  }
-
-  try {
-    const db = resolveDb();
-    
-    // Get tenant ID from JWT token
-    const token = req.headers.authorization?.replace('Bearer ', '') || 
-                  req.headers.cookie?.split(';').find(c => c.trim().startsWith('authToken='))?.split('=')[1];
-    
-    if (!token) {
-      res.status(401).json({ error: 'No token provided' });
+function createAccountsHandler(resolveDb: typeof getDb = getDb) {
+  return async function handler(req: AuthenticatedRequest, res: VercelResponse) {
+    if (req.method === 'OPTIONS') {
+      res.status(200).end();
       return;
     }
 
-    const decoded = jwt.verify(token, JWT_SECRET) as any;
-    const tenantId = decoded.tenantId;
+    try {
+      const db = resolveDb();
 
-    if (!tenantId) {
-      res.status(403).json({ error: 'No tenant access' });
-      return;
-    }
+      // Get tenant ID from JWT token
+      const token = req.headers.authorization?.replace('Bearer ', '') ||
+                    req.headers.cookie?.split(';').find(c => c.trim().startsWith('authToken='))?.split('=')[1];
 
-    if (req.method === 'GET') {
-      // Get all accounts for the tenant
-      const tenantAccounts = await db
-        .select({
-          id: accounts.id,
-          accountNumber: accounts.accountNumber,
-          creditor: accounts.creditor,
-          balanceCents: accounts.balanceCents,
-          dueDate: accounts.dueDate,
-          status: accounts.status,
-          additionalData: accounts.additionalData,
-          consumerId: accounts.consumerId,
-          tenantId: accounts.tenantId,
-          createdAt: accounts.createdAt,
-          consumer: {
-            id: consumers.id,
-            firstName: consumers.firstName,
-            lastName: consumers.lastName,
-            email: consumers.email,
-            phone: consumers.phone,
-            folderId: consumers.folderId,
-          },
-          folder: {
-            id: folders.id,
-            name: folders.name,
-            color: folders.color,
-            isDefault: folders.isDefault,
-          },
-        })
-        .from(accounts)
-        .leftJoin(consumers, eq(accounts.consumerId, consumers.id))
-        .leftJoin(folders, eq(consumers.folderId, folders.id))
-        .where(eq(accounts.tenantId, tenantId));
-
-      res.status(200).json(tenantAccounts);
-    } else if (req.method === 'POST') {
-      // Create a new account
-      const { 
-        firstName, lastName, email, phone, 
-        accountNumber, creditor, balanceCents, folderId, 
-        dateOfBirth, address, city, state, zipCode,
-        additionalData, dueDate
-      } = req.body;
-
-      if (!firstName || !lastName || !email || !creditor || balanceCents === undefined || !dateOfBirth) {
-        res.status(400).json({ error: 'Missing required fields' });
+      if (!token) {
+        res.status(401).json({ error: 'No token provided' });
         return;
       }
 
-      // Check if consumer exists or create new one
-      // Match by email, firstName, lastName, and dateOfBirth to ensure it's the same person
-      let [consumer] = await db
-        .select()
-        .from(consumers)
-        .where(and(
-          eq(consumers.email, email),
-          eq(consumers.firstName, firstName),
-          eq(consumers.lastName, lastName),
-          eq(consumers.tenantId, tenantId)
-        ))
-        .limit(1);
+      const decoded = jwt.verify(token, JWT_SECRET) as any;
+      const tenantId = decoded.tenantId;
 
-      if (!consumer) {
-        // Get default folder if no folder specified
-        let targetFolderId = folderId;
-        if (!targetFolderId) {
-          const [defaultFolder] = await db
-            .select()
-            .from(folders)
-            .where(and(
-              eq(folders.tenantId, tenantId),
-              eq(folders.isDefault, true)
-            ))
-            .limit(1);
-          
-          if (defaultFolder) {
-            targetFolderId = defaultFolder.id;
+      if (!tenantId) {
+        res.status(403).json({ error: 'No tenant access' });
+        return;
+      }
+
+      if (req.method === 'GET') {
+        // Get all accounts for the tenant
+        const tenantAccounts = await db
+          .select({
+            id: accounts.id,
+            accountNumber: accounts.accountNumber,
+            creditor: accounts.creditor,
+            balanceCents: accounts.balanceCents,
+            dueDate: accounts.dueDate,
+            status: accounts.status,
+            additionalData: accounts.additionalData,
+            consumerId: accounts.consumerId,
+            tenantId: accounts.tenantId,
+            createdAt: accounts.createdAt,
+            consumer: {
+              id: consumers.id,
+              firstName: consumers.firstName,
+              lastName: consumers.lastName,
+              email: consumers.email,
+              phone: consumers.phone,
+              folderId: consumers.folderId,
+            },
+            folder: {
+              id: folders.id,
+              name: folders.name,
+              color: folders.color,
+              isDefault: folders.isDefault,
+            },
+          })
+          .from(accounts)
+          .leftJoin(consumers, eq(accounts.consumerId, consumers.id))
+          .leftJoin(folders, eq(consumers.folderId, folders.id))
+          .where(eq(accounts.tenantId, tenantId));
+
+        res.status(200).json(tenantAccounts);
+      } else if (req.method === 'POST') {
+        // Create a new account
+        const {
+          firstName, lastName, email, phone,
+          accountNumber, creditor, balanceCents, folderId,
+          dateOfBirth, address, city, state, zipCode,
+          additionalData, dueDate
+        } = req.body;
+
+        if (!firstName || !lastName || !email || !creditor || balanceCents === undefined || !dateOfBirth) {
+          res.status(400).json({ error: 'Missing required fields' });
+          return;
+        }
+
+        // Check if consumer exists or create new one
+        // Match by email, firstName, lastName, and dateOfBirth to ensure it's the same person
+        let [consumer] = await db
+          .select()
+          .from(consumers)
+          .where(and(
+            eq(consumers.email, email),
+            eq(consumers.firstName, firstName),
+            eq(consumers.lastName, lastName),
+            eq(consumers.tenantId, tenantId)
+          ))
+          .limit(1);
+
+        if (!consumer) {
+          // Get default folder if no folder specified
+          let targetFolderId = folderId;
+          if (!targetFolderId) {
+            const [defaultFolder] = await db
+              .select()
+              .from(folders)
+              .where(and(
+                eq(folders.tenantId, tenantId),
+                eq(folders.isDefault, true)
+              ))
+              .limit(1);
+
+            if (defaultFolder) {
+              targetFolderId = defaultFolder.id;
+            }
+          }
+
+          // Create new consumer
+          const [newConsumer] = await db
+            .insert(consumers)
+            .values({
+              tenantId,
+              folderId: targetFolderId,
+              firstName,
+              lastName,
+              email,
+              phone: phone || null,
+              dateOfBirth: dateOfBirth,
+              address: address || null,
+              city: city || null,
+              state: state || null,
+              zipCode: zipCode || null,
+              additionalData: additionalData || {},
+              isRegistered: false,
+            })
+            .returning();
+
+          consumer = newConsumer;
+        } else {
+          type ConsumerUpdate = Partial<typeof consumers.$inferInsert>;
+          const updateData: ConsumerUpdate = {};
+
+          const normalizeNullable = (value?: string | null) =>
+            value === undefined ? undefined : (value || null);
+
+          const assignIfProvided = <K extends keyof ConsumerUpdate>(
+            key: K,
+            value: ConsumerUpdate[K] | undefined
+          ) => {
+            if (value !== undefined) {
+              updateData[key] = value;
+            }
+          };
+
+          assignIfProvided('dateOfBirth', dateOfBirth);
+          assignIfProvided('address', normalizeNullable(address));
+          assignIfProvided('city', normalizeNullable(city));
+          assignIfProvided('state', normalizeNullable(state));
+          assignIfProvided('zipCode', normalizeNullable(zipCode));
+          assignIfProvided('phone', normalizeNullable(phone));
+
+          if (Object.keys(updateData).length > 0) {
+            const [updatedConsumer] = await db
+              .update(consumers)
+              .set(updateData)
+              .where(and(
+                eq(consumers.id, consumer.id),
+                eq(consumers.tenantId, tenantId)
+              ))
+              .returning();
+
+            if (updatedConsumer) {
+              consumer = updatedConsumer;
+            } else {
+              consumer = { ...consumer, ...updateData } as typeof consumer;
+            }
           }
         }
 
-        // Create new consumer
-        const [newConsumer] = await db
-          .insert(consumers)
+        // Create the account
+        const [newAccount] = await db
+          .insert(accounts)
           .values({
+            consumerId: consumer.id,
             tenantId,
-            folderId: targetFolderId,
-            firstName,
-            lastName,
-            email,
-            phone: phone || null,
-            dateOfBirth: dateOfBirth,
-            address: address || null,
-            city: city || null,
-            state: state || null,
-            zipCode: zipCode || null,
+            accountNumber: accountNumber || '',
+            creditor,
+            balanceCents,
+            dueDate: dueDate || null,
+            status: 'active',
             additionalData: additionalData || {},
-            isRegistered: false,
           })
           .returning();
 
-        consumer = newConsumer;
+        res.status(201).json(newAccount);
+      } else if (req.method === 'DELETE') {
+        // Delete an account - expects /api/accounts?id=<accountId>
+        const accountId = req.query.id as string;
+
+        if (!accountId) {
+          res.status(400).json({ error: 'Account ID is required' });
+          return;
+        }
+
+        // Check if account exists and belongs to tenant
+        const [account] = await db
+          .select()
+          .from(accounts)
+          .where(and(
+            eq(accounts.id, accountId),
+            eq(accounts.tenantId, tenantId)
+          ))
+          .limit(1);
+
+        if (!account) {
+          res.status(404).json({ error: 'Account not found' });
+          return;
+        }
+
+        // Delete the account
+        await db
+          .delete(accounts)
+          .where(eq(accounts.id, accountId));
+
+        res.status(200).json({ success: true, message: 'Account deleted successfully' });
       } else {
-        const updateData: Partial<typeof consumers.$inferInsert> = {};
-
-        if (dateOfBirth !== undefined) {
-          updateData.dateOfBirth = dateOfBirth;
-        }
-        if (address !== undefined) {
-          updateData.address = address;
-        }
-        if (city !== undefined) {
-          updateData.city = city;
-        }
-        if (state !== undefined) {
-          updateData.state = state;
-        }
-        if (zipCode !== undefined) {
-          updateData.zipCode = zipCode;
-        }
-        if (phone !== undefined) {
-          updateData.phone = phone;
-        }
-
-        if (Object.keys(updateData).length > 0) {
-          const [updatedConsumer] = await db
-            .update(consumers)
-            .set(updateData)
-            .where(and(
-              eq(consumers.id, consumer.id),
-              eq(consumers.tenantId, tenantId)
-            ))
-            .returning();
-
-          if (updatedConsumer) {
-            consumer = updatedConsumer;
-          }
-        }
+        res.status(405).json({ error: 'Method not allowed' });
       }
-
-      // Create the account
-      const [newAccount] = await db
-        .insert(accounts)
-        .values({
-          consumerId: consumer.id,
-          tenantId,
-          accountNumber: accountNumber || '',
-          creditor,
-          balanceCents,
-          dueDate: dueDate || null,
-          status: 'active',
-          additionalData: additionalData || {},
-        })
-        .returning();
-
-      res.status(201).json(newAccount);
-    } else if (req.method === 'DELETE') {
-      // Delete an account - expects /api/accounts?id=<accountId>
-      const accountId = req.query.id as string;
-
-      if (!accountId) {
-        res.status(400).json({ error: 'Account ID is required' });
-        return;
-      }
-
-      // Check if account exists and belongs to tenant
-      const [account] = await db
-        .select()
-        .from(accounts)
-        .where(and(
-          eq(accounts.id, accountId),
-          eq(accounts.tenantId, tenantId)
-        ))
-        .limit(1);
-
-      if (!account) {
-        res.status(404).json({ error: 'Account not found' });
-        return;
-      }
-
-      // Delete the account
-      await db
-        .delete(accounts)
-        .where(eq(accounts.id, accountId));
-
-      res.status(200).json({ success: true, message: 'Account deleted successfully' });
-    } else {
-      res.status(405).json({ error: 'Method not allowed' });
+    } catch (error: any) {
+      console.error('Accounts API error:', error);
+      res.status(500).json({
+        error: 'Failed to process account request',
+        message: error.message
+      });
     }
-  } catch (error: any) {
-    console.error('Accounts API error:', error);
-    res.status(500).json({ 
-      error: 'Failed to process account request',
-      message: error.message 
-    });
-  }
+  };
 }
 
-export function __setTestDb(db: ReturnType<typeof getDb> | null | undefined) {
-  testDbOverride = db ?? null;
-}
+const handler = createAccountsHandler();
 
-export { handler };
+export { handler, createAccountsHandler };
 export default withAuth(handler);

--- a/client/src/pages/accounts.tsx
+++ b/client/src/pages/accounts.tsx
@@ -38,7 +38,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Checkbox } from "@/components/ui/checkbox";
-import { FolderOpen, Folder, Plus, Upload, Settings, Trash2, MoreVertical, Eye, Edit, Mail, Phone, MapPin, Calendar } from "lucide-react";
+import { FolderOpen, Folder, Plus, Upload, Trash2, MoreVertical, Eye, Edit, Mail, Phone, MapPin, Calendar } from "lucide-react";
 
 export default function Accounts() {
   const [selectedFolderId, setSelectedFolderId] = useState<string>("all");
@@ -1039,53 +1039,97 @@ export default function Accounts() {
               <DialogTitle>Account Details</DialogTitle>
             </DialogHeader>
             {selectedAccount && (
-              <div className="space-y-4">
-                <div className="grid grid-cols-2 gap-4">
-                  <div>
-                    <p className="text-sm text-gray-500">Name</p>
-                    <p className="font-medium">
+              <div className="space-y-6">
+                <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                  <div className="rounded-lg border border-gray-200 p-4">
+                    <p className="text-xs font-semibold uppercase text-gray-500">Consumer</p>
+                    <p className="mt-1 text-lg font-semibold text-gray-900">
                       {selectedAccount.consumer?.firstName} {selectedAccount.consumer?.lastName}
                     </p>
+                    <div className="mt-3 space-y-2 text-sm text-gray-600">
+                      <div className="flex items-center gap-2">
+                        <Mail className="h-4 w-4 text-gray-400" />
+                        <span>{selectedAccount.consumer?.email || '—'}</span>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <Phone className="h-4 w-4 text-gray-400" />
+                        <span>{selectedAccount.consumer?.phone || '—'}</span>
+                      </div>
+                    </div>
                   </div>
-                  <div>
-                    <p className="text-sm text-gray-500">Email</p>
-                    <p className="font-medium">{selectedAccount.consumer?.email}</p>
+                  <div className="rounded-lg border border-gray-200 p-4">
+                    <p className="text-xs font-semibold uppercase text-gray-500">Account</p>
+                    <div className="mt-3 space-y-3 text-sm text-gray-600">
+                      <div>
+                        <p className="text-xs text-gray-500">Account Number</p>
+                        <p className="font-medium text-gray-900">{selectedAccount.accountNumber || '—'}</p>
+                      </div>
+                      <div>
+                        <p className="text-xs text-gray-500">Creditor</p>
+                        <p className="font-medium text-gray-900">{selectedAccount.creditor}</p>
+                      </div>
+                      <div>
+                        <p className="text-xs text-gray-500">Balance</p>
+                        <p className="font-medium text-gray-900">{formatCurrency(selectedAccount.balanceCents || 0)}</p>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <span className="text-xs text-gray-500">Status</span>
+                        <span className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${getStatusColor(selectedAccount.status)}`}>
+                          {selectedAccount.status || 'Pending'}
+                        </span>
+                      </div>
+                    </div>
                   </div>
                 </div>
-                
-                <div className="grid grid-cols-2 gap-4">
-                  <div>
-                    <p className="text-sm text-gray-500">Phone</p>
-                    <p className="font-medium">{selectedAccount.consumer?.phone || '-'}</p>
+
+                <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                  <div className="rounded-lg border border-gray-200 p-4">
+                    <p className="text-xs font-semibold uppercase text-gray-500">Address</p>
+                    <div className="mt-3 space-y-2 text-sm text-gray-600">
+                      <div className="flex items-start gap-2">
+                        <MapPin className="mt-0.5 h-4 w-4 text-gray-400" />
+                        <div>
+                          <p className="font-medium text-gray-900">{selectedAccount.consumer?.address || '—'}</p>
+                          {(selectedAccount.consumer?.city || selectedAccount.consumer?.state || selectedAccount.consumer?.zipCode) ? (
+                            <p>
+                              {[selectedAccount.consumer?.city, selectedAccount.consumer?.state].filter(Boolean).join(', ')}
+                              {selectedAccount.consumer?.zipCode ? ` ${selectedAccount.consumer?.zipCode}` : ''}
+                            </p>
+                          ) : null}
+                        </div>
+                      </div>
+                    </div>
                   </div>
-                  <div>
-                    <p className="text-sm text-gray-500">Account Number</p>
-                    <p className="font-medium">{selectedAccount.accountNumber || '-'}</p>
+                  <div className="rounded-lg border border-gray-200 p-4">
+                    <p className="text-xs font-semibold uppercase text-gray-500">Key Dates</p>
+                    <div className="mt-3 space-y-3 text-sm text-gray-600">
+                      <div className="flex items-center gap-2">
+                        <Calendar className="h-4 w-4 text-gray-400" />
+                        <span>
+                          {selectedAccount.consumer?.dateOfBirth
+                            ? formatDate(selectedAccount.consumer.dateOfBirth)
+                            : 'Date of birth not available'}
+                        </span>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <Calendar className="h-4 w-4 text-gray-400" />
+                        <span>
+                          {selectedAccount.dueDate ? `Due ${formatDate(selectedAccount.dueDate)}` : 'No due date set'}
+                        </span>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <Calendar className="h-4 w-4 text-gray-400" />
+                        <span>Created {formatDate(selectedAccount.createdAt)}</span>
+                      </div>
+                    </div>
                   </div>
                 </div>
-                
-                <div className="grid grid-cols-2 gap-4">
-                  <div>
-                    <p className="text-sm text-gray-500">Creditor</p>
-                    <p className="font-medium">{selectedAccount.creditor}</p>
-                  </div>
-                  <div>
-                    <p className="text-sm text-gray-500">Balance</p>
-                    <p className="font-medium">{formatCurrency(selectedAccount.balanceCents || 0)}</p>
-                  </div>
-                </div>
-                
-                <div className="grid grid-cols-2 gap-4">
-                  <div>
-                    <p className="text-sm text-gray-500">Status</p>
-                    <span className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${getStatusColor(selectedAccount.status)}`}>
-                      {selectedAccount.status || 'Pending'}
-                    </span>
-                  </div>
-                  <div>
-                    <p className="text-sm text-gray-500">Created</p>
-                    <p className="font-medium">{formatDate(selectedAccount.createdAt)}</p>
-                  </div>
+
+                <div className="rounded-lg border border-gray-200 p-4">
+                  <p className="text-xs font-semibold uppercase text-gray-500">Folder</p>
+                  <p className="mt-2 text-sm font-medium text-gray-900">
+                    {selectedAccount.folder?.name || 'No folder assigned'}
+                  </p>
                 </div>
               </div>
             )}


### PR DESCRIPTION
## Summary
- update the existing-consumer flow in the accounts API to patch provided DOB, address, ZIP, and phone details before creating a new account
- add a test database override helper and a unit test that exercises account creation for an existing consumer to ensure data persistence

## Testing
- npm test
- node --test --import tsx api/__tests__/accounts-existing-consumer.test.ts
- npm run check *(fails: pre-existing TypeScript errors in unrelated client/server files)*

------
https://chatgpt.com/codex/tasks/task_e_68d33ec03c54832aa722d84161be69d7