### PR TITLE
Add automation execution table to API schema

### DIFF
--- a/api/_lib/schema.ts
+++ b/api/_lib/schema.ts
@@ -423,3 +423,16 @@ export const communicationAutomations = pgTable("communication_automations", {
   updatedAt: timestamp("updated_at").defaultNow(),
 });
 
+export const automationExecutions = pgTable("automation_executions", {
+  id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+  automationId: uuid("automation_id")
+    .references(() => communicationAutomations.id, { onDelete: "cascade" })
+    .notNull(),
+  executedAt: timestamp("executed_at").defaultNow(),
+  status: text("status").notNull(),
+  totalSent: bigint("total_sent", { mode: "number" }).default(0),
+  totalFailed: bigint("total_failed", { mode: "number" }).default(0),
+  errorMessage: text("error_message"),
+  executionDetails: jsonb("execution_details"),
+});
+


### PR DESCRIPTION
## Summary
- export the automation executions table in the API schema module
- align the Vercel API schema with shared definitions so the automations API can import it

## Testing
- npm run check *(fails: existing TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d4077a47d8832a874d8b48367f6448