### PR TITLE
Remove tenant slug from consumer accounts requests

### DIFF
--- a/client/src/pages/consumer-dashboard-simple.tsx
+++ b/client/src/pages/consumer-dashboard-simple.tsx
@@ -39,13 +39,12 @@ export default function ConsumerDashboardSimple() {
 
   // Only fetch data when we have a valid session
   const encodedEmail = session?.email ? encodeURIComponent(session.email) : null;
-  const encodedTenantSlug = session?.tenantSlug ? encodeURIComponent(session.tenantSlug) : null;
-  const accountsUrl = encodedEmail && encodedTenantSlug
-    ? `/api/consumer/accounts/${encodedEmail}?tenantSlug=${encodedTenantSlug}`
+  const accountsUrl = encodedEmail
+    ? `/api/consumer/accounts/${encodedEmail}`
     : null;
 
   const { data: accountData, isLoading, error } = useQuery({
-    queryKey: accountsUrl ? [accountsUrl] : ["no-fetch"],
+    queryKey: accountsUrl ? ["consumer-accounts", encodedEmail] : ["no-fetch"],
     enabled: !!(accountsUrl && mounted),
     retry: 1,
   });

--- a/client/src/pages/consumer-dashboard.tsx
+++ b/client/src/pages/consumer-dashboard.tsx
@@ -77,15 +77,13 @@ export default function ConsumerDashboard() {
   const tenantSlug = consumerSession?.tenantSlug;
   const encodedEmail = consumerSession?.email ? encodeURIComponent(consumerSession.email) : null;
   const encodedTenantSlug = tenantSlug ? encodeURIComponent(tenantSlug) : null;
-  const tenantQuery = encodedTenantSlug ? `?tenantSlug=${encodedTenantSlug}` : "";
-
-  const accountsUrl = encodedEmail && encodedTenantSlug
-    ? `/api/consumer/accounts/${encodedEmail}?tenantSlug=${encodedTenantSlug}`
+  const accountsUrl = encodedEmail
+    ? `/api/consumer/accounts/${encodedEmail}`
     : null;
 
   // Fetch consumer data - only create query when URL is available
   const { data, isLoading, error } = useQuery({
-    queryKey: [accountsUrl || "no-fetch"],
+    queryKey: accountsUrl ? ["consumer-accounts", encodedEmail] : ["no-fetch"],
     enabled: !!accountsUrl && !!consumerSession,
   });
 

--- a/client/src/pages/consumer-portal.tsx
+++ b/client/src/pages/consumer-portal.tsx
@@ -10,22 +10,21 @@ export default function ConsumerPortal() {
   const { tenantSlug, email } = useParams();
   const { agencySlug } = useAgencyContext();
 
-  const { encodedEmail, tenantQuery, accountsUrl, documentsUrl, arrangementsUrl } = useMemo(() => {
+  const { encodedEmail, accountsUrl, documentsUrl, arrangementsUrl } = useMemo(() => {
     const safeEmail = email ? encodeURIComponent(email) : "";
     const resolvedTenantSlug = tenantSlug && tenantSlug !== "undefined" ? tenantSlug : agencySlug;
     const safeTenantSlug = resolvedTenantSlug ? encodeURIComponent(resolvedTenantSlug) : "";
 
     return {
       encodedEmail: safeEmail,
-      tenantQuery: safeTenantSlug ? `?tenantSlug=${safeTenantSlug}` : "",
-      accountsUrl: safeEmail && safeTenantSlug ? `/api/consumer/accounts/${safeEmail}?tenantSlug=${safeTenantSlug}` : "",
+      accountsUrl: safeEmail ? `/api/consumer/accounts/${safeEmail}` : "",
       documentsUrl: safeEmail && safeTenantSlug ? `/api/consumer/documents/${safeEmail}?tenantSlug=${safeTenantSlug}` : "",
       arrangementsUrl: safeEmail && safeTenantSlug ? `/api/consumer/arrangements/${safeEmail}?tenantSlug=${safeTenantSlug}` : ""
     };
   }, [agencySlug, email, tenantSlug]);
 
   const { data, isLoading, error } = useQuery<any>({
-    queryKey: accountsUrl ? [accountsUrl] : ['consumer-portal-accounts'],
+    queryKey: accountsUrl ? ["consumer-accounts", encodedEmail] : ['consumer-portal-accounts'],
     enabled: !!accountsUrl,
   });
 

--- a/client/src/pages/enhanced-consumer-portal.tsx
+++ b/client/src/pages/enhanced-consumer-portal.tsx
@@ -26,7 +26,7 @@ export default function EnhancedConsumerPortal() {
   const encodedEmail = email ? encodeURIComponent(email) : "";
   const encodedTenantSlug = resolvedTenantSlug ? encodeURIComponent(resolvedTenantSlug) : "";
   const tenantQuery = encodedTenantSlug ? `?tenantSlug=${encodedTenantSlug}` : "";
-  const accountsUrl = encodedEmail && encodedTenantSlug ? `/api/consumer/accounts/${encodedEmail}${tenantQuery}` : "";
+  const accountsUrl = encodedEmail ? `/api/consumer/accounts/${encodedEmail}` : "";
   const notificationsUrl = encodedEmail && encodedTenantSlug ? `/api/consumer-notifications/${encodedEmail}/${encodedTenantSlug}` : "";
   const documentsUrl = encodedEmail && encodedTenantSlug ? `/api/consumer/documents/${encodedEmail}${tenantQuery}` : "";
 
@@ -43,7 +43,7 @@ export default function EnhancedConsumerPortal() {
 
   // Fetch consumer data
   const { data, isLoading, error } = useQuery<any>({
-    queryKey: accountsUrl ? [accountsUrl] : ['enhanced-consumer-accounts'],
+    queryKey: accountsUrl ? ["consumer-accounts", encodedEmail] : ['enhanced-consumer-accounts'],
     enabled: !!accountsUrl,
   });
 


### PR DESCRIPTION
## Summary
- update all consumer dashboard variants to request accounts without tenant slug query parameters
- align React Query keys to the new token-based consumer accounts URL

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9a81c2b80832a8dd4f78ef8028a51