### PR TITLE
Fix tenant slug detection on consumer login

### DIFF
--- a/client/src/pages/consumer-login.tsx
+++ b/client/src/pages/consumer-login.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Building2, Mail, Lock, ArrowRight, ShieldCheck, UserCheck } from "lucide-react";
+import { getAgencySlugFromRequest } from "@shared/utils/subdomain";
 import PublicHeroLayout from "@/components/public-hero-layout";
 
 interface LoginForm {
@@ -39,15 +40,17 @@ export default function ConsumerLogin() {
   const loginMutation = useMutation({
     mutationFn: async (loginData: LoginForm) => {
       // Get tenant slug from URL path (e.g., /waypoint-solutions/consumer)
-      const pathname = window.location.pathname;
-      const pathSegments = pathname.split('/').filter(Boolean);
-      const tenantSlug = pathSegments[0]; // First segment is the tenant slug
-      
+      const slugFromUrl = getAgencySlugFromRequest(
+        window.location.hostname,
+        window.location.pathname
+      );
+      const tenantSlug = slugFromUrl || agencyContext?.slug;
+
       // Send email and dateOfBirth for consumer verification
       const response = await apiRequest("POST", "/api/consumer/login", {
         email: loginData.email,
         dateOfBirth: loginData.dateOfBirth,
-        tenantSlug: tenantSlug || agencyContext?.slug
+        tenantSlug
       });
       return response.json();
     },


### PR DESCRIPTION
## Summary
- reuse the shared subdomain helper when deriving the tenant slug on the consumer login page
- avoid passing route names like `/consumer-login` as tenant slugs so existing accounts authenticate instead of hitting a 404

## Testing
- npm run check *(fails: existing TypeScript errors in communications.tsx, consumer-portal.tsx, enhanced-consumer-portal.tsx, payments.tsx, requests.tsx, server/emailService.ts, server/replitAuth.ts, server/storage.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d361617bd0832aa0f2ab6ce1bd98eb