### PR TITLE
Handle consumer login 409 responses consistently

### DIFF
--- a/client/src/pages/__tests__/consumer-login-flow.test.ts
+++ b/client/src/pages/__tests__/consumer-login-flow.test.ts
@@ -1,9 +1,11 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
+  handleLoginResult,
   retryLoginWithAgencySelection,
   storeAgencyContext,
   type AgencyContext,
+  type ConsumerLoginResult,
   type LoginMutationPayload,
   type LoginForm,
 } from "../consumer-login-helpers";
@@ -73,4 +75,43 @@ test("agency context is written to both storage layers when available", () => {
   const serialized = JSON.stringify(agency);
   assert.deepEqual(storedValues.session, [`agencyContext:${serialized}`]);
   assert.deepEqual(storedValues.local, [`agencyContext:${serialized}`]);
+});
+
+test("handleLoginResult routes 409 responses requiring agency link", () => {
+  const toastCalls: unknown[] = [];
+  const pendingAgencies: AgencyContext[][] = [];
+  const dialogStates: boolean[] = [];
+  const locations: string[] = [];
+
+  const payload: ConsumerLoginResult = {
+    message: "Your account needs to be linked to an agency. Please complete registration.",
+    needsAgencyLink: true,
+  };
+
+  const handled = handleLoginResult(payload, {
+    email: "user@example.com",
+    showToast: options => {
+      toastCalls.push(options);
+    },
+    setPendingAgencies: agencies => {
+      pendingAgencies.push(agencies);
+    },
+    setAgencyDialogOpen: open => {
+      dialogStates.push(open);
+    },
+    setLocation: path => {
+      locations.push(path);
+    },
+  });
+
+  assert.equal(handled, true, "409 payloads should be handled by the helper");
+  assert.deepEqual(pendingAgencies, [], "no agencies should be queued for selection");
+  assert.deepEqual(dialogStates, [], "dialog should not open for agency link flow");
+  assert.deepEqual(locations, ["/consumer-register?email=user@example.com"]);
+  assert.deepEqual(toastCalls, [
+    {
+      title: "Agency Link Required",
+      description: payload.message,
+    },
+  ]);
 });

--- a/client/src/pages/consumer-login-helpers.ts
+++ b/client/src/pages/consumer-login-helpers.ts
@@ -11,6 +11,72 @@ export type AgencyContext = {
 
 export type LoginMutationPayload = LoginForm & { tenantSlug?: string };
 
+export type ConsumerLoginResult = {
+  message?: string;
+  multipleAgencies?: boolean;
+  agencies?: AgencyContext[];
+  needsRegistration?: boolean;
+  needsAgencyLink?: boolean;
+  tenant?: {
+    slug: string;
+    name?: string | null;
+    logoUrl?: string | null;
+  } | null;
+};
+
+export type HandleLoginResultOptions = {
+  email: string;
+  showToast: (options: {
+    title: string;
+    description?: string;
+    variant?: string;
+  }) => void;
+  setPendingAgencies: (agencies: AgencyContext[]) => void;
+  setAgencyDialogOpen: (open: boolean) => void;
+  setLocation: (path: string) => void;
+};
+
+export function handleLoginResult(
+  data: ConsumerLoginResult,
+  {
+    email,
+    showToast,
+    setPendingAgencies,
+    setAgencyDialogOpen,
+    setLocation,
+  }: HandleLoginResultOptions,
+): boolean {
+  if (data.multipleAgencies) {
+    showToast({
+      title: "Choose your agency",
+      description: data.message ?? "Select which agency dashboard to open.",
+    });
+    setPendingAgencies(data.agencies ?? []);
+    setAgencyDialogOpen(true);
+    return true;
+  }
+
+  if (data.needsRegistration && data.tenant?.slug) {
+    showToast({
+      title: "Complete Registration",
+      description: data.message,
+    });
+    setLocation(`/consumer-register?email=${email}&tenant=${data.tenant.slug}`);
+    return true;
+  }
+
+  if (data.needsAgencyLink) {
+    showToast({
+      title: "Agency Link Required",
+      description: data.message,
+    });
+    setLocation(`/consumer-register?email=${email}`);
+    return true;
+  }
+
+  return false;
+}
+
 export interface StorageLike {
   setItem(key: string, value: string): void;
   removeItem?(key: string): void;


### PR DESCRIPTION
## Summary
- extract a reusable login result handler to coordinate agency selection and registration routing
- reuse the handler for 200 success and 409 ApiError paths to avoid falling through to the generic error toast
- add regression coverage that exercises the 409 agency-link flow

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6cb105840832a88117ecf2e516f6b