### PR TITLE
Fix consumer notification route conflicts

### DIFF
--- a/api/consumer-notifications/by-consumer/[tenantSlug]/[email].ts
+++ b/api/consumer-notifications/by-consumer/[tenantSlug]/[email].ts
@@ -1,0 +1,74 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { and, desc, eq, sql } from 'drizzle-orm';
+
+import { getDb } from '../../../../_lib/db.js';
+import { consumers, consumerNotifications, tenants } from '../../../../_lib/schema.js';
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method === 'OPTIONS') {
+    res.status(200).end();
+    return;
+  }
+
+  if (req.method !== 'GET') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  try {
+    const { tenantSlug, email } = req.query;
+
+    if (typeof tenantSlug !== 'string' || !tenantSlug) {
+      res.status(400).json({ error: 'Tenant slug is required' });
+      return;
+    }
+
+    if (typeof email !== 'string' || !email) {
+      res.status(400).json({ error: 'Email is required' });
+      return;
+    }
+
+    const db = getDb();
+
+    const [tenant] = await db
+      .select()
+      .from(tenants)
+      .where(eq(tenants.slug, tenantSlug))
+      .limit(1);
+
+    if (!tenant) {
+      res.status(404).json({ error: 'Tenant not found' });
+      return;
+    }
+
+    const [consumer] = await db
+      .select()
+      .from(consumers)
+      .where(
+        and(
+          eq(consumers.tenantId, tenant.id),
+          sql`LOWER(${consumers.email}) = LOWER(${email})`
+        )
+      )
+      .limit(1);
+
+    if (!consumer) {
+      res.status(404).json({ error: 'Consumer not found' });
+      return;
+    }
+
+    const notifications = await db
+      .select()
+      .from(consumerNotifications)
+      .where(eq(consumerNotifications.consumerId, consumer.id))
+      .orderBy(desc(consumerNotifications.createdAt));
+
+    res.status(200).json(notifications);
+  } catch (error: any) {
+    console.error('Consumer notifications API error:', error);
+    res.status(500).json({
+      error: 'Failed to fetch notifications',
+      message: error.message ?? 'Unknown error'
+    });
+  }
+}

--- a/api/consumer-notifications/read/[id].ts
+++ b/api/consumer-notifications/read/[id].ts
@@ -1,0 +1,57 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { eq } from 'drizzle-orm';
+
+import { getDb } from '../../../_lib/db.js';
+import { consumerNotifications } from '../../../_lib/schema.js';
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method === 'OPTIONS') {
+    res.status(200).end();
+    return;
+  }
+
+  if (req.method !== 'PATCH') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  try {
+    const { id } = req.query;
+
+    if (typeof id !== 'string' || !id) {
+      res.status(400).json({ error: 'Notification ID is required' });
+      return;
+    }
+
+    const db = getDb();
+
+    const [notification] = await db
+      .select()
+      .from(consumerNotifications)
+      .where(eq(consumerNotifications.id, id))
+      .limit(1);
+
+    if (!notification) {
+      res.status(404).json({ error: 'Notification not found' });
+      return;
+    }
+
+    if (notification.isRead) {
+      res.status(200).json({ message: 'Notification already marked as read' });
+      return;
+    }
+
+    await db
+      .update(consumerNotifications)
+      .set({ isRead: true })
+      .where(eq(consumerNotifications.id, id));
+
+    res.status(200).json({ message: 'Notification marked as read' });
+  } catch (error: any) {
+    console.error('Mark notification read API error:', error);
+    res.status(500).json({
+      error: 'Failed to mark notification as read',
+      message: error.message ?? 'Unknown error'
+    });
+  }
+}

--- a/client/src/pages/enhanced-consumer-portal.tsx
+++ b/client/src/pages/enhanced-consumer-portal.tsx
@@ -24,6 +24,9 @@ export default function EnhancedConsumerPortal() {
 
   const resolvedTenantSlug = tenantSlug ?? agencySlug;
   const encodedEmail = email ? encodeURIComponent(email) : "";
+  const notificationsPath = resolvedTenantSlug && encodedEmail
+    ? `/api/consumer-notifications/by-consumer/${resolvedTenantSlug}/${encodedEmail}`
+    : "";
 
   const [callbackForm, setCallbackForm] = useState({
     requestType: "callback",
@@ -44,8 +47,8 @@ export default function EnhancedConsumerPortal() {
 
   // Fetch notifications
   const { data: notifications } = useQuery({
-    queryKey: [`/api/consumer-notifications/${encodedEmail}/${resolvedTenantSlug ?? ""}`],
-    enabled: !!(resolvedTenantSlug && email),
+    queryKey: [notificationsPath],
+    enabled: !!notificationsPath,
   });
 
   // Fetch documents
@@ -96,12 +99,14 @@ export default function EnhancedConsumerPortal() {
   // Mark notification as read
   const markNotificationReadMutation = useMutation({
     mutationFn: async (notificationId: string) => {
-      await apiRequest("PATCH", `/api/consumer-notifications/${notificationId}/read`);
+      await apiRequest("PATCH", `/api/consumer-notifications/read/${notificationId}`);
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: [`/api/consumer-notifications/${encodedEmail}/${resolvedTenantSlug ?? ""}`],
-      });
+      if (notificationsPath) {
+        queryClient.invalidateQueries({
+          queryKey: [notificationsPath],
+        });
+      }
     },
   });
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2260,10 +2260,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
   });
 
   // Consumer notifications route
-  app.get('/api/consumer-notifications/:email/:tenantSlug', async (req, res) => {
+  app.get('/api/consumer-notifications/by-consumer/:tenantSlug/:email', async (req, res) => {
     try {
       const { email, tenantSlug } = req.params;
-      
+
       const consumer = await storage.getConsumerByEmailAndTenant(email, tenantSlug);
       if (!consumer) {
         return res.status(404).json({ message: "Consumer not found" });
@@ -2278,7 +2278,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   });
 
   // Mark notification as read
-  app.patch('/api/consumer-notifications/:id/read', async (req, res) => {
+  app.patch('/api/consumer-notifications/read/:id', async (req, res) => {
     try {
       const { id } = req.params;
       await storage.markNotificationRead(id);


### PR DESCRIPTION
## Summary
- add dedicated consumer notification API routes with unique path segments to avoid dynamic route conflicts
- update the Express server and front-end consumer portals to use the new notification endpoints

## Testing
- npm run check *(fails: existing TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d454e612f4832aa4d5b2b9d1655d37