### PR TITLE
Improve accessibility for admin layout buttons and navigation

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -2,7 +2,8 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Chain Consumer Portal</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Architects+Daughter&family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&family=Fira+Code:wght@300..700&family=Geist+Mono:wght@100..900&family=Geist:wght@100..900&family=IBM+Plex+Mono:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;1,100;1,200;1,300;1,400;1,500;1,600;1,700&family=IBM+Plex+Sans:ital,wght@0,100..700;1,100..700&family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&family=Libre+Baskerville:ital,wght@0,400;0,700;1,400&family=Lora:ital,wght@0,400..700;1,400..700&family=Merriweather:ital,opsz,wght@0,18..144,300..900;1,18..144,300..900&family=Montserrat:ital,wght@0,100..900;1,100..900&family=Open+Sans:ital,wght@0,300..800;1,300..800&family=Outfit:wght@100..900&family=Oxanium:wght@200..800&family=Playfair+Display:ital,wght@0,400..900;1,400..900&family=Plus+Jakarta+Sans:ital,wght@0,200..800;1,200..800&family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&family=Roboto+Mono:ital,wght@0,100..700;1,100..700&family=Roboto:ital,wght@0,100..900;1,100..900&family=Source+Code+Pro:ital,wght@0,200..900;1,200..900&family=Source+Serif+4:ital,opsz,wght@0,8..60,200..900;1,8..60,200..900&family=Space+Grotesk:wght@300..700&family=Space+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">

--- a/client/src/components/admin-layout.tsx
+++ b/client/src/components/admin-layout.tsx
@@ -83,31 +83,42 @@ export default function AdminLayout({ children }: AdminLayoutProps) {
               </div>
 
               {/* Navigation */}
-              <nav className="mt-10 flex-1 space-y-1 px-4">
-                {navigationItems.map((item) => (
-                  <Link key={item.name} href={item.href} data-testid={`nav-${item.name.toLowerCase()}`}>
-                    <div
-                      className={cn(
-                        "group flex items-center gap-3 rounded-2xl px-4 py-3 text-sm font-medium transition",
-                        isActiveRoute(item.href)
-                          ? "bg-white/15 text-white shadow-lg shadow-blue-900/20"
-                          : "text-blue-100/80 hover:bg-white/10 hover:text-white",
-                      )}
-                    >
-                      <span
-                        className={cn(
-                          "flex h-9 w-9 items-center justify-center rounded-xl border border-white/10 bg-white/10 text-sm transition",
-                          isActiveRoute(item.href)
-                            ? "border-white/30 bg-gradient-to-br from-sky-400/30 to-indigo-500/30 text-white"
-                            : "text-blue-100/70 group-hover:border-white/20 group-hover:bg-white/10",
-                        )}
-                      >
-                        <i className={`${item.icon} text-base`}></i>
-                      </span>
-                      <span>{item.name}</span>
-                    </div>
-                  </Link>
-                ))}
+              <nav className="mt-10 flex-1 px-4">
+                <ul className="space-y-1">
+                  {navigationItems.map((item) => {
+                    const isActive = isActiveRoute(item.href);
+
+                    return (
+                      <li key={item.name}>
+                        <Link href={item.href}>
+                          <a
+                            data-testid={`nav-${item.name.toLowerCase()}`}
+                            className={cn(
+                              "group flex items-center gap-3 rounded-2xl px-4 py-3 text-sm font-medium transition",
+                              isActive
+                                ? "bg-white/15 text-white shadow-lg shadow-blue-900/20"
+                                : "text-blue-100/80 hover:bg-white/10 hover:text-white",
+                            )}
+                            aria-current={isActive ? "page" : undefined}
+                          >
+                            <span
+                              aria-hidden="true"
+                              className={cn(
+                                "flex h-9 w-9 items-center justify-center rounded-xl border border-white/10 bg-white/10 text-sm transition",
+                                isActive
+                                  ? "border-white/30 bg-gradient-to-br from-sky-400/30 to-indigo-500/30 text-white"
+                                  : "text-blue-100/70 group-hover:border-white/20 group-hover:bg-white/10",
+                              )}
+                            >
+                              <i aria-hidden="true" className={`${item.icon} text-base`}></i>
+                            </span>
+                            <span>{item.name}</span>
+                          </a>
+                        </Link>
+                      </li>
+                    );
+                  })}
+                </ul>
               </nav>
 
               {/* User Profile */}
@@ -139,12 +150,17 @@ export default function AdminLayout({ children }: AdminLayoutProps) {
         {/* Main Content */}
         <div className="flex flex-1 flex-col overflow-hidden">
           <div className="relative z-10 flex h-20 flex-shrink-0 items-center border-b border-white/10 bg-white/5 px-4 backdrop-blur">
-            <button className="mr-4 flex h-10 w-10 items-center justify-center rounded-xl border border-white/10 bg-white/5 text-blue-100/70 transition hover:bg-white/10 md:hidden">
-              <i className="fas fa-bars text-lg"></i>
+            <button
+              type="button"
+              aria-label="Open navigation menu"
+              className="mr-4 flex h-10 w-10 items-center justify-center rounded-xl border border-white/10 bg-white/5 text-blue-100/70 transition hover:bg-white/10 md:hidden"
+            >
+              <i aria-hidden="true" className="fas fa-bars text-lg"></i>
+              <span className="sr-only">Open navigation menu</span>
             </button>
             <div className="flex flex-1 items-center justify-between gap-4">
               <div className="relative hidden w-full max-w-md md:block">
-                <i className="fas fa-search pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-blue-100/60"></i>
+                <i aria-hidden="true" className="fas fa-search pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-blue-100/60"></i>
                 <input
                   className="w-full rounded-2xl border border-white/15 bg-white/10 py-2.5 pl-11 pr-4 text-sm text-blue-50 placeholder:text-blue-100/60 focus:border-sky-400/60 focus:outline-none focus:ring-2 focus:ring-sky-400/40"
                   placeholder="Search consumers, accounts..."
@@ -152,8 +168,13 @@ export default function AdminLayout({ children }: AdminLayoutProps) {
                 />
               </div>
               <div className="flex items-center gap-3">
-                <button className="flex h-11 w-11 items-center justify-center rounded-xl border border-white/15 bg-white/10 text-blue-100/70 transition hover:bg-white/15">
-                  <i className="fas fa-bell text-base"></i>
+                <button
+                  type="button"
+                  aria-label="View notifications"
+                  className="flex h-11 w-11 items-center justify-center rounded-xl border border-white/15 bg-white/10 text-blue-100/70 transition hover:bg-white/15"
+                >
+                  <i aria-hidden="true" className="fas fa-bell text-base"></i>
+                  <span className="sr-only">View notifications</span>
                 </button>
                 <Button
                   variant="ghost"
@@ -163,7 +184,7 @@ export default function AdminLayout({ children }: AdminLayoutProps) {
                   }}
                   className="rounded-xl border border-white/15 bg-white/10 px-4 py-2 text-sm font-semibold text-blue-50 hover:bg-white/20"
                 >
-                  <i className="fas fa-sign-out-alt mr-2 text-base"></i>
+                  <i aria-hidden="true" className="fas fa-sign-out-alt mr-2 text-base"></i>
                   Logout
                 </Button>
               </div>


### PR DESCRIPTION
## Summary
- allow users to zoom by removing the restrictive maximum-scale attribute from the viewport meta tag
- add accessible labels and hidden text for icon-only buttons in the admin layout header
- structure the admin navigation as a list and hide decorative icons from assistive technology

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d89a82dd24832a979aa22a14e3f2fe