### PR TITLE
Refactor consumer notification endpoints to avoid dynamic route conflict

### DIFF
--- a/api/consumer-notifications/by-consumer.ts
+++ b/api/consumer-notifications/by-consumer.ts
@@ -1,0 +1,69 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { getDb } from '../_lib/db.js';
+import { consumers, consumerNotifications, tenants } from '../../shared/schema.js';
+import { and, desc, eq, sql } from 'drizzle-orm';
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  try {
+    const rawEmail = typeof req.query.email === 'string' ? req.query.email : Array.isArray(req.query.email) ? req.query.email[0] : '';
+    const rawTenantSlug = typeof req.query.tenantSlug === 'string'
+      ? req.query.tenantSlug
+      : Array.isArray(req.query.tenantSlug)
+        ? req.query.tenantSlug[0]
+        : undefined;
+
+    const email = rawEmail?.trim() ?? '';
+    const tenantSlug = rawTenantSlug?.trim() || undefined;
+
+    if (!email) {
+      return res.status(400).json({ error: 'Email is required' });
+    }
+
+    const db = getDb();
+
+    let tenantId: string | null = null;
+    if (tenantSlug) {
+      const [tenant] = await db
+        .select({ id: tenants.id })
+        .from(tenants)
+        .where(eq(tenants.slug, tenantSlug))
+        .limit(1);
+
+      if (!tenant) {
+        return res.status(404).json({ error: 'Agency not found' });
+      }
+
+      tenantId = tenant.id;
+    }
+
+    const normalizedEmailMatch = sql`LOWER(${consumers.email}) = LOWER(${email})`;
+    const consumerQuery = tenantId
+      ? and(eq(consumers.tenantId, tenantId), normalizedEmailMatch)
+      : normalizedEmailMatch;
+
+    const [consumer] = await db
+      .select({ id: consumers.id })
+      .from(consumers)
+      .where(consumerQuery)
+      .limit(1);
+
+    if (!consumer) {
+      return res.status(404).json({ error: 'Consumer not found' });
+    }
+
+    const notifications = await db
+      .select()
+      .from(consumerNotifications)
+      .where(eq(consumerNotifications.consumerId, consumer.id))
+      .orderBy(desc(consumerNotifications.createdAt));
+
+    return res.status(200).json(notifications);
+  } catch (error) {
+    console.error('Error fetching consumer notifications:', error);
+    return res.status(500).json({ error: 'Failed to fetch notifications' });
+  }
+}

--- a/api/consumer-notifications/mark-read.ts
+++ b/api/consumer-notifications/mark-read.ts
@@ -1,0 +1,65 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { getDb } from '../_lib/db.js';
+import { consumerNotifications } from '../../shared/schema.js';
+import { eq } from 'drizzle-orm';
+
+function resolveNotificationId(req: VercelRequest): string | undefined {
+  if (typeof req.body === 'object' && req.body !== null) {
+    const bodyId = (req.body as { notificationId?: unknown }).notificationId;
+    if (typeof bodyId === 'string' && bodyId.trim()) {
+      return bodyId.trim();
+    }
+  }
+
+  const queryId = req.query.id ?? req.query.notificationId;
+  if (typeof queryId === 'string' && queryId.trim()) {
+    return queryId.trim();
+  }
+  if (Array.isArray(queryId) && queryId.length > 0) {
+    const candidate = queryId[0];
+    if (typeof candidate === 'string' && candidate.trim()) {
+      return candidate.trim();
+    }
+  }
+
+  if (req.url) {
+    const url = new URL(req.url, 'http://localhost');
+    const lastSegment = url.pathname.split('/').filter(Boolean).pop();
+    if (lastSegment && lastSegment !== 'mark-read') {
+      return lastSegment;
+    }
+  }
+
+  return undefined;
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'PATCH') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  try {
+    const notificationId = resolveNotificationId(req);
+
+    if (!notificationId) {
+      return res.status(400).json({ error: 'Notification ID is required' });
+    }
+
+    const db = getDb();
+
+    const updated = await db
+      .update(consumerNotifications)
+      .set({ isRead: true })
+      .where(eq(consumerNotifications.id, notificationId))
+      .returning({ id: consumerNotifications.id });
+
+    if (updated.length === 0) {
+      return res.status(404).json({ error: 'Notification not found' });
+    }
+
+    return res.status(200).json({ message: 'Notification marked as read' });
+  } catch (error) {
+    console.error('Error marking notification as read:', error);
+    return res.status(500).json({ error: 'Failed to mark notification as read' });
+  }
+}

--- a/client/src/pages/consumer-dashboard.tsx
+++ b/client/src/pages/consumer-dashboard.tsx
@@ -31,6 +31,13 @@ export default function ConsumerDashboard() {
 
   const [showCallbackModal, setShowCallbackModal] = useState(false);
   const [consumerSession, setConsumerSession] = useState<any>(null);
+  const encodedEmail = consumerSession?.email ? encodeURIComponent(consumerSession.email) : "";
+  const encodedTenantSlug = consumerSession?.tenantSlug ? encodeURIComponent(consumerSession.tenantSlug) : "";
+  const notificationsQueryUrl = encodedEmail
+    ? consumerSession?.tenantSlug
+      ? `/api/consumer-notifications/by-consumer?email=${encodedEmail}&tenantSlug=${encodedTenantSlug}`
+      : `/api/consumer-notifications/by-consumer?email=${encodedEmail}`
+    : "";
 
   // Get consumer session data
   useEffect(() => {
@@ -89,7 +96,7 @@ export default function ConsumerDashboard() {
 
   // Fetch notifications
   const { data: notifications } = useQuery({
-    queryKey: [`/api/consumer-notifications/${consumerSession?.email}/${consumerSession?.tenantSlug}`],
+    queryKey: [notificationsQueryUrl],
     enabled: !!consumerSession?.email && !!consumerSession?.tenantSlug,
   });
 
@@ -150,11 +157,11 @@ export default function ConsumerDashboard() {
   // Mark notification as read
   const markNotificationReadMutation = useMutation({
     mutationFn: async (notificationId: string) => {
-      await apiRequest("PATCH", `/api/consumer-notifications/${notificationId}/read`);
+      await apiRequest("PATCH", "/api/consumer-notifications/mark-read", { notificationId });
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ 
-        queryKey: [`/api/consumer-notifications/${consumerSession?.email}/${consumerSession?.tenantSlug}`] 
+      queryClient.invalidateQueries({
+        queryKey: [notificationsQueryUrl]
       });
     },
   });

--- a/client/src/pages/enhanced-consumer-portal.tsx
+++ b/client/src/pages/enhanced-consumer-portal.tsx
@@ -24,6 +24,12 @@ export default function EnhancedConsumerPortal() {
 
   const resolvedTenantSlug = tenantSlug ?? agencySlug;
   const encodedEmail = email ? encodeURIComponent(email) : "";
+  const encodedTenantSlug = resolvedTenantSlug ? encodeURIComponent(resolvedTenantSlug) : "";
+  const notificationsQueryUrl = encodedEmail
+    ? resolvedTenantSlug
+      ? `/api/consumer-notifications/by-consumer?email=${encodedEmail}&tenantSlug=${encodedTenantSlug}`
+      : `/api/consumer-notifications/by-consumer?email=${encodedEmail}`
+    : "";
 
   const [callbackForm, setCallbackForm] = useState({
     requestType: "callback",
@@ -44,7 +50,7 @@ export default function EnhancedConsumerPortal() {
 
   // Fetch notifications
   const { data: notifications } = useQuery({
-    queryKey: [`/api/consumer-notifications/${encodedEmail}/${resolvedTenantSlug ?? ""}`],
+    queryKey: [notificationsQueryUrl],
     enabled: !!(resolvedTenantSlug && email),
   });
 
@@ -96,11 +102,11 @@ export default function EnhancedConsumerPortal() {
   // Mark notification as read
   const markNotificationReadMutation = useMutation({
     mutationFn: async (notificationId: string) => {
-      await apiRequest("PATCH", `/api/consumer-notifications/${notificationId}/read`);
+      await apiRequest("PATCH", "/api/consumer-notifications/mark-read", { notificationId });
     },
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: [`/api/consumer-notifications/${encodedEmail}/${resolvedTenantSlug ?? ""}`],
+        queryKey: [notificationsQueryUrl],
       });
     },
   });


### PR DESCRIPTION
## Summary
- add dedicated consumer notification API handlers that avoid conflicting dynamic path segments
- update consumer-facing pages to call the new endpoints and invalidate the correct query keys
- align Express routes with the new API contract to support query parameters and body payloads

## Testing
- npm run check *(fails: pre-existing type errors in consumer/admin pages and server utilities)*

------
https://chatgpt.com/codex/tasks/task_e_68d454e612f4832aa4d5b2b9d1655d37