### PR TITLE
Add fallback for folder deletion 405 errors

### DIFF
--- a/client/src/pages/accounts.tsx
+++ b/client/src/pages/accounts.tsx
@@ -219,7 +219,14 @@ export default function Accounts() {
         return await apiRequest("DELETE", `/api/folders/${folderId}`);
       } catch (error) {
         if (error instanceof ApiError && error.status === 405) {
-          return await apiRequest("POST", `/api/folders/${folderId}/delete`);
+          try {
+            return await apiRequest("POST", `/api/folders/${folderId}/delete`);
+          } catch (fallbackError) {
+            if (fallbackError instanceof ApiError && fallbackError.status === 405) {
+              return await apiRequest("POST", "/api/folders/delete", { folderId });
+            }
+            throw fallbackError;
+          }
         }
         throw error;
       }


### PR DESCRIPTION
## Summary
- extend the folder deletion mutation to fall back to a POST request with a body when DELETE and POST endpoints return 405

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d9b7ff1838832a9b2c448bc5a19b41