### PR TITLE
Fix document upload defaults and deletion confirmation

### DIFF
--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -61,7 +61,7 @@ export default function Settings() {
     fileUrl: "",
     fileSize: 0,
     mimeType: "",
-    isPublic: false,
+    isPublic: true,
     accountId: "",
   };
 
@@ -1176,14 +1176,38 @@ export default function Settings() {
                               </div>
                             </div>
                           </div>
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            onClick={() => deleteDocumentMutation.mutate(document.id)}
-                            className="text-red-500 hover:text-red-700"
-                          >
-                            <i className="fas fa-trash"></i>
-                          </Button>
+                          <AlertDialog>
+                            <AlertDialogTrigger asChild>
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                className="text-red-500 hover:text-red-700"
+                              >
+                                <Trash2 className="h-4 w-4" />
+                              </Button>
+                            </AlertDialogTrigger>
+                            <AlertDialogContent>
+                              <AlertDialogHeader>
+                                <AlertDialogTitle>Delete document?</AlertDialogTitle>
+                                <AlertDialogDescription>
+                                  This action cannot be undone. The document "{document.title}" will no longer be available to
+                                  consumers.
+                                </AlertDialogDescription>
+                              </AlertDialogHeader>
+                              <AlertDialogFooter>
+                                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                                <AlertDialogAction asChild>
+                                  <Button
+                                    variant="destructive"
+                                    onClick={() => deleteDocumentMutation.mutate(document.id)}
+                                    disabled={deleteDocumentMutation.isPending}
+                                  >
+                                    Delete
+                                  </Button>
+                                </AlertDialogAction>
+                              </AlertDialogFooter>
+                            </AlertDialogContent>
+                          </AlertDialog>
                         </div>
                       ))}
                     </div>


### PR DESCRIPTION
## Summary
- default new admin documents to be shared with all consumers so uploads no longer require an account selection
- add a confirmation dialog before deleting a document and reuse the destructive button style

## Testing
- npm test *(fails: missing dev dependency `tsx` because registry access is blocked in the environment)*
- npm install *(fails: 403 Forbidden when fetching npm package registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d459985870832ab2e531cd11672b17