### PR TITLE
Ensure consumer dashboard queries use authenticated fetcher

### DIFF
--- a/client/src/lib/consumer-auth.ts
+++ b/client/src/lib/consumer-auth.ts
@@ -1,0 +1,125 @@
+type StorageLike = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+export interface ConsumerSession {
+  email: string;
+  tenantSlug: string;
+  consumerData?: unknown;
+}
+
+export const CONSUMER_SESSION_KEY = "consumerSession";
+export const CONSUMER_TOKEN_KEY = "consumerToken";
+
+function isStorageAvailable(storage: Storage | undefined): storage is Storage {
+  if (!storage) {
+    return false;
+  }
+
+  try {
+    const testKey = "__storage_test__";
+    storage.setItem(testKey, testKey);
+    storage.removeItem(testKey);
+    return true;
+  } catch (error) {
+    console.warn("Storage unavailable", error);
+    return false;
+  }
+}
+
+function getStorages(): StorageLike[] {
+  if (typeof window === "undefined") {
+    return [];
+  }
+
+  const storages: StorageLike[] = [];
+
+  if (isStorageAvailable(window.localStorage)) {
+    storages.push(window.localStorage);
+  }
+
+  if (isStorageAvailable(window.sessionStorage)) {
+    storages.push(window.sessionStorage);
+  }
+
+  return storages;
+}
+
+function getFirstValue(key: string): string | null {
+  for (const storage of getStorages()) {
+    const value = storage.getItem(key);
+    if (value) {
+      return value;
+    }
+  }
+  return null;
+}
+
+function setValue(key: string, value: string): boolean {
+  let stored = false;
+  for (const storage of getStorages()) {
+    try {
+      storage.setItem(key, value);
+      stored = true;
+    } catch (error) {
+      console.warn(`Failed to write ${key} to storage`, error);
+    }
+  }
+  return stored;
+}
+
+function removeValue(key: string): void {
+  for (const storage of getStorages()) {
+    try {
+      storage.removeItem(key);
+    } catch (error) {
+      console.warn(`Failed to remove ${key} from storage`, error);
+    }
+  }
+}
+
+export function clearConsumerAuth(): void {
+  removeValue(CONSUMER_SESSION_KEY);
+  removeValue(CONSUMER_TOKEN_KEY);
+}
+
+export function getStoredConsumerToken(): string | null {
+  return getFirstValue(CONSUMER_TOKEN_KEY);
+}
+
+export function getStoredConsumerSession(): ConsumerSession | null {
+  const raw = getFirstValue(CONSUMER_SESSION_KEY);
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as ConsumerSession;
+    if (!parsed?.email || !parsed?.tenantSlug) {
+      throw new Error("Invalid consumer session payload");
+    }
+    return parsed;
+  } catch (error) {
+    console.error("Failed to parse consumer session", error);
+    clearConsumerAuth();
+    return null;
+  }
+}
+
+export function persistConsumerAuth({
+  session,
+  token,
+}: {
+  session: ConsumerSession;
+  token: string;
+}): { sessionStored: boolean; tokenStored: boolean } {
+  const sessionStored = setValue(CONSUMER_SESSION_KEY, JSON.stringify(session));
+  const tokenStored = setValue(CONSUMER_TOKEN_KEY, token);
+
+  if (!sessionStored || !tokenStored) {
+    console.error("Failed to persist consumer auth", { sessionStored, tokenStored });
+  }
+
+  return {
+    sessionStored,
+    tokenStored,
+  };
+}

--- a/client/src/pages/consumer-dashboard.tsx
+++ b/client/src/pages/consumer-dashboard.tsx
@@ -3,6 +3,11 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useLocation } from "wouter";
 import { apiRequest } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
+import {
+  clearConsumerAuth,
+  getStoredConsumerSession,
+  getStoredConsumerToken,
+} from "@/lib/consumer-auth";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -39,48 +44,55 @@ export default function ConsumerDashboard() {
   const [consumerSession, setConsumerSession] = useState<any>(null);
 
   useEffect(() => {
-    const token = localStorage.getItem("consumerToken");
+    const token = getStoredConsumerToken();
     if (!token) {
-      setLocation("/consumer-login");
-    }
-  }, [setLocation]);
-
-  // Get consumer session data
-  useEffect(() => {
-    const sessionData = localStorage.getItem("consumerSession");
-    if (!sessionData) {
-      setLocation("/consumer-login");
-      return;
-    }
-
-    try {
-      const session = JSON.parse(sessionData);
-      setConsumerSession(session);
-      setCallbackForm(prev => ({
-        ...prev,
-        emailAddress: session.email,
-      }));
-    } catch (error) {
       toast({
-        title: "Session Error",
-        description: "Your session has expired. Please log in again.",
+        title: "Not Signed In",
+        description: "Please sign in to access your dashboard.",
         variant: "destructive",
       });
       setLocation("/consumer-login");
     }
   }, [setLocation, toast]);
 
+  // Get consumer session data
+  useEffect(() => {
+    const session = getStoredConsumerSession();
+    if (!session) {
+      toast({
+        title: "Session Expired",
+        description: "We couldn't locate your saved login. Please sign in again to continue.",
+        variant: "destructive",
+      });
+      setLocation("/consumer-login");
+      return;
+    }
+    setConsumerSession(session);
+    setCallbackForm(prev => ({
+      ...prev,
+      emailAddress: session.email,
+    }));
+  }, [setLocation, toast]);
+
   const tenantSlug = consumerSession?.tenantSlug;
   const encodedEmail = consumerSession?.email ? encodeURIComponent(consumerSession.email) : "";
   const encodedTenantSlug = tenantSlug ? encodeURIComponent(tenantSlug) : "";
+  const tenantQuery = encodedTenantSlug ? `?tenantSlug=${encodedTenantSlug}` : "";
 
   const accountsUrl = encodedEmail && encodedTenantSlug
-    ? `/api/consumer/accounts/${encodedEmail}`
+    ? `/api/consumer/accounts/${encodedEmail}${tenantQuery}`
     : "";
 
   // Fetch consumer data
   const { data, isLoading, error } = useQuery({
-    queryKey: accountsUrl ? [accountsUrl] : ['consumer-accounts'],
+    queryKey: accountsUrl ? [accountsUrl] : ["consumer-accounts"],
+    queryFn: async () => {
+      if (!accountsUrl) {
+        return null;
+      }
+      const response = await apiRequest("GET", accountsUrl);
+      return response.json();
+    },
     enabled: !!accountsUrl,
   });
 
@@ -90,14 +102,28 @@ export default function ConsumerDashboard() {
     : "";
 
   const { data: notifications } = useQuery({
-    queryKey: notificationsUrl ? [notificationsUrl] : ['consumer-notifications'],
+    queryKey: notificationsUrl ? [notificationsUrl] : ["consumer-notifications"],
+    queryFn: async () => {
+      if (!notificationsUrl) {
+        return null;
+      }
+      const response = await apiRequest("GET", notificationsUrl);
+      return response.json();
+    },
     enabled: !!notificationsUrl,
   });
 
   const brandingUrl = tenantSlug ? `/api/public/agency-branding?slug=${encodeURIComponent(tenantSlug)}` : "";
 
-  const { data: branding } = useQuery<AgencyBranding>({
-    queryKey: brandingUrl ? [brandingUrl] : ['consumer-agency-branding'],
+  const { data: branding } = useQuery<AgencyBranding | null>({
+    queryKey: brandingUrl ? [brandingUrl] : ["consumer-agency-branding"],
+    queryFn: async () => {
+      if (!brandingUrl) {
+        return null;
+      }
+      const response = await apiRequest("GET", brandingUrl);
+      return response.json();
+    },
     enabled: !!brandingUrl,
   });
 
@@ -186,7 +212,7 @@ export default function ConsumerDashboard() {
   });
 
   const handleLogout = () => {
-    localStorage.removeItem("consumerSession");
+    clearConsumerAuth();
     toast({
       title: "Logged Out",
       description: "You have been logged out successfully.",

--- a/client/src/pages/consumer-login-helpers.ts
+++ b/client/src/pages/consumer-login-helpers.ts
@@ -29,7 +29,7 @@ export type HandleLoginResultOptions = {
   showToast: (options: {
     title: string;
     description?: string;
-    variant?: string;
+    variant?: "default" | "destructive" | null;
   }) => void;
   setPendingAgencies: (agencies: AgencyContext[]) => void;
   setAgencyDialogOpen: (open: boolean) => void;

--- a/client/src/pages/consumer-registration.tsx
+++ b/client/src/pages/consumer-registration.tsx
@@ -11,6 +11,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { UserPlus, ArrowRight, Shield, MapPin, AlertTriangle } from "lucide-react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import PublicHeroLayout from "@/components/public-hero-layout";
+import { clearConsumerAuth } from "@/lib/consumer-auth";
 
 export default function ConsumerRegistration() {
   const { tenantSlug } = useParams();
@@ -76,8 +77,7 @@ export default function ConsumerRegistration() {
         ? data.message
         : "Registration completed. Please log in to finish setting up your access.";
 
-      localStorage.removeItem("consumerSession");
-      localStorage.removeItem("consumerToken");
+      clearConsumerAuth();
 
       if (tenantName) {
         toast({


### PR DESCRIPTION
## Summary
- add the tenant slug query parameter to the consumer accounts request so the dashboard reuses the scoped API URL
- fetch accounts, notifications, and branding with the shared apiRequest helper to guarantee consumer auth headers are attached

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d88430ad18832a8392c9f41175149b