### PR TITLE
Normalize consumer email comparisons for account workflows

### DIFF
--- a/api/accounts.ts
+++ b/api/accounts.ts
@@ -2,7 +2,7 @@ import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { getDb } from './_lib/db.js';
 import { withAuth, AuthenticatedRequest, JWT_SECRET } from './_lib/auth.js';
 import { accounts, consumers, folders } from './_lib/schema.js';
-import { eq, and } from 'drizzle-orm';
+import { eq, and, sql } from 'drizzle-orm';
 import jwt from 'jsonwebtoken';
 
 function resolveAccountId(req: AuthenticatedRequest) {
@@ -100,11 +100,13 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
 
       // Check if consumer exists or create new one
       // Match by email, firstName, lastName, and dateOfBirth to ensure it's the same person
+      const normalizedEmail = email.toLowerCase();
+
       let [consumer] = await db
         .select()
         .from(consumers)
         .where(and(
-          eq(consumers.email, email),
+          sql`lower(${consumers.email}) = ${normalizedEmail}`,
           eq(consumers.firstName, firstName),
           eq(consumers.lastName, lastName),
           eq(consumers.tenantId, tenantId)

--- a/api/import/csv.ts
+++ b/api/import/csv.ts
@@ -70,13 +70,14 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
         console.error(`Skipping consumer: missing required fields`, csvConsumer);
         continue;
       }
+      const normalizedEmail = csvConsumer.email.toLowerCase();
       // Check if consumer already exists
       // Match by email, firstName, lastName to ensure it's the same person
       let [existingConsumer] = await db
         .select()
         .from(consumers)
         .where(and(
-          eq(consumers.email, csvConsumer.email),
+          sql`lower(${consumers.email}) = ${normalizedEmail}`,
           eq(consumers.firstName, csvConsumer.firstName),
           eq(consumers.lastName, csvConsumer.lastName),
           eq(consumers.tenantId, tenantId)
@@ -110,7 +111,7 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
 
       // Find accounts for this consumer
       const consumerAccounts = csvAccounts.filter(
-        (acc: any) => acc.consumerEmail === csvConsumer.email
+        (acc: any) => typeof acc.consumerEmail === 'string' && acc.consumerEmail.toLowerCase() === normalizedEmail
       );
 
       // Process each account


### PR DESCRIPTION
## Summary
- make consumer email lookups case-insensitive when creating accounts through the API
- normalize email comparisons while importing accounts from CSV and when matching account rows to consumers

## Testing
- npm run check *(fails: pre-existing TypeScript errors in unrelated client/server files)*

------
https://chatgpt.com/codex/tasks/task_e_68d35f47e640832ab90785f121b28fa7