### PR TITLE
Fix tenant document handling

### DIFF
--- a/api/documents/[id].ts
+++ b/api/documents/[id].ts
@@ -81,7 +81,7 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
       // Delete the document
       await db
         .delete(documents)
-        .where(eq(documents.id, id));
+        .where(and(eq(documents.id, id), eq(documents.tenantId, tenantId)));
 
       res.status(200).json({ success: true });
     } else {


### PR DESCRIPTION
## Summary
- return tenant documents with related account and consumer details from the API
- persist account-specific visibility when uploading documents and validate tenant ownership
- restrict document deletion to the current tenant context

## Testing
- npm run check *(fails: existing type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d459985870832ab2e531cd11672b17