### PR TITLE
Improve tenant slug persistence across hosts

### DIFF
--- a/client/src/hooks/useAuth.ts
+++ b/client/src/hooks/useAuth.ts
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
-import { getAuthToken, getCookie } from "@/lib/cookies";
+import { getAuthToken, getStoredTenantName, getStoredTenantSlug, persistTenantMetadata } from "@/lib/cookies";
 
 export function useAuth() {
   const [jwtAuth, setJwtAuth] = useState<any>(null);
@@ -26,10 +26,12 @@ export function useAuth() {
             localStorage.removeItem('authToken');
             setJwtAuth(null);
           } else {
-            // Get tenant info from cookies
-            const tenantSlug = getCookie('tenantSlug') || payload.tenantSlug;
-            const tenantName = getCookie('tenantName') ? decodeURIComponent(getCookie('tenantName')!) : payload.tenantName;
-            
+            // Get tenant info from storage
+            const tenantSlug = getStoredTenantSlug() || payload.tenantSlug;
+            const tenantName = getStoredTenantName() || payload.tenantName;
+
+            persistTenantMetadata({ slug: tenantSlug, name: tenantName });
+
             setJwtAuth({
               id: payload.userId,
               tenantId: payload.tenantId,

--- a/client/src/pages/agency-login.tsx
+++ b/client/src/pages/agency-login.tsx
@@ -9,7 +9,7 @@ import { apiRequest, queryClient } from "@/lib/queryClient";
 import { Building2, Lock, Sparkles, UserCheck } from "lucide-react";
 import { z } from "zod";
 import { isSubdomainSupported } from "@shared/utils/subdomain";
-import { setCookie } from "@/lib/cookies";
+import { persistTenantMetadata, setCookie } from "@/lib/cookies";
 import AgencyAuthLayout from "@/components/agency-auth-layout";
 
 const loginSchema = z.object({
@@ -42,13 +42,10 @@ export default function AgencyLogin() {
       }
 
       // Persist tenant details for cross-subdomain navigation
-      if (result.tenant?.slug) {
-        setCookie('tenantSlug', result.tenant.slug);
-      }
-
-      if (result.tenant?.name) {
-        setCookie('tenantName', encodeURIComponent(result.tenant.name));
-      }
+      persistTenantMetadata({
+        slug: result.tenant?.slug,
+        name: result.tenant?.name,
+      });
 
       return result;
     },


### PR DESCRIPTION
## Summary
- add helpers to persist and retrieve tenant slug/name across cookies and storage so agency context survives cross-origin hosting
- update agency login and auth hooks to use the new helpers when storing or restoring tenant metadata
- enhance the agency context hook to fall back to stored slug data when the current URL does not contain an agency segment

## Testing
- npm test
- time npx tsc --noEmit --pretty false *(fails: pre-existing type errors in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68d4ae2e0f10832a8583eabdba373b54