### PR TITLE
Fix platform admin authentication gating

### DIFF
--- a/server/authMiddleware.ts
+++ b/server/authMiddleware.ts
@@ -16,6 +16,7 @@ export const authenticateUser: RequestHandler = async (req: any, res, next) => {
       // Attach user info from JWT
       req.user = {
         id: decoded.userId,
+        userId: decoded.userId,
         tenantId: decoded.tenantId,
         tenantSlug: decoded.tenantSlug,
         isJwtAuth: true,

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -3743,12 +3743,16 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   // Global Admin Routes (Platform Owner Only)
   const isPlatformAdmin = async (req: any, res: any, next: any) => {
-    const userId = req.user?.userId;
-    
+    const userId = req.user?.id ?? req.user?.userId;
+
+    if (!userId) {
+      return res.status(401).json({ message: "Unauthorized" });
+    }
+
     // Check if user has platform_admin role (they might have multiple roles)
     const userRoles = await db.select().from(platformUsers).where(eq(platformUsers.authId, userId));
     const hasPlatformAdminRole = userRoles.some((user: any) => user.role === 'platform_admin');
-    
+
     if (!hasPlatformAdminRole) {
       return res.status(403).json({ message: "Platform admin access required" });
     }


### PR DESCRIPTION
## Summary
- ensure JWT-authenticated requests expose the userId field expected by downstream middleware
- update the platform admin guard to read either id or userId and fail fast when no identifier is present

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d57a3d0598832aab6a25e12b7338e6