### PR TITLE
Align consumer login responses with session payload contract

### DIFF
--- a/api/consumer/login.ts
+++ b/api/consumer/login.ts
@@ -97,7 +97,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           slug: row.tenant!.slug
         }));
 
-        return res.status(200).json({
+        return res.status(409).json({
           multipleAgencies: true,
           message: 'Your account is registered with multiple agencies. Please select one:',
           agencies,
@@ -124,7 +124,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           consumer = firstConsumer;
           // Flow will continue and fetch tenant by ID below
         } else {
-          return res.status(200).json({
+          return res.status(409).json({
             message: 'Your account needs to be linked to an agency. Please complete registration.',
             needsAgencyLink: true,
             consumer: {
@@ -161,7 +161,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     }
 
     if (!tenant) {
-      return res.status(200).json({
+      return res.status(409).json({
         message: 'Your account needs to be linked to an agency. Please complete registration.',
         needsAgencyLink: true,
         consumer: {
@@ -175,7 +175,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     }
 
     if (!consumer.isRegistered) {
-      return res.status(200).json({
+      return res.status(409).json({
         message: 'Account found but not yet activated. Complete your registration.',
         needsRegistration: true,
         consumer: {
@@ -224,7 +224,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     }
 
     if (!consumer.tenantId) {
-      return res.status(200).json({
+      return res.status(409).json({
         message: 'Your account needs to be linked to an agency. Please complete registration.',
         needsAgencyLink: true,
         consumer: {
@@ -263,7 +263,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         id: tenant.id,
         name: tenant.name,
         slug: tenant.slug
-      }
+      },
+      tenantSlug: tenant.slug
     });
   } catch (error) {
     console.error('Consumer login error:', error);

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2183,7 +2183,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         if (consumersForTenant.length === 0) {
           if (stillUnlinkedConsumers.length > 0) {
             const consumerCandidate = stillUnlinkedConsumers[0];
-            return res.status(200).json({
+            return res.status(409).json({
               message: "Your account needs to be linked to an agency. Please complete registration.",
               needsAgencyLink: true,
               consumer: {
@@ -2206,7 +2206,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         if (linkedConsumers.length === 0) {
           if (stillUnlinkedConsumers.length > 0) {
             const consumerCandidate = stillUnlinkedConsumers[0];
-            return res.status(200).json({
+            return res.status(409).json({
               message: "Your account needs to be linked to an agency. Please complete registration.",
               needsAgencyLink: true,
               consumer: {
@@ -2245,7 +2245,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         }
 
         if (dedupedAgencies.size > 1) {
-          return res.json({
+          return res.status(409).json({
             multipleAgencies: true,
             message: 'Your account is registered with multiple agencies. Please select one:',
             agencies: Array.from(dedupedAgencies.values()).map(({ tenantRecord }) => ({
@@ -2277,7 +2277,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       }
 
       if (!tenant) {
-        return res.status(200).json({
+        return res.status(409).json({
           message: "Your account needs to be linked to an agency. Please complete registration.",
           needsAgencyLink: true,
           consumer: {
@@ -2291,7 +2291,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       }
 
       if (!consumer.isRegistered) {
-        return res.status(200).json({
+        return res.status(409).json({
           message: "Account found but not yet activated. Complete your registration.",
           needsRegistration: true,
           consumer: {
@@ -2328,7 +2328,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         { expiresIn: '7d' }
       );
 
-      res.json({
+      res.status(200).json({
         token,
         consumer: {
           id: consumer.id,
@@ -2339,9 +2339,11 @@ export async function registerRoutes(app: Express): Promise<Server> {
           tenantId: consumer.tenantId,
         },
         tenant: {
+          id: tenant.id,
           name: tenant.name,
           slug: tenant.slug,
         },
+        tenantSlug: tenant.slug,
       });
     } catch (error) {
       console.error("Error during consumer login:", error);


### PR DESCRIPTION
## Summary
- update the Express consumer login handler to return HTTP 409 for multi-agency, registration, and tenant-linking interruptions
- ensure successful consumer login responses include the tenant slug and tenant id along with the token and consumer payload

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d5650e9358832a978a46dc4795780d