### PR TITLE
Fix document API selections for drizzle types

### DIFF
--- a/api/documents.ts
+++ b/api/documents.ts
@@ -51,19 +51,15 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
           isPublic: documents.isPublic,
           createdAt: documents.createdAt,
           updatedAt: documents.updatedAt,
-          account: {
-            id: accounts.id,
-            accountNumber: accounts.accountNumber,
-            creditor: accounts.creditor,
-            consumerId: accounts.consumerId,
-            consumer: {
-              id: consumers.id,
-              firstName: consumers.firstName,
-              lastName: consumers.lastName,
-              email: consumers.email,
-              phone: consumers.phone,
-            },
-          },
+          linkedAccountId: accounts.id,
+          linkedAccountNumber: accounts.accountNumber,
+          linkedAccountCreditor: accounts.creditor,
+          linkedAccountConsumerId: accounts.consumerId,
+          linkedConsumerId: consumers.id,
+          linkedConsumerFirstName: consumers.firstName,
+          linkedConsumerLastName: consumers.lastName,
+          linkedConsumerEmail: consumers.email,
+          linkedConsumerPhone: consumers.phone,
         })
         .from(documents)
         .leftJoin(accounts, eq(documents.accountId, accounts.id))
@@ -71,23 +67,43 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
         .where(eq(documents.tenantId, tenantId));
 
       const formattedDocuments = tenantDocuments.map((document) => {
-        const { account, ...rest } = document;
+        const {
+          linkedAccountId,
+          linkedAccountNumber,
+          linkedAccountCreditor,
+          linkedAccountConsumerId,
+          linkedConsumerId,
+          linkedConsumerFirstName,
+          linkedConsumerLastName,
+          linkedConsumerEmail,
+          linkedConsumerPhone,
+          ...rest
+        } = document;
 
-        if (!account?.id) {
+        if (!linkedAccountId) {
           return {
             ...rest,
             account: null,
           };
         }
 
-        const consumer = account.consumer?.id
-          ? account.consumer
+        const consumer = linkedConsumerId
+          ? {
+              id: linkedConsumerId,
+              firstName: linkedConsumerFirstName,
+              lastName: linkedConsumerLastName,
+              email: linkedConsumerEmail,
+              phone: linkedConsumerPhone,
+            }
           : null;
 
         return {
           ...rest,
           account: {
-            ...account,
+            id: linkedAccountId,
+            accountNumber: linkedAccountNumber,
+            creditor: linkedAccountCreditor,
+            consumerId: linkedAccountConsumerId,
             consumer,
           },
         };

--- a/api/documents/[id].ts
+++ b/api/documents/[id].ts
@@ -61,19 +61,15 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
           isPublic: documents.isPublic,
           createdAt: documents.createdAt,
           updatedAt: documents.updatedAt,
-          account: {
-            id: accounts.id,
-            accountNumber: accounts.accountNumber,
-            creditor: accounts.creditor,
-            consumerId: accounts.consumerId,
-            consumer: {
-              id: consumers.id,
-              firstName: consumers.firstName,
-              lastName: consumers.lastName,
-              email: consumers.email,
-              phone: consumers.phone,
-            },
-          },
+          linkedAccountId: accounts.id,
+          linkedAccountNumber: accounts.accountNumber,
+          linkedAccountCreditor: accounts.creditor,
+          linkedAccountConsumerId: accounts.consumerId,
+          linkedConsumerId: consumers.id,
+          linkedConsumerFirstName: consumers.firstName,
+          linkedConsumerLastName: consumers.lastName,
+          linkedConsumerEmail: consumers.email,
+          linkedConsumerPhone: consumers.phone,
         })
         .from(documents)
         .leftJoin(accounts, eq(documents.accountId, accounts.id))
@@ -90,21 +86,43 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
       }
 
       const formattedDocument = (() => {
-        const { account, ...rest } = document;
+        const {
+          linkedAccountId,
+          linkedAccountNumber,
+          linkedAccountCreditor,
+          linkedAccountConsumerId,
+          linkedConsumerId,
+          linkedConsumerFirstName,
+          linkedConsumerLastName,
+          linkedConsumerEmail,
+          linkedConsumerPhone,
+          ...rest
+        } = document;
 
-        if (!account?.id) {
+        if (!linkedAccountId) {
           return {
             ...rest,
             account: null,
           };
         }
 
-        const consumer = account.consumer?.id ? account.consumer : null;
+        const consumer = linkedConsumerId
+          ? {
+              id: linkedConsumerId,
+              firstName: linkedConsumerFirstName,
+              lastName: linkedConsumerLastName,
+              email: linkedConsumerEmail,
+              phone: linkedConsumerPhone,
+            }
+          : null;
 
         return {
           ...rest,
           account: {
-            ...account,
+            id: linkedAccountId,
+            accountNumber: linkedAccountNumber,
+            creditor: linkedAccountCreditor,
+            consumerId: linkedAccountConsumerId,
             consumer,
           },
         };


### PR DESCRIPTION
## Summary
- adjust document list and detail queries to select joined columns without nested objects
- reconstruct account and consumer payloads in application code to match previous response shape

## Testing
- npm run check *(fails: existing type errors in unrelated files such as communications.tsx, payments.tsx, requests.tsx, emailService.ts, replitAuth.ts, routes.ts, storage.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d45df4c718832a9572e07a2a53fe72