### PR TITLE
Add authenticated consumer portal endpoints

### DIFF
--- a/api/_lib/auth.ts
+++ b/api/_lib/auth.ts
@@ -11,11 +11,81 @@ export interface AuthenticatedRequest extends VercelRequest {
   platformUser?: any;
 }
 
+export interface ConsumerAuthContext {
+  consumerId: string;
+  email: string;
+  tenantId?: string;
+  tenantSlug?: string;
+}
+
+interface ConsumerAuthError {
+  status: number;
+  message: string;
+}
+
+function parseCookies(cookieHeader?: string): Record<string, string> {
+  if (!cookieHeader) {
+    return {};
+  }
+
+  return cookieHeader.split(';').reduce((acc, part) => {
+    const [name, ...rest] = part.trim().split('=');
+    if (name) {
+      acc[name] = decodeURIComponent(rest.join('=') || '');
+    }
+    return acc;
+  }, {} as Record<string, string>);
+}
+
+function extractBearerToken(req: VercelRequest): string | null {
+  const authHeader = req.headers.authorization;
+  if (authHeader && authHeader.startsWith('Bearer ')) {
+    return authHeader.slice(7).trim() || null;
+  }
+
+  const cookies = parseCookies(req.headers.cookie);
+  if (cookies.consumerToken) {
+    return cookies.consumerToken;
+  }
+
+  return null;
+}
+
+export function verifyConsumerAuth(
+  req: VercelRequest,
+): { consumer: ConsumerAuthContext } | { error: ConsumerAuthError } {
+  const token = extractBearerToken(req);
+
+  if (!token) {
+    return { error: { status: 401, message: 'No consumer token provided' } };
+  }
+
+  try {
+    const decoded = jwt.verify(token, JWT_SECRET) as any;
+
+    if (decoded?.type !== 'consumer' || !decoded?.consumerId || !decoded?.email) {
+      return { error: { status: 401, message: 'Invalid consumer token' } };
+    }
+
+    return {
+      consumer: {
+        consumerId: decoded.consumerId,
+        email: decoded.email,
+        tenantId: decoded.tenantId,
+        tenantSlug: decoded.tenantSlug,
+      },
+    };
+  } catch (error) {
+    console.error('Consumer auth verification error:', error);
+    return { error: { status: 401, message: 'Invalid consumer token' } };
+  }
+}
+
 export async function verifyAuth(req: AuthenticatedRequest): Promise<boolean> {
   try {
     // Check for token in Authorization header or cookies
     let token = req.headers.authorization?.replace('Bearer ', '');
-    
+
     // If no Authorization header, check cookies
     if (!token && req.headers.cookie) {
       const cookies = req.headers.cookie.split(';').reduce((acc, cookie) => {

--- a/api/consumer-notifications/[email]/[tenantSlug].ts
+++ b/api/consumer-notifications/[email]/[tenantSlug].ts
@@ -1,0 +1,85 @@
+import { VercelRequest, VercelResponse } from '@vercel/node';
+import { and, desc, eq, sql } from 'drizzle-orm';
+
+import { getDb } from '../../_lib/db.js';
+import { verifyConsumerAuth } from '../../_lib/auth.js';
+import {
+  consumerNotifications,
+  consumers,
+  tenants,
+} from '../../../shared/schema.js';
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  try {
+    const authResult = verifyConsumerAuth(req);
+    if ('error' in authResult) {
+      return res.status(authResult.error.status).json({ error: authResult.error.message });
+    }
+
+    const { consumer: authConsumer } = authResult;
+
+    const emailParam = req.query.email;
+    const tenantSlugParam = req.query.tenantSlug;
+
+    const requestedEmail = Array.isArray(emailParam) ? emailParam[0] : emailParam;
+    const requestedTenantSlug = Array.isArray(tenantSlugParam) ? tenantSlugParam[0] : tenantSlugParam;
+
+    const sanitizedEmail = decodeURIComponent((requestedEmail ?? '').trim());
+    const tenantSlug = decodeURIComponent((requestedTenantSlug ?? '').trim());
+
+    if (!sanitizedEmail || !tenantSlug) {
+      return res.status(400).json({ error: 'Email and tenant slug are required' });
+    }
+
+    if (sanitizedEmail.toLowerCase() !== authConsumer.email.trim().toLowerCase()) {
+      return res.status(403).json({ error: 'Access denied' });
+    }
+
+    const db = getDb();
+
+    const [tenant] = await db
+      .select()
+      .from(tenants)
+      .where(eq(tenants.slug, tenantSlug))
+      .limit(1);
+
+    if (!tenant) {
+      return res.status(404).json({ error: 'Tenant not found' });
+    }
+
+    if (authConsumer.tenantId && authConsumer.tenantId !== tenant.id) {
+      return res.status(403).json({ error: 'Access denied' });
+    }
+
+    const [consumer] = await db
+      .select()
+      .from(consumers)
+      .where(
+        and(
+          eq(consumers.id, authConsumer.consumerId),
+          eq(consumers.tenantId, tenant.id),
+          sql`LOWER(${consumers.email}) = LOWER(${sanitizedEmail})`
+        )
+      )
+      .limit(1);
+
+    if (!consumer) {
+      return res.status(404).json({ error: 'Consumer not found' });
+    }
+
+    const notifications = await db
+      .select()
+      .from(consumerNotifications)
+      .where(and(eq(consumerNotifications.consumerId, consumer.id), eq(consumerNotifications.tenantId, tenant.id)))
+      .orderBy(desc(consumerNotifications.createdAt));
+
+    res.status(200).json(notifications);
+  } catch (error) {
+    console.error('Error fetching consumer notifications:', error);
+    res.status(500).json({ error: 'Failed to fetch notifications' });
+  }
+}

--- a/api/consumer-notifications/[id]/read.ts
+++ b/api/consumer-notifications/[id]/read.ts
@@ -1,0 +1,50 @@
+import { VercelRequest, VercelResponse } from '@vercel/node';
+import { and, eq } from 'drizzle-orm';
+
+import { getDb } from '../../_lib/db.js';
+import { verifyConsumerAuth } from '../../_lib/auth.js';
+import { consumerNotifications } from '../../../shared/schema.js';
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'PATCH') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  try {
+    const authResult = verifyConsumerAuth(req);
+    if ('error' in authResult) {
+      return res.status(authResult.error.status).json({ error: authResult.error.message });
+    }
+
+    const { consumer: authConsumer } = authResult;
+
+    const idParam = req.query.id;
+    const notificationId = Array.isArray(idParam) ? idParam[0] : idParam;
+
+    if (!notificationId) {
+      return res.status(400).json({ error: 'Notification id is required' });
+    }
+
+    const db = getDb();
+
+    const updated = await db
+      .update(consumerNotifications)
+      .set({ isRead: true })
+      .where(
+        and(
+          eq(consumerNotifications.id, notificationId),
+          eq(consumerNotifications.consumerId, authConsumer.consumerId),
+        )
+      )
+      .returning({ id: consumerNotifications.id });
+
+    if (updated.length === 0) {
+      return res.status(404).json({ error: 'Notification not found' });
+    }
+
+    res.status(200).json({ success: true });
+  } catch (error) {
+    console.error('Error marking notification as read:', error);
+    res.status(500).json({ error: 'Failed to update notification' });
+  }
+}

--- a/api/consumer/accounts/[email].ts
+++ b/api/consumer/accounts/[email].ts
@@ -1,7 +1,8 @@
 import { VercelRequest, VercelResponse } from '@vercel/node';
 import { getDb } from '../../_lib/db.js';
-import { consumers, accounts, tenants } from '../../../shared/schema.js';
+import { consumers, accounts, tenants, tenantSettings } from '../../../shared/schema.js';
 import { eq, and, sql } from 'drizzle-orm';
+import { verifyConsumerAuth } from '../../_lib/auth.js';
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'GET') {
@@ -9,20 +10,44 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
 
   try {
-    const email = (req.query.email as string | undefined) ?? '';
-    const tenantSlug = req.query.tenantSlug as string;
+    const authResult = verifyConsumerAuth(req);
+    if ('error' in authResult) {
+      return res.status(authResult.error.status).json({ error: authResult.error.message });
+    }
 
-    const sanitizedEmail = email.trim();
+    const { consumer: authConsumer } = authResult;
+
+    const emailParam = req.query.email;
+    const tenantSlugParam = req.query.tenantSlug;
+
+    const requestedEmail = Array.isArray(emailParam) ? emailParam[0] : emailParam;
+    const requestedTenantSlug = Array.isArray(tenantSlugParam) ? tenantSlugParam[0] : tenantSlugParam;
+
+    const sanitizedEmail = decodeURIComponent((requestedEmail ?? '').trim());
 
     if (!sanitizedEmail) {
       return res.status(400).json({ error: 'Email is required' });
     }
 
-    const db = getDb();
-    let tenantId: string | null = null;
+    if (sanitizedEmail.toLowerCase() !== authConsumer.email.trim().toLowerCase()) {
+      return res.status(403).json({ error: 'Access denied' });
+    }
 
-    // Get tenant if slug provided
-    if (tenantSlug) {
+    const db = getDb();
+
+    let tenantRecord: typeof tenants.$inferSelect | null = null;
+    if (authConsumer.tenantId) {
+      const [tenant] = await db
+        .select()
+        .from(tenants)
+        .where(eq(tenants.id, authConsumer.tenantId))
+        .limit(1);
+      tenantRecord = tenant ?? null;
+    }
+
+    const tenantSlug = (requestedTenantSlug ?? authConsumer.tenantSlug ?? '').trim();
+
+    if (!tenantRecord && tenantSlug) {
       const [tenant] = await db
         .select()
         .from(tenants)
@@ -32,31 +57,45 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       if (!tenant) {
         return res.status(404).json({ error: 'Agency not found' });
       }
-      tenantId = tenant.id;
+      tenantRecord = tenant;
     }
 
-    // Get consumer
-    const normalizedEmailMatch = sql`LOWER(${consumers.email}) = LOWER(${sanitizedEmail})`;
+    if (!tenantRecord) {
+      return res.status(400).json({ error: 'Tenant context is missing' });
+    }
 
-    const consumerQuery = tenantId
-      ? and(eq(consumers.tenantId, tenantId), normalizedEmailMatch)
-      : normalizedEmailMatch;
+    if (tenantSlug && tenantRecord.slug !== tenantSlug) {
+      return res.status(403).json({ error: 'Access denied' });
+    }
+
+    const tenantId = tenantRecord.id;
 
     const [consumer] = await db
       .select()
       .from(consumers)
-      .where(consumerQuery)
+      .where(
+        and(
+          eq(consumers.id, authConsumer.consumerId),
+          eq(consumers.tenantId, tenantId),
+          sql`LOWER(${consumers.email}) = LOWER(${sanitizedEmail})`
+        )
+      )
       .limit(1);
 
     if (!consumer) {
       return res.status(404).json({ error: 'Consumer not found' });
     }
 
-    // Get accounts
     const accountsData = await db
       .select()
       .from(accounts)
-      .where(eq(accounts.consumerId, consumer.id));
+      .where(and(eq(accounts.consumerId, consumer.id), eq(accounts.tenantId, tenantId)));
+
+    const [settings] = await db
+      .select()
+      .from(tenantSettings)
+      .where(eq(tenantSettings.tenantId, tenantId))
+      .limit(1);
 
     res.status(200).json({
       consumer: {
@@ -64,9 +103,15 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         firstName: consumer.firstName,
         lastName: consumer.lastName,
         email: consumer.email,
-        phone: consumer.phone
+        phone: consumer.phone,
       },
-      accounts: accountsData
+      accounts: accountsData,
+      tenant: {
+        id: tenantRecord.id,
+        name: tenantRecord.name,
+        slug: tenantRecord.slug,
+      },
+      tenantSettings: settings ?? null,
     });
   } catch (error) {
     console.error('Error fetching consumer accounts:', error);

--- a/api/consumer/arrangements/[email].ts
+++ b/api/consumer/arrangements/[email].ts
@@ -1,0 +1,110 @@
+import { VercelRequest, VercelResponse } from '@vercel/node';
+import { and, eq, sql } from 'drizzle-orm';
+
+import { getDb } from '../../_lib/db.js';
+import { verifyConsumerAuth } from '../../_lib/auth.js';
+import {
+  arrangementOptions,
+  consumers,
+  tenants,
+  tenantSettings,
+} from '../../../shared/schema.js';
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  try {
+    const authResult = verifyConsumerAuth(req);
+    if ('error' in authResult) {
+      return res.status(authResult.error.status).json({ error: authResult.error.message });
+    }
+
+    const { consumer: authConsumer } = authResult;
+
+    const emailParam = req.query.email;
+    const tenantSlugParam = req.query.tenantSlug;
+    const balanceParam = req.query.balance;
+
+    const requestedEmail = Array.isArray(emailParam) ? emailParam[0] : emailParam;
+    const requestedTenantSlug = Array.isArray(tenantSlugParam) ? tenantSlugParam[0] : tenantSlugParam;
+    const balanceRaw = Array.isArray(balanceParam) ? balanceParam[0] : balanceParam;
+
+    const sanitizedEmail = decodeURIComponent((requestedEmail ?? '').trim());
+
+    if (!sanitizedEmail) {
+      return res.status(400).json({ error: 'Email is required' });
+    }
+
+    if (sanitizedEmail.toLowerCase() !== authConsumer.email.trim().toLowerCase()) {
+      return res.status(403).json({ error: 'Access denied' });
+    }
+
+    const tenantSlug = (requestedTenantSlug ?? authConsumer.tenantSlug ?? '').trim();
+    if (!tenantSlug) {
+      return res.status(400).json({ error: 'Tenant slug required' });
+    }
+
+    const db = getDb();
+
+    const [tenant] = await db
+      .select()
+      .from(tenants)
+      .where(eq(tenants.slug, tenantSlug))
+      .limit(1);
+
+    if (!tenant) {
+      return res.status(404).json({ error: 'Tenant not found' });
+    }
+
+    if (authConsumer.tenantId && authConsumer.tenantId !== tenant.id) {
+      return res.status(403).json({ error: 'Access denied' });
+    }
+
+    const [settings] = await db
+      .select()
+      .from(tenantSettings)
+      .where(eq(tenantSettings.tenantId, tenant.id))
+      .limit(1);
+
+    if (settings && settings.showPaymentPlans === false) {
+      return res.status(200).json([]);
+    }
+
+    const [consumer] = await db
+      .select()
+      .from(consumers)
+      .where(
+        and(
+          eq(consumers.id, authConsumer.consumerId),
+          eq(consumers.tenantId, tenant.id),
+          sql`LOWER(${consumers.email}) = LOWER(${sanitizedEmail})`
+        )
+      )
+      .limit(1);
+
+    if (!consumer) {
+      return res.status(404).json({ error: 'Consumer not found' });
+    }
+
+    const balanceCents = Number.parseInt(balanceRaw ?? '0', 10);
+    const safeBalance = Number.isFinite(balanceCents) ? balanceCents : 0;
+
+    const options = await db
+      .select()
+      .from(arrangementOptions)
+      .where(and(eq(arrangementOptions.tenantId, tenant.id), eq(arrangementOptions.isActive, true)));
+
+    const applicableOptions = options.filter(option => {
+      const min = option.minBalance ?? 0;
+      const max = option.maxBalance ?? Number.MAX_SAFE_INTEGER;
+      return safeBalance >= min && safeBalance <= max;
+    });
+
+    res.status(200).json(applicableOptions);
+  } catch (error) {
+    console.error('Error fetching arrangement options:', error);
+    res.status(500).json({ error: 'Failed to fetch arrangement options' });
+  }
+}

--- a/api/consumer/documents/[email].ts
+++ b/api/consumer/documents/[email].ts
@@ -1,0 +1,130 @@
+import { VercelRequest, VercelResponse } from '@vercel/node';
+import { and, desc, eq, sql } from 'drizzle-orm';
+
+import { getDb } from '../../_lib/db.js';
+import { verifyConsumerAuth } from '../../_lib/auth.js';
+import {
+  accounts,
+  consumers,
+  documents,
+  tenants,
+  tenantSettings,
+} from '../../../shared/schema.js';
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  try {
+    const authResult = verifyConsumerAuth(req);
+    if ('error' in authResult) {
+      return res.status(authResult.error.status).json({ error: authResult.error.message });
+    }
+
+    const { consumer: authConsumer } = authResult;
+
+    const emailParam = req.query.email;
+    const tenantSlugParam = req.query.tenantSlug;
+    const accountIdParam = req.query.accountId;
+
+    const requestedEmail = Array.isArray(emailParam) ? emailParam[0] : emailParam;
+    const requestedTenantSlug = Array.isArray(tenantSlugParam) ? tenantSlugParam[0] : tenantSlugParam;
+    const requestedAccountId = Array.isArray(accountIdParam) ? accountIdParam[0] : accountIdParam;
+
+    const sanitizedEmail = decodeURIComponent((requestedEmail ?? '').trim());
+
+    if (!sanitizedEmail) {
+      return res.status(400).json({ error: 'Email is required' });
+    }
+
+    if (sanitizedEmail.toLowerCase() !== authConsumer.email.trim().toLowerCase()) {
+      return res.status(403).json({ error: 'Access denied' });
+    }
+
+    const db = getDb();
+
+    const tenantSlug = (requestedTenantSlug ?? authConsumer.tenantSlug ?? '').trim();
+    if (!tenantSlug) {
+      return res.status(400).json({ error: 'Tenant slug required' });
+    }
+
+    const [tenant] = await db
+      .select()
+      .from(tenants)
+      .where(eq(tenants.slug, tenantSlug))
+      .limit(1);
+
+    if (!tenant) {
+      return res.status(404).json({ error: 'Tenant not found' });
+    }
+
+    if (authConsumer.tenantId && authConsumer.tenantId !== tenant.id) {
+      return res.status(403).json({ error: 'Access denied' });
+    }
+
+    const [settings] = await db
+      .select()
+      .from(tenantSettings)
+      .where(eq(tenantSettings.tenantId, tenant.id))
+      .limit(1);
+
+    if (settings && settings.showDocuments === false) {
+      return res.status(200).json([]);
+    }
+
+    const [consumer] = await db
+      .select()
+      .from(consumers)
+      .where(
+        and(
+          eq(consumers.id, authConsumer.consumerId),
+          eq(consumers.tenantId, tenant.id),
+          sql`LOWER(${consumers.email}) = LOWER(${sanitizedEmail})`
+        )
+      )
+      .limit(1);
+
+    if (!consumer) {
+      return res.status(404).json({ error: 'Consumer not found' });
+    }
+
+    const consumerAccounts = await db
+      .select({ id: accounts.id })
+      .from(accounts)
+      .where(and(eq(accounts.consumerId, consumer.id), eq(accounts.tenantId, tenant.id)));
+
+    const consumerAccountIds = new Set(consumerAccounts.map(account => account.id));
+
+    if (requestedAccountId && !consumerAccountIds.has(requestedAccountId)) {
+      return res.status(200).json([]);
+    }
+
+    const documentsList = await db
+      .select()
+      .from(documents)
+      .where(eq(documents.tenantId, tenant.id))
+      .orderBy(desc(documents.createdAt));
+
+    const visibleDocuments = documentsList.filter(doc => {
+      if (doc.isPublic) {
+        return true;
+      }
+
+      if (!doc.accountId) {
+        return false;
+      }
+
+      if (requestedAccountId) {
+        return doc.accountId === requestedAccountId;
+      }
+
+      return consumerAccountIds.has(doc.accountId);
+    });
+
+    res.status(200).json(visibleDocuments);
+  } catch (error) {
+    console.error('Error fetching consumer documents:', error);
+    res.status(500).json({ error: 'Failed to fetch documents' });
+  }
+}


### PR DESCRIPTION
## Summary
- add shared consumer auth verification utilities to reuse the consumer JWT
- secure the consumer accounts API with token validation and tenant metadata
- implement serverless consumer document, arrangement, and notification endpoints used by the portal

## Testing
- npm run check *(fails: existing TypeScript errors in unrelated files)*
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d450782998832a924f13df0e7ec095