### PR TITLE
Fix consumer notification API route conflicts

### DIFF
--- a/api/consumer-notifications/[email]/[tenantSlug].ts
+++ b/api/consumer-notifications/[email]/[tenantSlug].ts
@@ -1,0 +1,78 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { getDb } from '../../../_lib/db.js';
+import { consumers, consumerNotifications, tenants } from '../../../_lib/schema.js';
+import { and, desc, eq, sql } from 'drizzle-orm';
+
+function normalizeParam(param: string | string[] | undefined) {
+  if (!param) {
+    return undefined;
+  }
+
+  const value = Array.isArray(param) ? param[0] : param;
+  return value ? value.trim() : undefined;
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  try {
+    const emailParam = normalizeParam(req.query.email);
+    const tenantParam = normalizeParam(req.query.tenantSlug);
+
+    if (!emailParam || !tenantParam) {
+      res.status(400).json({ error: 'Email and tenant identifier are required' });
+      return;
+    }
+
+    const email = decodeURIComponent(emailParam);
+    const tenantIdentifier = decodeURIComponent(tenantParam);
+
+    const db = getDb();
+
+    // Resolve tenant identifier to tenant ID
+    const [tenantBySlug] = await db
+      .select({ id: tenants.id })
+      .from(tenants)
+      .where(eq(tenants.slug, tenantIdentifier))
+      .limit(1);
+
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    const tenantId = tenantBySlug?.id ?? (uuidRegex.test(tenantIdentifier) ? tenantIdentifier : undefined);
+
+    if (!tenantId) {
+      res.status(404).json({ error: 'Tenant not found' });
+      return;
+    }
+
+    const [consumer] = await db
+      .select({ id: consumers.id })
+      .from(consumers)
+      .where(
+        and(
+          eq(consumers.tenantId, tenantId),
+          sql`LOWER(${consumers.email}) = LOWER(${email})`
+        )
+      )
+      .limit(1);
+
+    if (!consumer) {
+      res.status(404).json({ error: 'Consumer not found' });
+      return;
+    }
+
+    const notifications = await db
+      .select()
+      .from(consumerNotifications)
+      .where(eq(consumerNotifications.consumerId, consumer.id))
+      .orderBy(desc(consumerNotifications.createdAt));
+
+    res.status(200).json(notifications);
+  } catch (error) {
+    console.error('Error fetching consumer notifications:', error);
+    res.status(500).json({ error: 'Failed to fetch notifications' });
+  }
+}

--- a/api/consumer-notifications/read/[id].ts
+++ b/api/consumer-notifications/read/[id].ts
@@ -1,0 +1,45 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { getDb } from '../../_lib/db.js';
+import { consumerNotifications } from '../../_lib/schema.js';
+import { eq } from 'drizzle-orm';
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method === 'OPTIONS') {
+    res.status(200).end();
+    return;
+  }
+
+  if (req.method !== 'PATCH') {
+    res.setHeader('Allow', 'PATCH, OPTIONS');
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  try {
+    const idParam = req.query.id;
+    const notificationId = Array.isArray(idParam) ? idParam[0] : idParam;
+
+    if (!notificationId) {
+      res.status(400).json({ error: 'Notification ID is required' });
+      return;
+    }
+
+    const db = getDb();
+
+    const updated = await db
+      .update(consumerNotifications)
+      .set({ isRead: true })
+      .where(eq(consumerNotifications.id, notificationId))
+      .returning({ id: consumerNotifications.id });
+
+    if (updated.length === 0) {
+      res.status(404).json({ error: 'Notification not found' });
+      return;
+    }
+
+    res.status(200).json({ message: 'Notification marked as read' });
+  } catch (error) {
+    console.error('Error marking consumer notification as read:', error);
+    res.status(500).json({ error: 'Failed to mark notification as read' });
+  }
+}

--- a/client/src/pages/consumer-dashboard.tsx
+++ b/client/src/pages/consumer-dashboard.tsx
@@ -150,7 +150,7 @@ export default function ConsumerDashboard() {
   // Mark notification as read
   const markNotificationReadMutation = useMutation({
     mutationFn: async (notificationId: string) => {
-      await apiRequest("PATCH", `/api/consumer-notifications/${notificationId}/read`);
+      await apiRequest("PATCH", `/api/consumer-notifications/read/${notificationId}`);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ 

--- a/client/src/pages/enhanced-consumer-portal.tsx
+++ b/client/src/pages/enhanced-consumer-portal.tsx
@@ -96,7 +96,7 @@ export default function EnhancedConsumerPortal() {
   // Mark notification as read
   const markNotificationReadMutation = useMutation({
     mutationFn: async (notificationId: string) => {
-      await apiRequest("PATCH", `/api/consumer-notifications/${notificationId}/read`);
+      await apiRequest("PATCH", `/api/consumer-notifications/read/${notificationId}`);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2278,7 +2278,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   });
 
   // Mark notification as read
-  app.patch('/api/consumer-notifications/:id/read', async (req, res) => {
+  app.patch('/api/consumer-notifications/read/:id', async (req, res) => {
     try {
       const { id } = req.params;
       await storage.markNotificationRead(id);


### PR DESCRIPTION
## Summary
- add Vercel API handlers for fetching consumer notifications and marking a notification as read using non-conflicting route segments
- update the Express route and front-end mutation calls to use the new `/api/consumer-notifications/read/:id` path

## Testing
- npm run check *(fails: existing TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d454e612f4832aa4d5b2b9d1655d37