### PR TITLE
Implement messaging plan selection and usage tracking

### DIFF
--- a/migrations/20250304120000_messaging_usage_events.sql
+++ b/migrations/20250304120000_messaging_usage_events.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS "messaging_usage_events" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    "tenant_id" uuid NOT NULL REFERENCES tenants("id") ON DELETE CASCADE,
+    "provider" text NOT NULL,
+    "message_type" text NOT NULL,
+    "quantity" integer NOT NULL DEFAULT 1,
+    "external_message_id" text NOT NULL,
+    "occurred_at" timestamp DEFAULT now(),
+    "metadata" jsonb DEFAULT '{}'::jsonb,
+    "created_at" timestamp DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "messaging_usage_events_external_idx"
+    ON "messaging_usage_events" ("external_message_id");
+
+CREATE INDEX IF NOT EXISTS "messaging_usage_events_tenant_period_idx"
+    ON "messaging_usage_events" ("tenant_id", "occurred_at");

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -12,6 +12,7 @@ import {
   smsTemplates,
   smsCampaigns,
   smsTracking,
+  messagingUsageEvents,
   communicationAutomations,
   automationExecutions,
   emailSequences,
@@ -51,6 +52,7 @@ import {
   type InsertSmsCampaign,
   type SmsTracking,
   type InsertSmsTracking,
+  type InsertMessagingUsageEvent,
   type CommunicationAutomation,
   type InsertCommunicationAutomation,
   type AutomationExecution,
@@ -78,8 +80,9 @@ import {
   type Invoice,
   type InsertInvoice,
 } from "@shared/schema";
+import { messagingPlans, EMAIL_OVERAGE_RATE_PER_EMAIL, SMS_OVERAGE_RATE_PER_SEGMENT, type MessagingPlanId } from "@shared/billing-plans";
 import { db } from "./db";
-import { eq, and, desc, sql, inArray } from "drizzle-orm";
+import { eq, and, desc, sql, inArray, gte, lte } from "drizzle-orm";
 
 export interface IStorage {
   // User operations (mandatory for Replit Auth)
@@ -293,7 +296,32 @@ export interface IStorage {
     usageCharges: number;
     totalBill: number;
     nextBillDate: string;
+    planId: MessagingPlanId | null;
+    planName: string | null;
+    emailUsage: {
+      used: number;
+      included: number;
+      overage: number;
+      overageCharge: number;
+    };
+    smsUsage: {
+      used: number;
+      included: number;
+      overage: number;
+      overageCharge: number;
+    };
+    billingPeriod: { start: string; end: string } | null;
   }>;
+  recordMessagingUsageEvent(event: InsertMessagingUsageEvent): Promise<void>;
+  getMessagingUsageTotals(
+    tenantId: string,
+    periodStart: Date,
+    periodEnd: Date
+  ): Promise<{ emailCount: number; smsSegments: number }>;
+  findSmsTrackingByExternalId(
+    externalId: string
+  ): Promise<{ tracking: SmsTracking; tenantId: string | null; campaignId: string | null } | undefined>;
+  updateSmsTracking(id: string, updates: Partial<SmsTracking>): Promise<SmsTracking | undefined>;
   
   // Company management operations
   getPlatformUsersByTenant(tenantId: string): Promise<(PlatformUser & { userDetails?: User })[]>;
@@ -986,6 +1014,86 @@ export class DatabaseStorage implements IStorage {
     return newTracking;
   }
 
+  async recordMessagingUsageEvent(event: InsertMessagingUsageEvent): Promise<void> {
+    await db
+      .insert(messagingUsageEvents)
+      .values(event)
+      .onConflictDoNothing({ target: messagingUsageEvents.externalMessageId });
+  }
+
+  async getMessagingUsageTotals(
+    tenantId: string,
+    periodStart: Date,
+    periodEnd: Date
+  ): Promise<{ emailCount: number; smsSegments: number }> {
+    const results = await db
+      .select({
+        messageType: messagingUsageEvents.messageType,
+        total: sql<number>`COALESCE(SUM(${messagingUsageEvents.quantity}), 0)`,
+      })
+      .from(messagingUsageEvents)
+      .where(
+        and(
+          eq(messagingUsageEvents.tenantId, tenantId),
+          gte(messagingUsageEvents.occurredAt, periodStart),
+          lte(messagingUsageEvents.occurredAt, periodEnd)
+        )
+      )
+      .groupBy(messagingUsageEvents.messageType);
+
+    let emailCount = 0;
+    let smsSegments = 0;
+
+    for (const row of results) {
+      if (row.messageType === 'email') {
+        emailCount = row.total;
+      }
+      if (row.messageType === 'sms') {
+        smsSegments = row.total;
+      }
+    }
+
+    return { emailCount, smsSegments };
+  }
+
+  async findSmsTrackingByExternalId(
+    externalId: string
+  ): Promise<{ tracking: SmsTracking; tenantId: string | null; campaignId: string | null } | undefined> {
+    const [result] = await db
+      .select({
+        tracking: smsTracking,
+        campaign: smsCampaigns,
+      })
+      .from(smsTracking)
+      .leftJoin(smsCampaigns, eq(smsTracking.campaignId, smsCampaigns.id))
+      .where(sql`(${smsTracking.trackingData} ->> 'twilioSid') = ${externalId}`)
+      .limit(1);
+
+    if (!result?.tracking) {
+      return undefined;
+    }
+
+    return {
+      tracking: result.tracking,
+      tenantId: result.campaign?.tenantId ?? null,
+      campaignId: result.tracking.campaignId ?? null,
+    };
+  }
+
+  async updateSmsTracking(id: string, updates: Partial<SmsTracking>): Promise<SmsTracking | undefined> {
+    const sanitizedUpdates = Object.fromEntries(
+      Object.entries(updates).filter(([, value]) => value !== undefined)
+    ) as Partial<SmsTracking>;
+
+    if (Object.keys(sanitizedUpdates).length === 0) {
+      const [existing] = await db.select().from(smsTracking).where(eq(smsTracking.id, id));
+      return existing;
+    }
+
+    const [updated] = await db.update(smsTracking).set(sanitizedUpdates).where(eq(smsTracking.id, id)).returning();
+    return updated;
+  }
+
   // Automation operations
   async getAutomationsByTenant(tenantId: string): Promise<CommunicationAutomation[]> {
     return await db.select()
@@ -1497,21 +1605,72 @@ export class DatabaseStorage implements IStorage {
     usageCharges: number;
     totalBill: number;
     nextBillDate: string;
+    planId: MessagingPlanId | null;
+    planName: string | null;
+    emailUsage: {
+      used: number;
+      included: number;
+      overage: number;
+      overageCharge: number;
+    };
+    smsUsage: {
+      used: number;
+      included: number;
+      overage: number;
+      overageCharge: number;
+    };
+    billingPeriod: { start: string; end: string } | null;
   }> {
-    // Get active consumers count
     const activeConsumersResult = await db.select().from(consumers).where(eq(consumers.tenantId, tenantId));
     const activeConsumers = activeConsumersResult.length;
 
-    // Get subscription details
     const subscription = await this.getSubscriptionByTenant(tenantId);
-    const monthlyBase = subscription ? subscription.monthlyBaseCents / 100 : 0;
-    const usageCharges = subscription ? (activeConsumers * subscription.pricePerConsumerCents) / 100 : 0;
-    const totalBill = monthlyBase + usageCharges;
+    const planId = subscription?.plan as MessagingPlanId | undefined;
+    const plan = planId ? messagingPlans[planId] : undefined;
 
-    // Calculate next bill date (end of current billing period)
-    const nextBillDate = subscription 
-      ? new Date(subscription.currentPeriodEnd).toLocaleDateString()
-      : new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toLocaleDateString(); // Default to 30 days from now
+    const monthlyBase = plan?.price ?? (subscription ? subscription.monthlyBaseCents / 100 : 0);
+
+    let emailUsage = { used: 0, included: plan?.includedEmails ?? 0, overage: 0, overageCharge: 0 };
+    let smsUsage = { used: 0, included: plan?.includedSmsSegments ?? 0, overage: 0, overageCharge: 0 };
+    let usageCharges = 0;
+    let totalBill = monthlyBase;
+    let nextBillDate = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toLocaleDateString();
+    let billingPeriod: { start: string; end: string } | null = null;
+
+    if (subscription) {
+      const periodStart = new Date(subscription.currentPeriodStart);
+      const periodEnd = new Date(subscription.currentPeriodEnd);
+      billingPeriod = { start: periodStart.toISOString(), end: periodEnd.toISOString() };
+      nextBillDate = periodEnd.toLocaleDateString();
+
+      const usageTotals = await this.getMessagingUsageTotals(tenantId, periodStart, periodEnd);
+
+      const includedEmails = plan?.includedEmails ?? 0;
+      const includedSms = plan?.includedSmsSegments ?? 0;
+
+      const emailOverage = Math.max(0, usageTotals.emailCount - includedEmails);
+      const smsOverage = Math.max(0, usageTotals.smsSegments - includedSms);
+
+      const emailOverageCharge = Number((emailOverage * EMAIL_OVERAGE_RATE_PER_EMAIL).toFixed(2));
+      const smsOverageCharge = Number((smsOverage * SMS_OVERAGE_RATE_PER_SEGMENT).toFixed(2));
+
+      emailUsage = {
+        used: usageTotals.emailCount,
+        included: includedEmails,
+        overage: emailOverage,
+        overageCharge: emailOverageCharge,
+      };
+
+      smsUsage = {
+        used: usageTotals.smsSegments,
+        included: includedSms,
+        overage: smsOverage,
+        overageCharge: smsOverageCharge,
+      };
+
+      usageCharges = Number((emailOverageCharge + smsOverageCharge).toFixed(2));
+      totalBill = Number((monthlyBase + usageCharges).toFixed(2));
+    }
 
     return {
       activeConsumers,
@@ -1519,6 +1678,11 @@ export class DatabaseStorage implements IStorage {
       usageCharges,
       totalBill,
       nextBillDate,
+      planId: plan?.id ?? planId ?? null,
+      planName: plan?.name ?? planId ?? null,
+      emailUsage,
+      smsUsage,
+      billingPeriod,
     };
   }
 

--- a/shared/billing-plans.ts
+++ b/shared/billing-plans.ts
@@ -1,0 +1,46 @@
+export type MessagingPlanId = "launch" | "growth" | "pro" | "scale";
+
+export interface MessagingPlan {
+  id: MessagingPlanId;
+  name: string;
+  price: number;
+  includedEmails: number;
+  includedSmsSegments: number;
+}
+
+export const EMAIL_OVERAGE_RATE_PER_THOUSAND = 2.5;
+export const EMAIL_OVERAGE_RATE_PER_EMAIL = EMAIL_OVERAGE_RATE_PER_THOUSAND / 1000;
+export const SMS_OVERAGE_RATE_PER_SEGMENT = 0.03;
+
+export const messagingPlans: Record<MessagingPlanId, MessagingPlan> = {
+  launch: {
+    id: "launch",
+    name: "Launch",
+    price: 300,
+    includedEmails: 5_000,
+    includedSmsSegments: 500,
+  },
+  growth: {
+    id: "growth",
+    name: "Growth",
+    price: 500,
+    includedEmails: 25_000,
+    includedSmsSegments: 2_500,
+  },
+  pro: {
+    id: "pro",
+    name: "Pro",
+    price: 1_000,
+    includedEmails: 100_000,
+    includedSmsSegments: 10_000,
+  },
+  scale: {
+    id: "scale",
+    name: "Scale",
+    price: 2_000,
+    includedEmails: 250_000,
+    includedSmsSegments: 25_000,
+  },
+};
+
+export const messagingPlanList: MessagingPlan[] = Object.values(messagingPlans);


### PR DESCRIPTION
## Summary
- define shared messaging plan metadata and add a messaging usage events table with migration
- enhance storage and API routes to support plan selection, usage-aware billing stats, and webhook-driven usage logging from Twilio/Postmark
- refresh the billing UI with plan selection cards and real-time email/SMS usage breakdowns

## Testing
- npm run check *(fails: existing TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d35bc27734832ab17d99656869984a