### PR TITLE
Fix consumer dashboard account fetch URL

### DIFF
--- a/client/src/pages/consumer-dashboard-simple.tsx
+++ b/client/src/pages/consumer-dashboard-simple.tsx
@@ -38,11 +38,15 @@ export default function ConsumerDashboardSimple() {
   }, [setLocation, toast]);
 
   // Only fetch data when we have a valid session
+  const encodedEmail = session?.email ? encodeURIComponent(session.email) : null;
+  const encodedTenantSlug = session?.tenantSlug ? encodeURIComponent(session.tenantSlug) : null;
+  const accountsUrl = encodedEmail && encodedTenantSlug
+    ? `/api/consumer/accounts/${encodedEmail}?tenantSlug=${encodedTenantSlug}`
+    : null;
+
   const { data: accountData, isLoading, error } = useQuery({
-    queryKey: session?.email && session?.tenantSlug
-      ? [`/api/consumer/accounts?email=${encodeURIComponent(session.email)}&tenantSlug=${encodeURIComponent(session.tenantSlug)}`]
-      : ["skip"],
-    enabled: !!(session?.email && session?.tenantSlug && mounted),
+    queryKey: accountsUrl ? [accountsUrl] : ["no-fetch"],
+    enabled: !!(accountsUrl && mounted),
     retry: 1,
   });
 


### PR DESCRIPTION
## Summary
- point the consumer dashboard query at the correct accounts endpoint using the email path parameter
- guard the React Query request behind the composed URL to avoid unnecessary fetches

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d989ed06d8832a9bb82468b4640591