### PR TITLE
Persist agency auth context across subdomains

### DIFF
--- a/client/src/pages/agency-login.tsx
+++ b/client/src/pages/agency-login.tsx
@@ -9,6 +9,7 @@ import { apiRequest, queryClient } from "@/lib/queryClient";
 import { Building2, Lock, Sparkles, UserCheck } from "lucide-react";
 import { z } from "zod";
 import { isSubdomainSupported } from "@shared/utils/subdomain";
+import { setCookie } from "@/lib/cookies";
 import AgencyAuthLayout from "@/components/agency-auth-layout";
 
 const loginSchema = z.object({
@@ -37,8 +38,18 @@ export default function AgencyLogin() {
       // Store the JWT token
       if (result.token) {
         localStorage.setItem('authToken', result.token);
+        setCookie('authToken', result.token);
       }
-      
+
+      // Persist tenant details for cross-subdomain navigation
+      if (result.tenant?.slug) {
+        setCookie('tenantSlug', result.tenant.slug);
+      }
+
+      if (result.tenant?.name) {
+        setCookie('tenantName', encodeURIComponent(result.tenant.name));
+      }
+
       return result;
     },
     onSuccess: (data) => {


### PR DESCRIPTION
## Summary
- persist the agency auth token and tenant identifiers in cookies during login so JWT-based sessions survive cross-subdomain redirects

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d456520260832aa12c4f872ddacaa0