### PR TITLE
Refresh company accounts UI with hero visuals

### DIFF
--- a/client/src/components/accounts-table.tsx
+++ b/client/src/components/accounts-table.tsx
@@ -25,6 +25,7 @@ interface AccountsTableProps {
   showDeleteButton?: boolean;
   onView?: (account: any) => void;
   onContact?: (account: any) => void;
+  onEdit?: (account: any) => void;
 }
 
 export default function AccountsTable({
@@ -34,6 +35,7 @@ export default function AccountsTable({
   showDeleteButton = false,
   onView,
   onContact,
+  onEdit,
 }: AccountsTableProps) {
   const [statusFilter, setStatusFilter] = useState("all");
   const [selectedAccounts, setSelectedAccounts] = useState<Set<string>>(new Set());
@@ -301,6 +303,17 @@ export default function AccountsTable({
                         >
                           View
                         </Button>
+                        {onEdit && (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="rounded-lg border border-sky-400/40 bg-sky-500/20 px-3 text-xs font-semibold text-white hover:bg-sky-500/30"
+                            data-testid={`button-edit-account-${account.id}`}
+                            onClick={() => onEdit(account)}
+                          >
+                            Edit
+                          </Button>
+                        )}
                         <Button
                           variant="ghost"
                           size="sm"


### PR DESCRIPTION
## Summary
- add optional edit action support to the shared AccountsTable component so account rows can expose hero-style edit controls
- rebuild the company accounts page with the new hero layout, including the gradient header, modern folder navigation chips, and the shared AccountsTable for the account list
- refresh the account view and contact dialogs to match the hero visual system while keeping the existing creation, editing, and folder management flows

## Testing
- pnpm check *(fails: existing TypeScript errors in communications, consumer portal, enhanced consumer portal, payments, requests, emailService, replitAuth, and storage files)*

------
https://chatgpt.com/codex/tasks/task_e_68d42892d97c832a9449a229d1a06c79