### PR TITLE
Allow unauthenticated OPTIONS requests for API routes

### DIFF
--- a/api/_lib/auth.ts
+++ b/api/_lib/auth.ts
@@ -66,8 +66,14 @@ export async function verifyAuth(req: AuthenticatedRequest): Promise<boolean> {
 
 export function withAuth(handler: (req: AuthenticatedRequest, res: VercelResponse) => Promise<void>) {
   return async (req: AuthenticatedRequest, res: VercelResponse) => {
+    // Allow CORS preflight requests to proceed without authentication
+    if (req.method?.toUpperCase() === 'OPTIONS') {
+      res.status(200).end();
+      return;
+    }
+
     const isAuthenticated = await verifyAuth(req);
-    
+
     if (!isAuthenticated) {
       return res.status(401).json({ error: 'Unauthorized' });
     }


### PR DESCRIPTION
## Summary
- allow CORS preflight OPTIONS requests to bypass auth in the shared API auth wrapper so DELETE calls are no longer rejected before reaching the handler

## Testing
- npm run check *(fails: existing TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d54d26d7ac832a98bc1a69178a0664