### PR TITLE
Fix target id filters type guard

### DIFF
--- a/api/automations.ts
+++ b/api/automations.ts
@@ -473,10 +473,10 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
       const normalizedDescription = typeof body.description === 'string' ? body.description : undefined;
 
       const normalizedTargetFolderIds = Array.isArray(targetFolderIds)
-        ? targetFolderIds.filter((id: unknown): id is string => typeof id === 'string' && id)
+        ? targetFolderIds.filter((id: unknown): id is string => typeof id === 'string' && id.length > 0)
         : [];
       const normalizedTargetCustomerIds = Array.isArray(targetCustomerIds)
-        ? targetCustomerIds.filter((id: unknown): id is string => typeof id === 'string' && id)
+        ? targetCustomerIds.filter((id: unknown): id is string => typeof id === 'string' && id.length > 0)
         : [];
       const normalizedCustomFilters = customFilters && typeof customFilters === 'object'
         ? customFilters


### PR DESCRIPTION
## Summary
- ensure automation target folder and customer ID filters return booleans while narrowing to strings

## Testing
- npm run check *(fails: existing TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d422129100832a9f82dc51b236c939