### PR TITLE
Fix consumer notification route conflicts

### DIFF
--- a/api/consumer-notifications/[id]/read.ts
+++ b/api/consumer-notifications/[id]/read.ts
@@ -1,0 +1,38 @@
+import { VercelRequest, VercelResponse } from '@vercel/node';
+import { eq } from 'drizzle-orm';
+
+import { getDb } from '../../../_lib/db.js';
+import { consumerNotifications } from '../../../../shared/schema.js';
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'PATCH') {
+    res.setHeader('Allow', 'PATCH');
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  try {
+    const idParam = req.query.id;
+    const notificationId = Array.isArray(idParam) ? idParam[0] : idParam;
+
+    if (!notificationId) {
+      return res.status(400).json({ error: 'Notification ID is required' });
+    }
+
+    const db = getDb();
+
+    const [updated] = await db
+      .update(consumerNotifications)
+      .set({ isRead: true })
+      .where(eq(consumerNotifications.id, notificationId))
+      .returning({ id: consumerNotifications.id });
+
+    if (!updated) {
+      return res.status(404).json({ error: 'Notification not found' });
+    }
+
+    return res.status(200).json({ message: 'Notification marked as read' });
+  } catch (error) {
+    console.error('Error marking notification as read:', error);
+    return res.status(500).json({ error: 'Failed to mark notification as read' });
+  }
+}

--- a/api/consumer-notifications/by-consumer/[email]/[tenantSlug].ts
+++ b/api/consumer-notifications/by-consumer/[email]/[tenantSlug].ts
@@ -1,0 +1,63 @@
+import { VercelRequest, VercelResponse } from '@vercel/node';
+import { and, desc, eq, sql } from 'drizzle-orm';
+
+import { getDb } from '../../../../_lib/db.js';
+import { consumers, consumerNotifications, tenants } from '../../../../../shared/schema.js';
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  try {
+    const emailParam = req.query.email;
+    const tenantSlugParam = req.query.tenantSlug;
+
+    if (typeof emailParam !== 'string' || !emailParam.trim()) {
+      return res.status(400).json({ error: 'Email is required' });
+    }
+
+    if (typeof tenantSlugParam !== 'string' || !tenantSlugParam.trim()) {
+      return res.status(400).json({ error: 'Tenant slug is required' });
+    }
+
+    const email = emailParam.trim();
+    const tenantSlug = tenantSlugParam.trim();
+
+    const db = getDb();
+
+    const [tenant] = await db
+      .select()
+      .from(tenants)
+      .where(eq(tenants.slug, tenantSlug))
+      .limit(1);
+
+    if (!tenant) {
+      return res.status(404).json({ message: 'Consumer not found' });
+    }
+
+    const normalizedEmailMatch = sql`LOWER(${consumers.email}) = LOWER(${email})`;
+
+    const [consumer] = await db
+      .select()
+      .from(consumers)
+      .where(and(eq(consumers.tenantId, tenant.id), normalizedEmailMatch))
+      .limit(1);
+
+    if (!consumer) {
+      return res.status(404).json({ message: 'Consumer not found' });
+    }
+
+    const notifications = await db
+      .select()
+      .from(consumerNotifications)
+      .where(eq(consumerNotifications.consumerId, consumer.id))
+      .orderBy(desc(consumerNotifications.createdAt));
+
+    return res.status(200).json(notifications);
+  } catch (error) {
+    console.error('Error fetching consumer notifications:', error);
+    return res.status(500).json({ error: 'Failed to fetch notifications' });
+  }
+}

--- a/client/src/pages/consumer-dashboard.tsx
+++ b/client/src/pages/consumer-dashboard.tsx
@@ -89,7 +89,7 @@ export default function ConsumerDashboard() {
 
   // Fetch notifications
   const { data: notifications } = useQuery({
-    queryKey: [`/api/consumer-notifications/${consumerSession?.email}/${consumerSession?.tenantSlug}`],
+    queryKey: [`/api/consumer-notifications/by-consumer/${consumerSession?.email}/${consumerSession?.tenantSlug}`],
     enabled: !!consumerSession?.email && !!consumerSession?.tenantSlug,
   });
 
@@ -153,8 +153,8 @@ export default function ConsumerDashboard() {
       await apiRequest("PATCH", `/api/consumer-notifications/${notificationId}/read`);
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ 
-        queryKey: [`/api/consumer-notifications/${consumerSession?.email}/${consumerSession?.tenantSlug}`] 
+      queryClient.invalidateQueries({
+        queryKey: [`/api/consumer-notifications/by-consumer/${consumerSession?.email}/${consumerSession?.tenantSlug}`]
       });
     },
   });

--- a/client/src/pages/enhanced-consumer-portal.tsx
+++ b/client/src/pages/enhanced-consumer-portal.tsx
@@ -44,7 +44,7 @@ export default function EnhancedConsumerPortal() {
 
   // Fetch notifications
   const { data: notifications } = useQuery({
-    queryKey: [`/api/consumer-notifications/${encodedEmail}/${resolvedTenantSlug ?? ""}`],
+    queryKey: [`/api/consumer-notifications/by-consumer/${encodedEmail}/${resolvedTenantSlug ?? ""}`],
     enabled: !!(resolvedTenantSlug && email),
   });
 
@@ -100,7 +100,7 @@ export default function EnhancedConsumerPortal() {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: [`/api/consumer-notifications/${encodedEmail}/${resolvedTenantSlug ?? ""}`],
+        queryKey: [`/api/consumer-notifications/by-consumer/${encodedEmail}/${resolvedTenantSlug ?? ""}`],
       });
     },
   });


### PR DESCRIPTION
## Summary
- move consumer notification fetch endpoint under `/api/consumer-notifications/by-consumer/...` to avoid dynamic segment conflicts
- add matching Vercel functions and update Express server route to serve both the new and legacy paths
- update React consumer portals to call the new route and keep notification invalidation in sync

## Testing
- `npm run check` *(fails: existing TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d454e612f4832aa4d5b2b9d1655d37