### PR TITLE
Clean up storage interface method declarations

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -271,12 +271,8 @@ export interface IStorage {
   
   // Consumer registration operations
   registerConsumer(consumerData: InsertConsumer): Promise<Consumer>;
-  getConsumerByEmailAndTenant(email: string, tenantIdentifier: string): Promise<Consumer | undefined>;
-  getConsumerByEmail(email: string, tenantId: string): Promise<Consumer | undefined>;
-  getTenantBySlug(slug: string): Promise<Tenant | undefined>;
-  
+
   // Account management operations
-  createAccount(account: InsertAccount): Promise<Account>;
   deleteAccount(id: string, tenantId: string): Promise<void>;
   bulkDeleteAccounts(ids: string[], tenantId: string): Promise<number>;
   
@@ -365,7 +361,6 @@ export interface IStorage {
   
   // Company management operations
   getPlatformUsersByTenant(tenantId: string): Promise<(PlatformUser & { userDetails?: User })[]>;
-  updateConsumer(id: string, updates: Partial<Consumer>): Promise<Consumer>;
   
   // Stats operations
   getTenantStats(tenantId: string): Promise<{


### PR DESCRIPTION
## Summary
- remove duplicated method declarations from `IStorage` to align with the implemented methods
- retain a single `getConsumerByEmail` signature that matches the database storage implementation

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d6c1486a14832a91dd7e94498289e7