### PR TITLE
Fix folders DELETE route for serverless

### DIFF
--- a/api/folders/[id].ts
+++ b/api/folders/[id].ts
@@ -1,0 +1,1 @@
+export { default } from "../folders.js";


### PR DESCRIPTION
## Summary
- add a dynamic Vercel API route for `/api/folders/:id`
- reuse the existing folders handler so DELETE requests succeed in production

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d42a548c00832abff97b2c2ddec4bc