### PR TITLE
Align communications/billing/settings tabs with gradient theme

### DIFF
--- a/client/src/components/ui/button.tsx
+++ b/client/src/components/ui/button.tsx
@@ -5,25 +5,27 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-xl text-sm font-semibold ring-offset-background transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/60 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-60 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        default:
+          "border border-white/15 bg-gradient-to-r from-sky-500/80 to-indigo-500/80 text-white shadow-lg shadow-blue-900/30 hover:from-sky-400/80 hover:to-indigo-400/80",
         destructive:
-          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+          "border border-rose-400/40 bg-rose-500/80 text-white shadow-lg shadow-rose-900/30 hover:bg-rose-500",
         outline:
-          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+          "border border-white/15 bg-white/5 text-blue-100 hover:bg-white/10 hover:text-white",
         secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 hover:underline",
+          "border border-white/10 bg-white/10 text-blue-100 shadow-sm shadow-blue-900/20 hover:bg-white/20 hover:text-white",
+        ghost:
+          "text-blue-100 hover:bg-white/10 hover:text-white",
+        link: "text-sky-300 underline-offset-4 hover:text-white hover:underline",
       },
       size: {
-        default: "h-10 px-4 py-2",
-        sm: "h-9 rounded-md px-3",
-        lg: "h-11 rounded-md px-8",
-        icon: "h-10 w-10",
+        default: "h-11 px-5",
+        sm: "h-10 rounded-lg px-4",
+        lg: "h-12 rounded-2xl px-7",
+        icon: "h-11 w-11",
       },
     },
     defaultVariants: {

--- a/client/src/components/ui/tabs.tsx
+++ b/client/src/components/ui/tabs.tsx
@@ -12,7 +12,7 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
+      "inline-flex flex-wrap items-center gap-1 rounded-2xl border border-white/10 bg-white/5 p-1 text-sm text-blue-100 shadow-lg shadow-blue-900/20 backdrop-blur",
       className
     )}
     {...props}
@@ -27,7 +27,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+      "inline-flex items-center justify-center whitespace-nowrap rounded-xl px-4 py-2 text-sm font-semibold text-blue-100 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/60 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 hover:text-white data-[state=active]:bg-gradient-to-r data-[state=active]:from-sky-500/80 data-[state=active]:to-indigo-500/80 data-[state=active]:text-white data-[state=active]:shadow-lg data-[state=active]:shadow-blue-900/40",
       className
     )}
     {...props}

--- a/client/src/pages/billing.tsx
+++ b/client/src/pages/billing.tsx
@@ -332,26 +332,14 @@ export default function Billing() {
         </section>
 
         <Tabs defaultValue="overview" className="space-y-8">
-          <TabsList className="flex w-full flex-wrap items-center gap-2 rounded-2xl border border-white/10 bg-white/10 p-1 text-sm text-blue-100/80 sm:w-auto">
-            <TabsTrigger
-              value="overview"
-              data-testid="tab-overview"
-              className="rounded-xl px-4 py-2 font-semibold transition data-[state=active]:bg-white/25 data-[state=active]:text-white"
-            >
+          <TabsList className="flex w-full flex-wrap items-center gap-2 p-1 sm:w-auto">
+            <TabsTrigger value="overview" data-testid="tab-overview" className="px-4 py-2">
               Overview
             </TabsTrigger>
-            <TabsTrigger
-              value="invoices"
-              data-testid="tab-invoices"
-              className="rounded-xl px-4 py-2 font-semibold transition data-[state=active]:bg-white/25 data-[state=active]:text-white"
-            >
+            <TabsTrigger value="invoices" data-testid="tab-invoices" className="px-4 py-2">
               Invoices
             </TabsTrigger>
-            <TabsTrigger
-              value="subscription"
-              data-testid="tab-subscription"
-              className="rounded-xl px-4 py-2 font-semibold transition data-[state=active]:bg-white/25 data-[state=active]:text-white"
-            >
+            <TabsTrigger value="subscription" data-testid="tab-subscription" className="px-4 py-2">
               Subscription
             </TabsTrigger>
           </TabsList>

--- a/client/src/pages/communications.tsx
+++ b/client/src/pages/communications.tsx
@@ -656,35 +656,20 @@ export default function Communications() {
         </section>
 
         <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-10">
-          <TabsList className="grid w-full grid-cols-5 gap-2 rounded-2xl border border-white/10 bg-white/5 p-2 text-sm font-semibold text-blue-100">
-            <TabsTrigger
-              value="overview"
-              className="rounded-xl px-4 py-2.5 transition data-[state=active]:bg-white/90 data-[state=active]:text-slate-900 data-[state=active]:shadow-lg"
-            >
+          <TabsList className="grid w-full grid-cols-5 gap-2 p-2">
+            <TabsTrigger value="overview" className="px-4 py-2.5">
               Overview
             </TabsTrigger>
-            <TabsTrigger
-              value="templates"
-              className="rounded-xl px-4 py-2.5 transition data-[state=active]:bg-white/90 data-[state=active]:text-slate-900 data-[state=active]:shadow-lg"
-            >
+            <TabsTrigger value="templates" className="px-4 py-2.5">
               Templates
             </TabsTrigger>
-            <TabsTrigger
-              value="campaigns"
-              className="rounded-xl px-4 py-2.5 transition data-[state=active]:bg-white/90 data-[state=active]:text-slate-900 data-[state=active]:shadow-lg"
-            >
+            <TabsTrigger value="campaigns" className="px-4 py-2.5">
               Campaigns
             </TabsTrigger>
-            <TabsTrigger
-              value="automation"
-              className="rounded-xl px-4 py-2.5 transition data-[state=active]:bg-white/90 data-[state=active]:text-slate-900 data-[state=active]:shadow-lg"
-            >
+            <TabsTrigger value="automation" className="px-4 py-2.5">
               Automation
             </TabsTrigger>
-            <TabsTrigger
-              value="requests"
-              className="rounded-xl px-4 py-2.5 transition data-[state=active]:bg-white/90 data-[state=active]:text-slate-900 data-[state=active]:shadow-lg"
-            >
+            <TabsTrigger value="requests" className="px-4 py-2.5">
               Callback Requests
             </TabsTrigger>
           </TabsList>

--- a/client/src/pages/payments.tsx
+++ b/client/src/pages/payments.tsx
@@ -9,7 +9,6 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Badge } from "@/components/ui/badge";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { CreditCard, DollarSign, TrendingUp, Clock, CheckCircle, XCircle, RefreshCw, Calendar, User, Building2, Lock } from "lucide-react";
 

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -683,35 +683,20 @@ export default function Settings() {
 
         <section className="rounded-3xl border border-white/10 bg-white/5 p-6 shadow-lg shadow-blue-900/20 backdrop-blur">
           <Tabs defaultValue="general" className="space-y-8">
-            <TabsList className="grid w-full grid-cols-1 gap-2 rounded-2xl border border-white/10 bg-white/10 p-2 text-blue-100 sm:grid-cols-5">
-              <TabsTrigger
-                value="general"
-                className="rounded-xl px-4 py-2 text-sm font-semibold transition data-[state=active]:bg-gradient-to-r data-[state=active]:from-sky-500/80 data-[state=active]:to-indigo-500/80 data-[state=active]:text-white data-[state=active]:shadow-lg data-[state=active]:shadow-blue-900/40"
-              >
+            <TabsList className="grid w-full grid-cols-1 gap-2 p-2 text-blue-100 sm:grid-cols-5">
+              <TabsTrigger value="general" className="px-4 py-2">
                 General
               </TabsTrigger>
-              <TabsTrigger
-                value="merchant"
-                className="rounded-xl px-4 py-2 text-sm font-semibold transition data-[state=active]:bg-gradient-to-r data-[state=active]:from-sky-500/80 data-[state=active]:to-indigo-500/80 data-[state=active]:text-white data-[state=active]:shadow-lg data-[state=active]:shadow-blue-900/40"
-              >
+              <TabsTrigger value="merchant" className="px-4 py-2">
                 Payment Processing
               </TabsTrigger>
-              <TabsTrigger
-                value="documents"
-                className="rounded-xl px-4 py-2 text-sm font-semibold transition data-[state=active]:bg-gradient-to-r data-[state=active]:from-sky-500/80 data-[state=active]:to-indigo-500/80 data-[state=active]:text-white data-[state=active]:shadow-lg data-[state=active]:shadow-blue-900/40"
-              >
+              <TabsTrigger value="documents" className="px-4 py-2">
                 Documents
               </TabsTrigger>
-              <TabsTrigger
-                value="arrangements"
-                className="rounded-xl px-4 py-2 text-sm font-semibold transition data-[state=active]:bg-gradient-to-r data-[state=active]:from-sky-500/80 data-[state=active]:to-indigo-500/80 data-[state=active]:text-white data-[state=active]:shadow-lg data-[state=active]:shadow-blue-900/40"
-              >
+              <TabsTrigger value="arrangements" className="px-4 py-2">
                 Payment Plans
               </TabsTrigger>
-              <TabsTrigger
-                value="privacy"
-                className="rounded-xl px-4 py-2 text-sm font-semibold transition data-[state=active]:bg-gradient-to-r data-[state=active]:from-sky-500/80 data-[state=active]:to-indigo-500/80 data-[state=active]:text-white data-[state=active]:shadow-lg data-[state=active]:shadow-blue-900/40"
-              >
+              <TabsTrigger value="privacy" className="px-4 py-2">
                 Privacy & Legal
               </TabsTrigger>
             </TabsList>


### PR DESCRIPTION
## Summary
- rely on the shared gradient/glass styling for communications, billing, and settings tab lists
- remove per-page active state overrides so tab triggers pick up the unified hover/active treatments
- keep page-specific spacing/layout adjustments while letting the new theme drive visuals

## Testing
- `npm run check` *(fails: existing TypeScript errors in communications, payments, requests, emailService, replitAuth, routes, storage)*

------
https://chatgpt.com/codex/tasks/task_e_68d53f416a20832abbd87b5a95d62ba2