### PR TITLE
Fix consumer mobile biometric startup and session persistence

### DIFF
--- a/client/src/lib/expo-bridge.ts
+++ b/client/src/lib/expo-bridge.ts
@@ -4,8 +4,8 @@ declare global {
     platform?: 'ios' | 'android';
     sendToNative?: (data: any) => void;
     hapticFeedback?: (style?: 'light' | 'medium' | 'heavy') => void;
-    saveToken?: (token: string) => void;
-    enableBiometric?: () => void;
+    saveToken?: (token: string, session?: string) => void;
+    enableBiometric?: (token?: string, session?: string) => void;
     disableBiometric?: () => void;
     checkBiometric?: () => void;
     authenticateBiometric?: (reason?: string) => void;
@@ -37,15 +37,15 @@ export const hapticFeedback = (style: 'light' | 'medium' | 'heavy' = 'light'): v
   }
 };
 
-export const saveAuthToken = (token: string): void => {
+export const saveAuthToken = (token: string, session?: string): void => {
   if (isExpoApp() && window.saveToken) {
-    window.saveToken(token);
+    window.saveToken(token, session);
   }
 };
 
-export const enableBiometricLogin = (): void => {
+export const enableBiometricLogin = (token?: string, session?: string): void => {
   if (isExpoApp() && window.enableBiometric) {
-    window.enableBiometric();
+    window.enableBiometric(token, session);
   }
 };
 

--- a/client/src/pages/mobile-app-login.tsx
+++ b/client/src/pages/mobile-app-login.tsx
@@ -8,6 +8,7 @@ import { useToast } from "@/hooks/use-toast";
 import { apiCall } from "@/lib/api";
 import { persistConsumerAuth } from "@/lib/consumer-auth";
 import { biometricAuth } from "@/lib/biometric-auth";
+import { enableBiometricLogin, saveAuthToken } from "@/lib/expo-bridge";
 import { pushNotificationService } from "@/lib/push-notifications";
 
 interface AgencyContext {
@@ -130,14 +131,17 @@ export default function MobileAppLogin() {
       const data = await response.json();
 
       if (data.token && data.tenant) {
+        const session = {
+          email: savedEmail,
+          tenantSlug: data.tenant.slug,
+          consumerData: data.consumer,
+        };
+
         persistConsumerAuth({
-          session: {
-            email: savedEmail,
-            tenantSlug: data.tenant.slug,
-            consumerData: data.consumer,
-          },
+          session,
           token: data.token,
         });
+        saveAuthToken(data.token, JSON.stringify(session));
 
         // Push notifications disabled - will be enabled after Firebase setup
         // await pushNotificationService.registerPendingToken();
@@ -227,19 +231,23 @@ export default function MobileAppLogin() {
       // Handle successful login
       if (data.token && data.tenant) {
         // Store auth and redirect
+        const session = {
+          email,
+          tenantSlug: data.tenant.slug,
+          consumerData: data.consumer,
+        };
+
         persistConsumerAuth({
-          session: {
-            email,
-            tenantSlug: data.tenant.slug,
-            consumerData: data.consumer,
-          },
+          session,
           token: data.token,
         });
+        saveAuthToken(data.token, JSON.stringify(session));
 
         // Save credentials for biometric authentication
         if (biometricAvailable) {
           localStorage.setItem('biometric_email', email);
           localStorage.setItem('biometric_dob', dateOfBirth);
+          enableBiometricLogin(data.token, JSON.stringify(session));
         }
 
         // Push notifications disabled - will be enabled after Firebase setup

--- a/mobile-app/App.js
+++ b/mobile-app/App.js
@@ -17,7 +17,7 @@ import {
   SafeAreaProvider,
   useSafeAreaInsets,
 } from 'react-native-safe-area-context';
-import { useEffect, useState, useRef, useCallback } from 'react';
+import { useEffect, useState, useRef, useCallback, useMemo } from 'react';
 
 const API_BASE_URL = 'https://chain-admin-production.up.railway.app';
 const LOAD_TIMEOUT_MS = 15000;
@@ -27,7 +27,7 @@ SplashScreen.preventAutoHideAsync().catch(() => {});
 function ChainApp() {
   const insets = useSafeAreaInsets();
   const [isBootstrapping, setIsBootstrapping] = useState(true);
-  const [biometricToken, setBiometricToken] = useState(null);
+  const [biometricAuth, setBiometricAuth] = useState(null);
   const [status, setStatus] = useState('loading');
   const [reloadKey, setReloadKey] = useState(0);
   const webViewRef = useRef(null);
@@ -39,9 +39,10 @@ function ChainApp() {
     (async () => {
       try {
         const savedToken = await SecureStore.getItemAsync('consumerToken');
+        const savedSession = await SecureStore.getItemAsync('consumerSession');
         const biometricEnabled = await SecureStore.getItemAsync('biometricEnabled');
 
-        if (savedToken && biometricEnabled === 'true') {
+        if (savedToken && savedSession && biometricEnabled === 'true') {
           const hasHardware = await LocalAuthentication.hasHardwareAsync();
           const isEnrolled = await LocalAuthentication.isEnrolledAsync();
 
@@ -53,7 +54,7 @@ function ChainApp() {
             });
 
             if (!cancelled && result.success) {
-              setBiometricToken(savedToken);
+              setBiometricAuth({ token: savedToken, session: savedSession });
             }
           }
         }
@@ -97,16 +98,28 @@ function ChainApp() {
         }
 
         case 'SAVE_TOKEN':
-          await SecureStore.setItemAsync('consumerToken', data.token);
+          if (typeof data.token === 'string' && data.token.length > 0) {
+            await SecureStore.setItemAsync('consumerToken', data.token);
+          }
+          if (typeof data.session === 'string' && data.session.length > 0) {
+            await SecureStore.setItemAsync('consumerSession', data.session);
+          }
           break;
 
         case 'ENABLE_BIOMETRIC':
           await SecureStore.setItemAsync('biometricEnabled', 'true');
+          if (typeof data.token === 'string' && data.token.length > 0) {
+            await SecureStore.setItemAsync('consumerToken', data.token);
+          }
+          if (typeof data.session === 'string' && data.session.length > 0) {
+            await SecureStore.setItemAsync('consumerSession', data.session);
+          }
           break;
 
         case 'DISABLE_BIOMETRIC':
           await SecureStore.deleteItemAsync('biometricEnabled');
           await SecureStore.deleteItemAsync('consumerToken');
+          await SecureStore.deleteItemAsync('consumerSession');
           break;
 
         case 'CHECK_BIOMETRIC': {
@@ -155,9 +168,10 @@ function ChainApp() {
 
         case 'LOGOUT':
           await SecureStore.deleteItemAsync('consumerToken');
+          await SecureStore.deleteItemAsync('consumerSession');
           await SecureStore.deleteItemAsync('biometricEnabled');
           redirectedRef.current = false;
-          setBiometricToken(null);
+          setBiometricAuth(null);
           break;
       }
     } catch (error) {
@@ -167,7 +181,7 @@ function ChainApp() {
 
   const safePlatform = JSON.stringify(Platform.OS);
 
-  const injectedJavaScript = `
+  const injectedJavaScript = useMemo(() => `
     (function() {
       try {
         window.isExpoApp = true;
@@ -182,11 +196,11 @@ function ChainApp() {
         window.hapticFeedback = function(style) {
           window.sendToNative({ type: 'HAPTIC_FEEDBACK', style: style || 'light' });
         };
-        window.saveToken = function(token) {
-          window.sendToNative({ type: 'SAVE_TOKEN', token: token });
+        window.saveToken = function(token, session) {
+          window.sendToNative({ type: 'SAVE_TOKEN', token: token, session: session });
         };
-        window.enableBiometric = function() {
-          window.sendToNative({ type: 'ENABLE_BIOMETRIC' });
+        window.enableBiometric = function(token, session) {
+          window.sendToNative({ type: 'ENABLE_BIOMETRIC', token: token, session: session });
         };
         window.disableBiometric = function() {
           window.sendToNative({ type: 'DISABLE_BIOMETRIC' });
@@ -213,7 +227,7 @@ function ChainApp() {
       }
     })();
     true;
-  `;
+  `, [safePlatform]);
 
   const clearLoadTimer = () => {
     if (loadTimerRef.current) {
@@ -238,18 +252,22 @@ function ChainApp() {
     clearLoadTimer();
     setStatus('ok');
 
-    if (biometricToken && !redirectedRef.current && webViewRef.current) {
+    if (biometricAuth && !redirectedRef.current && webViewRef.current) {
       redirectedRef.current = true;
-      const tokenJson = JSON.stringify(biometricToken);
-      const escaped = tokenJson.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+      const tokenLiteral = JSON.stringify(biometricAuth.token);
+      const sessionLiteral = JSON.stringify(biometricAuth.session);
       webViewRef.current.injectJavaScript(`
         (function(){
           try {
-            localStorage.setItem('consumerAuth', JSON.stringify({ token: ${escaped} }));
+            localStorage.setItem('consumerToken', ${tokenLiteral});
+            sessionStorage.setItem('consumerToken', ${tokenLiteral});
+            localStorage.setItem('consumerSession', ${sessionLiteral});
+            sessionStorage.setItem('consumerSession', ${sessionLiteral});
+            localStorage.setItem('consumerAuth', JSON.stringify({ token: ${tokenLiteral} }));
           } catch(e){}
           try {
-            if (window.location.pathname.indexOf('/consumer/dashboard') === -1) {
-              window.location.replace('/consumer/dashboard');
+            if (window.location.pathname.indexOf('/consumer-dashboard') === -1) {
+              window.location.replace('/consumer-dashboard');
             }
           } catch(e){}
         })();


### PR DESCRIPTION
### Motivation
- Returning biometric users were redirected into the WebView dashboard without the full session payload the web client expects, causing startup failures for the mobile consumer app. 
- The native ↔ web bridge only passed a token previously, so `consumerSession` was never restored into `localStorage`/`sessionStorage` for the WebView.

### Description
- Persist and restore both `consumerToken` and `consumerSession` in the native Expo wrapper by updating `mobile-app/App.js` to store/read `consumerSession` from `SecureStore`, expose a `biometricAuth` object, and inject both token and session into the WebView before redirecting to the dashboard. 
- Extend the injected bridge and native handlers to accept and save a serialized session payload by updating `client/src/lib/expo-bridge.ts` to `saveAuthToken(token, session)` and `enableBiometricLogin(token, session)` and to call `window.saveToken(token, session)`. 
- Update the web login flow in `client/src/pages/mobile-app-login.tsx` to serialize and forward the consumer session to native storage on successful login and when enabling biometric login using `saveAuthToken` and `enableBiometricLogin`. 
- Add defensive checks and minor optimizations (`useMemo` for injected JS) and ensure biometric disable/logout clears both token and session from native secure storage.

### Testing
- `node --check mobile-app/App.js` — succeeded. 
- `cd mobile-app && npx expo export --platform android --output-dir /tmp/chain-mobile-export` — succeeded (bundled exports created). 
- `cd mobile-app && npx expo export --platform ios --output-dir /tmp/chain-mobile-export-ios` — succeeded (bundled exports created). 
- TypeScript narrow-scope compile for the changed client files via a temporary `tsconfig` targeting `client/src/lib/expo-bridge.ts` and `client/src/pages/mobile-app-login.tsx` using `npx tsc --project tmp-chain-mobile-tsconfig.json` — succeeded for those files. 
- Project-wide `npm run check` (full `tsc`) failed due to unrelated pre-existing TypeScript errors in other parts of the repo; those failures are not introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f6436c1a4832aaf0ed72dbc9b3572)