### PR TITLE
Fix DELETE handlers to tolerate lowercase methods

### DIFF
--- a/api/accounts.ts
+++ b/api/accounts.ts
@@ -24,7 +24,9 @@ function resolveAccountId(req: AuthenticatedRequest) {
 }
 
 async function handler(req: AuthenticatedRequest, res: VercelResponse) {
-  if (req.method === 'OPTIONS') {
+  const method = (req.method ?? '').toUpperCase();
+
+  if (method === 'OPTIONS') {
     res.status(200).end();
     return;
   }
@@ -49,7 +51,7 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
       return;
     }
 
-    if (req.method === 'GET') {
+    if (method === 'GET') {
       // Get all accounts for the tenant
       const tenantAccounts = await db
         .select({
@@ -89,7 +91,7 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
         .where(eq(accounts.tenantId, tenantId));
 
       res.status(200).json(tenantAccounts);
-    } else if (req.method === 'POST') {
+    } else if (method === 'POST') {
       // Create a new account
       const {
         firstName, lastName, email, phone,
@@ -208,7 +210,7 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
         .returning();
 
       res.status(201).json(newAccount);
-    } else if (req.method === 'PATCH') {
+    } else if (method === 'PATCH') {
       const queryId = req.query.id;
       let accountId: string | undefined;
 
@@ -370,7 +372,7 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
         .limit(1);
 
       res.status(200).json(updatedAccount);
-    } else if (req.method === 'DELETE') {
+    } else if (method === 'DELETE') {
       // Delete an account - supports /api/accounts?id=<accountId> and /api/accounts/<accountId>
       const accountId = resolveAccountId(req);
 

--- a/api/accounts/[id].ts
+++ b/api/accounts/[id].ts
@@ -6,7 +6,9 @@ import { eq, and } from 'drizzle-orm';
 import jwt from 'jsonwebtoken';
 
 async function handler(req: AuthenticatedRequest, res: VercelResponse) {
-  if (req.method === 'OPTIONS') {
+  const method = (req.method ?? '').toUpperCase();
+
+  if (method === 'OPTIONS') {
     res.status(200).end();
     return;
   }
@@ -37,7 +39,7 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
       return;
     }
 
-    if (req.method === 'GET') {
+    if (method === 'GET') {
       // Get single account
       const [account] = await db
         .select()
@@ -54,7 +56,7 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
       }
 
       res.status(200).json(account);
-    } else if (req.method === 'DELETE') {
+    } else if (method === 'DELETE') {
       // Check if account exists and belongs to tenant
       const [account] = await db
         .select()
@@ -79,7 +81,7 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
         ));
 
       res.status(200).json({ success: true, message: 'Account deleted successfully' });
-    } else if (req.method === 'PATCH') {
+    } else if (method === 'PATCH') {
       // Update account
       const { accountNumber, creditor, balanceCents, dueDate, status } = req.body;
 

--- a/api/accounts/bulk-delete.ts
+++ b/api/accounts/bulk-delete.ts
@@ -6,12 +6,14 @@ import { eq, and, inArray } from 'drizzle-orm';
 import jwt from 'jsonwebtoken';
 
 async function handler(req: AuthenticatedRequest, res: VercelResponse) {
-  if (req.method === 'OPTIONS') {
+  const method = (req.method ?? '').toUpperCase();
+
+  if (method === 'OPTIONS') {
     res.status(200).end();
     return;
   }
 
-  if (req.method !== 'DELETE') {
+  if (method !== 'DELETE') {
     res.status(405).json({ error: 'Method not allowed' });
     return;
   }

--- a/api/arrangement-options.ts
+++ b/api/arrangement-options.ts
@@ -10,7 +10,9 @@ interface AuthenticatedRequest extends VercelRequest {
 }
 
 async function handler(req: AuthenticatedRequest, res: VercelResponse) {
-  if (req.method === 'OPTIONS') {
+  const method = (req.method ?? '').toUpperCase();
+
+  if (method === 'OPTIONS') {
     res.status(200).end();
     return;
   }
@@ -146,7 +148,7 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
       return;
     }
 
-    if (req.method === 'GET') {
+    if (method === 'GET') {
       // Get all arrangement options for the tenant
       const options = await db
         .select()
@@ -154,7 +156,7 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
         .where(eq(arrangementOptions.tenantId, tenantId));
 
       res.status(200).json(options);
-    } else if (req.method === 'POST') {
+    } else if (method === 'POST') {
       // Create a new arrangement option
       const name = typeof req.body.name === 'string' ? req.body.name.trim() : '';
       const planTypeRaw = typeof req.body.planType === 'string' ? req.body.planType : 'range';

--- a/api/arrangement-options/[id].ts
+++ b/api/arrangement-options/[id].ts
@@ -13,7 +13,9 @@ interface AuthenticatedRequest extends VercelRequest {
 }
 
 async function handler(req: AuthenticatedRequest, res: VercelResponse) {
-  if (req.method === 'OPTIONS') {
+  const method = (req.method ?? '').toUpperCase();
+
+  if (method === 'OPTIONS') {
     res.status(200).end();
     return;
   }
@@ -45,7 +47,7 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
       return;
     }
 
-    if (req.method === 'GET') {
+    if (method === 'GET') {
       // Get a specific arrangement option
       const [option] = await db
         .select()
@@ -62,7 +64,7 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
       }
 
       res.status(200).json(option);
-    } else if (req.method === 'DELETE') {
+    } else if (method === 'DELETE') {
       // Check if option belongs to tenant
       const [option] = await db
         .select()

--- a/api/automations.ts
+++ b/api/automations.ts
@@ -305,7 +305,9 @@ function resolveAutomationId(req: AuthenticatedRequest) {
 }
 
 async function handler(req: AuthenticatedRequest, res: VercelResponse) {
-  if (req.method === 'OPTIONS') {
+  const method = (req.method ?? '').toUpperCase();
+
+  if (method === 'OPTIONS') {
     res.status(200).end();
     return;
   }
@@ -330,7 +332,7 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
       return;
     }
 
-    if (req.method === 'GET') {
+    if (method === 'GET') {
       // Get all automations for the tenant
       const automations = await db
         .select()
@@ -339,7 +341,7 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
         .orderBy(desc(communicationAutomations.createdAt));
 
       res.status(200).json(automations.map(formatAutomation));
-    } else if (req.method === 'POST') {
+    } else if (method === 'POST') {
       // Create a new automation aligned with the updated communications UI
       const body = req.body || {};
 
@@ -546,7 +548,7 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
         .returning();
 
       res.status(201).json(formatAutomation(newAutomation));
-    } else if (req.method === 'PUT') {
+    } else if (method === 'PUT') {
       // Update automation (activate/deactivate or modify settings)
       const automationId = resolveAutomationId(req);
       const updates = req.body;
@@ -582,7 +584,7 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
         .returning();
 
       res.status(200).json(updatedAutomation);
-    } else if (req.method === 'DELETE') {
+    } else if (method === 'DELETE') {
       // Delete an automation
       const automationId = resolveAutomationId(req);
 

--- a/api/consumers.ts
+++ b/api/consumers.ts
@@ -6,7 +6,9 @@ import { eq, and, sql, inArray } from 'drizzle-orm';
 import jwt from 'jsonwebtoken';
 
 async function handler(req: AuthenticatedRequest, res: VercelResponse) {
-  if (req.method === 'OPTIONS') {
+  const method = (req.method ?? '').toUpperCase();
+
+  if (method === 'OPTIONS') {
     res.status(200).end();
     return;
   }
@@ -31,7 +33,7 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
       return;
     }
 
-    if (req.method === 'GET') {
+    if (method === 'GET') {
       // Get all consumers for the tenant with their folders
       const tenantConsumers = await db
         .select({
@@ -81,7 +83,7 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
       }));
 
       res.status(200).json(consumersWithCounts);
-    } else if (req.method === 'PATCH') {
+    } else if (method === 'PATCH') {
       // Update consumer information
       const consumerId = req.url?.split('/').pop();
       
@@ -118,7 +120,7 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
         .returning();
       
       res.status(200).json(updatedConsumer);
-    } else if (req.method === 'DELETE') {
+    } else if (method === 'DELETE') {
       // Handle consumer deletion
       const normalizeIds = (value: unknown): string[] => {
         if (!value && value !== 0) {

--- a/api/documents/[id].ts
+++ b/api/documents/[id].ts
@@ -13,7 +13,9 @@ interface AuthenticatedRequest extends VercelRequest {
 }
 
 async function handler(req: AuthenticatedRequest, res: VercelResponse) {
-  if (req.method === 'OPTIONS') {
+  const method = (req.method ?? '').toUpperCase();
+
+  if (method === 'OPTIONS') {
     res.status(200).end();
     return;
   }
@@ -45,7 +47,7 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
       return;
     }
 
-    if (req.method === 'GET') {
+    if (method === 'GET') {
       // Get a specific document including related account & consumer info if available
       const [document] = await db
         .select({
@@ -122,7 +124,7 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
       })();
 
       res.status(200).json(formattedDocument);
-    } else if (req.method === 'DELETE') {
+    } else if (method === 'DELETE') {
       // Check if document belongs to tenant
       const [document] = await db
         .select()

--- a/api/email-campaigns.ts
+++ b/api/email-campaigns.ts
@@ -24,7 +24,9 @@ function resolveCampaignId(req: AuthenticatedRequest) {
 }
 
 async function handler(req: AuthenticatedRequest, res: VercelResponse) {
-  if (req.method === 'OPTIONS') {
+  const method = (req.method ?? '').toUpperCase();
+
+  if (method === 'OPTIONS') {
     res.status(200).end();
     return;
   }
@@ -49,7 +51,7 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
       return;
     }
 
-    if (req.method === 'GET') {
+    if (method === 'GET') {
       // Get all email campaigns for the tenant
       const campaigns = await db
         .select()
@@ -58,7 +60,7 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
         .orderBy(desc(emailCampaigns.createdAt));
 
       res.status(200).json(campaigns);
-    } else if (req.method === 'POST') {
+    } else if (method === 'POST') {
       // Create a new email campaign
       const { templateId, name, targetGroup } = req.body;
 
@@ -133,7 +135,7 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
         .returning();
 
       res.status(201).json(newCampaign);
-    } else if (req.method === 'PUT') {
+    } else if (method === 'PUT') {
       // Update campaign status (start/pause/cancel)
       const { campaignId, status } = req.body;
 
@@ -171,7 +173,7 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
         .returning();
 
       res.status(200).json(updatedCampaign);
-    } else if (req.method === 'DELETE') {
+    } else if (method === 'DELETE') {
       // Delete a campaign
       const campaignId = resolveCampaignId(req);
 

--- a/api/email-templates.ts
+++ b/api/email-templates.ts
@@ -24,7 +24,9 @@ function resolveTemplateId(req: AuthenticatedRequest) {
 }
 
 async function handler(req: AuthenticatedRequest, res: VercelResponse) {
-  if (req.method === 'OPTIONS') {
+  const method = (req.method ?? '').toUpperCase();
+
+  if (method === 'OPTIONS') {
     res.status(200).end();
     return;
   }
@@ -49,7 +51,7 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
       return;
     }
 
-    if (req.method === 'GET') {
+    if (method === 'GET') {
       // Get all email templates for the tenant
       const templates = await db
         .select()
@@ -58,7 +60,7 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
         .orderBy(desc(emailTemplates.createdAt));
 
       res.status(200).json(templates);
-    } else if (req.method === 'POST') {
+    } else if (method === 'POST') {
       // Create a new email template
       const { name, subject, html, status } = req.body;
 
@@ -79,7 +81,7 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
         .returning();
 
       res.status(201).json(newTemplate);
-    } else if (req.method === 'DELETE') {
+    } else if (method === 'DELETE') {
       // Delete an email template - supports /api/email-templates?id=<templateId> and /api/email-templates/<templateId>
       const templateId = resolveTemplateId(req);
 

--- a/api/email-templates/[id].ts
+++ b/api/email-templates/[id].ts
@@ -6,12 +6,14 @@ import { eq, and } from 'drizzle-orm';
 import jwt from 'jsonwebtoken';
 
 async function handler(req: AuthenticatedRequest, res: VercelResponse) {
-  if (req.method === 'OPTIONS') {
+  const method = (req.method ?? '').toUpperCase();
+
+  if (method === 'OPTIONS') {
     res.status(200).end();
     return;
   }
 
-  if (req.method !== 'DELETE') {
+  if (method !== 'DELETE') {
     res.status(405).json({ error: 'Method not allowed' });
     return;
   }

--- a/api/sms-campaigns.ts
+++ b/api/sms-campaigns.ts
@@ -24,7 +24,9 @@ function resolveCampaignId(req: AuthenticatedRequest) {
 }
 
 async function handler(req: AuthenticatedRequest, res: VercelResponse) {
-  if (req.method === 'OPTIONS') {
+  const method = (req.method ?? '').toUpperCase();
+
+  if (method === 'OPTIONS') {
     res.status(200).end();
     return;
   }
@@ -49,7 +51,7 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
       return;
     }
 
-    if (req.method === 'GET') {
+    if (method === 'GET') {
       // Get all SMS campaigns for the tenant
       const campaigns = await db
         .select()
@@ -58,7 +60,7 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
         .orderBy(desc(smsCampaigns.createdAt));
 
       res.status(200).json(campaigns);
-    } else if (req.method === 'POST') {
+    } else if (method === 'POST') {
       // Create a new SMS campaign
       const { templateId, name, targetGroup, throttleRate } = req.body;
 
@@ -128,7 +130,7 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
         .returning();
 
       res.status(201).json(newCampaign);
-    } else if (req.method === 'PUT') {
+    } else if (method === 'PUT') {
       // Update campaign status (start/pause/cancel)
       const { campaignId, status } = req.body;
 
@@ -166,7 +168,7 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
         .returning();
 
       res.status(200).json(updatedCampaign);
-    } else if (req.method === 'DELETE') {
+    } else if (method === 'DELETE') {
       // Delete a campaign
       const campaignId = resolveCampaignId(req);
 

--- a/api/sms-templates.ts
+++ b/api/sms-templates.ts
@@ -24,7 +24,9 @@ function resolveTemplateId(req: AuthenticatedRequest) {
 }
 
 async function handler(req: AuthenticatedRequest, res: VercelResponse) {
-  if (req.method === 'OPTIONS') {
+  const method = (req.method ?? '').toUpperCase();
+
+  if (method === 'OPTIONS') {
     res.status(200).end();
     return;
   }
@@ -49,7 +51,7 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
       return;
     }
 
-    if (req.method === 'GET') {
+    if (method === 'GET') {
       // Get all SMS templates for the tenant
       const templates = await db
         .select()
@@ -58,7 +60,7 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
         .orderBy(desc(smsTemplates.createdAt));
 
       res.status(200).json(templates);
-    } else if (req.method === 'POST') {
+    } else if (method === 'POST') {
       // Create a new SMS template
       const { name, message } = req.body;
 
@@ -77,7 +79,7 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
         .returning();
 
       res.status(201).json(newTemplate);
-    } else if (req.method === 'DELETE') {
+    } else if (method === 'DELETE') {
       // Delete an SMS template - supports /api/sms-templates?id=<templateId> and /api/sms-templates/<templateId>
       const templateId = resolveTemplateId(req);
 


### PR DESCRIPTION
## Summary
- normalize HTTP method handling in serverless API routes so DELETE handlers work even when the verb arrives in lowercase
- apply the normalization across accounts, consumers, arrangements, templates, campaigns, automations, and documents endpoints to eliminate spurious 405 responses

## Testing
- `npm run check` *(fails: pre-existing TypeScript issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d54d26d7ac832a98bc1a69178a0664