### PR TITLE
Handle case-insensitive consumer email when authorizing account fetch

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -257,9 +257,12 @@ export async function registerRoutes(app: Express): Promise<Server> {
       // Get consumer info from JWT token (already verified by authenticateConsumer)
       const { email: tokenEmail, tenantId, tenantSlug } = req.consumer;
       const requestedEmail = req.params.email;
-      
-      // Ensure consumer can only access their own data
-      if (tokenEmail !== requestedEmail) {
+
+      const normalizedTokenEmail = (tokenEmail || '').trim().toLowerCase();
+      const normalizedRequestedEmail = (requestedEmail || '').trim().toLowerCase();
+
+      // Ensure consumer can only access their own data (case-insensitive)
+      if (!normalizedTokenEmail || normalizedTokenEmail !== normalizedRequestedEmail) {
         return res.status(403).json({ message: "Access denied" });
       }
 
@@ -635,9 +638,11 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.get('/api/consumer/accounts/:email', authenticateConsumer, async (req: any, res) => {
     try {
       const { email } = req.params;
-      
+      const normalizedEmail = (email || '').trim().toLowerCase();
+      const normalizedConsumerEmail = (req.consumer.email || '').trim().toLowerCase();
+
       // Verify the email in the URL matches the authenticated consumer's email
-      if (email !== req.consumer.email) {
+      if (!normalizedEmail || normalizedEmail !== normalizedConsumerEmail) {
         return res.status(403).json({ message: "Access denied to this account" });
       }
       


### PR DESCRIPTION
## Summary
- normalize consumer emails before checking authorization in both consumer account routes
- ensure requests from portals are compared against stored emails without case sensitivity

## Testing
- npx tsc --noEmit --incremental false *(fails: existing type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d40ad1d774832aa2bf2eab38e5735a