### PR TITLE
Enable dashboard account view and contact actions

### DIFF
--- a/client/src/pages/admin-dashboard.tsx
+++ b/client/src/pages/admin-dashboard.tsx
@@ -1,13 +1,93 @@
 import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
 import AdminLayout from "@/components/admin-layout";
 import StatsCard from "@/components/stats-card";
 import AccountsTable from "@/components/accounts-table";
 import ImportModal from "@/components/import-modal";
 import { Button } from "@/components/ui/button";
-import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Calendar, Mail, MapPin, Phone } from "lucide-react";
 
 export default function AdminDashboard() {
   const [showImportModal, setShowImportModal] = useState(false);
+  const [showViewModal, setShowViewModal] = useState(false);
+  const [showContactDialog, setShowContactDialog] = useState(false);
+  const [selectedAccount, setSelectedAccount] = useState<any | null>(null);
+
+  const handleView = (account: any) => {
+    setSelectedAccount(account);
+    setShowViewModal(true);
+  };
+
+  const handleContact = (account: any) => {
+    setSelectedAccount(account);
+    setShowContactDialog(true);
+  };
+
+  const handleViewModalChange = (open: boolean) => {
+    setShowViewModal(open);
+    if (!open && !showContactDialog) {
+      setSelectedAccount(null);
+    }
+  };
+
+  const handleContactModalChange = (open: boolean) => {
+    setShowContactDialog(open);
+    if (!open && !showViewModal) {
+      setSelectedAccount(null);
+    }
+  };
+
+  const formatCurrency = (cents?: number | null) => {
+    if (typeof cents !== "number") {
+      return "$0.00";
+    }
+    return `$${(cents / 100).toLocaleString("en-US", { minimumFractionDigits: 2 })}`;
+  };
+
+  const formatDate = (dateString?: string | null) => {
+    if (!dateString) {
+      return "Unknown";
+    }
+    const date = new Date(dateString);
+    if (Number.isNaN(date.getTime())) {
+      return "Unknown";
+    }
+    return date.toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  };
+
+  const getStatusColor = (status?: string | null) => {
+    switch (status?.toLowerCase()) {
+      case "active":
+        return "border border-emerald-400/30 bg-emerald-500/10 text-emerald-200";
+      case "overdue":
+        return "border border-rose-400/30 bg-rose-500/10 text-rose-200";
+      case "settled":
+        return "border border-slate-400/30 bg-slate-500/10 text-slate-200";
+      default:
+        return "border border-amber-400/30 bg-amber-500/10 text-amber-200";
+    }
+  };
+
+  const selectedAccountLocation = selectedAccount
+    ? [
+        selectedAccount.consumer?.city,
+        selectedAccount.consumer?.state,
+        selectedAccount.consumer?.zipCode,
+      ]
+        .filter(Boolean)
+        .join(", ")
+    : "";
 
   const { data: stats, isLoading: statsLoading } = useQuery({
     queryKey: ["/api/stats"],
@@ -109,7 +189,12 @@ export default function AdminDashboard() {
         </section>
 
         <section>
-          <AccountsTable accounts={(accounts as any) || []} isLoading={accountsLoading} />
+          <AccountsTable
+            accounts={(accounts as any) || []}
+            isLoading={accountsLoading}
+            onView={handleView}
+            onContact={handleContact}
+          />
         </section>
       </div>
 
@@ -117,6 +202,216 @@ export default function AdminDashboard() {
         isOpen={showImportModal}
         onClose={() => setShowImportModal(false)}
       />
+
+      <Dialog open={showViewModal} onOpenChange={handleViewModalChange}>
+        <DialogContent className="max-w-3xl border border-white/10 bg-[#0f1a3c] text-blue-100">
+          {selectedAccount && (
+            <>
+              <DialogHeader className="space-y-2 text-left">
+                <DialogTitle className="text-2xl font-semibold text-white">Account overview</DialogTitle>
+                <DialogDescription className="text-sm text-blue-100/70">
+                  Snapshot for {selectedAccount.consumer?.firstName} {selectedAccount.consumer?.lastName}
+                </DialogDescription>
+              </DialogHeader>
+
+              <div className="space-y-6">
+                <div className="flex flex-col gap-4 rounded-2xl border border-white/10 bg-white/5 p-5 sm:flex-row sm:items-start sm:justify-between">
+                  <div>
+                    <p className="text-xs uppercase tracking-wide text-blue-100/60">Consumer</p>
+                    <p className="mt-2 text-2xl font-semibold text-white">
+                      {selectedAccount.consumer?.firstName} {selectedAccount.consumer?.lastName}
+                    </p>
+                    <p className="text-sm text-blue-100/70">
+                      {selectedAccount.consumer?.email || "No email on file"}
+                    </p>
+                    {selectedAccount.consumer?.phone && (
+                      <p className="text-sm text-blue-100/60">{selectedAccount.consumer.phone}</p>
+                    )}
+                  </div>
+                  <div className="rounded-2xl border border-white/10 bg-[#0c1630] px-5 py-4 text-right text-sm text-blue-100/80">
+                    <p className="text-xs uppercase tracking-wide text-blue-100/60">Account #</p>
+                    <p className="mt-2 text-lg font-semibold text-white">
+                      {selectedAccount.accountNumber || "N/A"}
+                    </p>
+                    <p className="text-xs text-blue-100/60">
+                      Created {selectedAccount.createdAt ? formatDate(selectedAccount.createdAt) : "Unknown"}
+                    </p>
+                  </div>
+                </div>
+
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
+                    <p className="text-xs uppercase tracking-wide text-blue-100/60">Creditor</p>
+                    <p className="mt-2 text-base font-semibold text-white">
+                      {selectedAccount.creditor || "Unknown creditor"}
+                    </p>
+                  </div>
+                  <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
+                    <p className="text-xs uppercase tracking-wide text-blue-100/60">Balance</p>
+                    <p className="mt-2 text-base font-semibold text-white">
+                      {formatCurrency(
+                        typeof selectedAccount.balanceCents === "number"
+                          ? selectedAccount.balanceCents
+                          : Number(selectedAccount.balanceCents ?? 0)
+                      )}
+                    </p>
+                  </div>
+                  <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
+                    <p className="text-xs uppercase tracking-wide text-blue-100/60">Status</p>
+                    <span
+                      className={`mt-2 inline-flex w-fit items-center rounded-full px-3 py-1 text-xs font-semibold ${getStatusColor(
+                        selectedAccount.status
+                      )}`}
+                    >
+                      {selectedAccount.status || "Unknown"}
+                    </span>
+                  </div>
+                  <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
+                    <p className="text-xs uppercase tracking-wide text-blue-100/60">Due date</p>
+                    <p className="mt-2 text-base font-semibold text-white">
+                      {selectedAccount.dueDate ? formatDate(selectedAccount.dueDate) : "Not scheduled"}
+                    </p>
+                  </div>
+                  <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
+                    <p className="text-xs uppercase tracking-wide text-blue-100/60">Folder</p>
+                    <p className="mt-2 text-base font-semibold text-white">
+                      {selectedAccount.folder?.name || "Not assigned"}
+                    </p>
+                  </div>
+                </div>
+
+                <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
+                  <p className="text-xs uppercase tracking-wide text-blue-100/60">Address</p>
+                  <p className="mt-2 text-base font-semibold text-white">
+                    {selectedAccount.consumer?.address || "Not provided"}
+                  </p>
+                  {selectedAccountLocation && (
+                    <p className="mt-1 text-sm text-blue-100/70">{selectedAccountLocation}</p>
+                  )}
+                </div>
+              </div>
+            </>
+          )}
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={showContactDialog} onOpenChange={handleContactModalChange}>
+        <DialogContent className="max-w-xl border border-white/10 bg-[#0f1a3c] text-blue-100">
+          {selectedAccount && (
+            <>
+              <DialogHeader className="space-y-2 text-left">
+                <DialogTitle className="text-xl font-semibold text-white">
+                  Contact {selectedAccount.consumer?.firstName} {selectedAccount.consumer?.lastName}
+                </DialogTitle>
+                <DialogDescription className="text-sm text-blue-100/70">
+                  Reach out using the consumer's preferred channel.
+                </DialogDescription>
+              </DialogHeader>
+
+              <div className="space-y-4">
+                <div className="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 p-4">
+                  <span className="rounded-xl bg-sky-500/20 p-2 text-sky-300">
+                    <Mail className="h-5 w-5" />
+                  </span>
+                  <div className="flex-1">
+                    <p className="text-xs uppercase tracking-wide text-blue-100/60">Email</p>
+                    <p className="text-sm font-semibold text-white">
+                      {selectedAccount.consumer?.email || "Not provided"}
+                    </p>
+                  </div>
+                  {selectedAccount.consumer?.email ? (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      asChild
+                      className="border-white/20 bg-transparent text-blue-100 hover:bg-white/10"
+                    >
+                      <a href={`mailto:${selectedAccount.consumer.email}`}>Email</a>
+                    </Button>
+                  ) : (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled
+                      className="border-white/10 bg-transparent text-blue-100/50"
+                    >
+                      Email
+                    </Button>
+                  )}
+                </div>
+
+                <div className="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 p-4">
+                  <span className="rounded-xl bg-emerald-500/20 p-2 text-emerald-300">
+                    <Phone className="h-5 w-5" />
+                  </span>
+                  <div className="flex-1">
+                    <p className="text-xs uppercase tracking-wide text-blue-100/60">Phone</p>
+                    <p className="text-sm font-semibold text-white">
+                      {selectedAccount.consumer?.phone || "Not provided"}
+                    </p>
+                  </div>
+                  {selectedAccount.consumer?.phone ? (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      asChild
+                      className="border-white/20 bg-transparent text-blue-100 hover:bg-white/10"
+                    >
+                      <a href={`tel:${selectedAccount.consumer.phone}`}>Call</a>
+                    </Button>
+                  ) : (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled
+                      className="border-white/10 bg-transparent text-blue-100/50"
+                    >
+                      Call
+                    </Button>
+                  )}
+                </div>
+
+                <div className="flex items-start gap-3 rounded-2xl border border-white/10 bg-white/5 p-4">
+                  <span className="rounded-xl bg-indigo-500/20 p-2 text-indigo-300">
+                    <MapPin className="h-5 w-5" />
+                  </span>
+                  <div>
+                    <p className="text-xs uppercase tracking-wide text-blue-100/60">Address</p>
+                    <p className="text-sm font-semibold text-white">
+                      {selectedAccount.consumer?.address || "Not provided"}
+                    </p>
+                    {selectedAccountLocation && (
+                      <p className="text-xs text-blue-100/70">{selectedAccountLocation}</p>
+                    )}
+                  </div>
+                </div>
+
+                <div className="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 p-4">
+                  <span className="rounded-xl bg-amber-500/20 p-2 text-amber-300">
+                    <Calendar className="h-5 w-5" />
+                  </span>
+                  <div className="flex-1">
+                    <p className="text-xs uppercase tracking-wide text-blue-100/60">Next due date</p>
+                    <p className="text-sm font-semibold text-white">
+                      {selectedAccount.dueDate ? formatDate(selectedAccount.dueDate) : "Not scheduled"}
+                    </p>
+                  </div>
+                </div>
+
+                <div className="flex justify-end">
+                  <Button
+                    variant="ghost"
+                    className="rounded-lg border border-white/10 bg-white/5 px-4 text-blue-100 hover:bg-white/10"
+                    onClick={() => setShowContactDialog(false)}
+                  >
+                    Close
+                  </Button>
+                </div>
+              </div>
+            </>
+          )}
+        </DialogContent>
+      </Dialog>
     </AdminLayout>
   );
 }


### PR DESCRIPTION
## Summary
- add state and handlers to the admin dashboard so account view and contact actions work again
- introduce account overview and contact dialogs that mirror the dashboard styling while exposing key account details

## Testing
- npm run check *(fails: existing type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d3edd1cde8832a802e7ab64dced019