### PR TITLE
Pass session to native bridge, persist consumerSession, update WebView flow and bump mobile version

### DIFF
--- a/client/src/lib/expo-bridge.ts
+++ b/client/src/lib/expo-bridge.ts
@@ -4,8 +4,8 @@ declare global {
     platform?: 'ios' | 'android';
     sendToNative?: (data: any) => void;
     hapticFeedback?: (style?: 'light' | 'medium' | 'heavy') => void;
-    saveToken?: (token: string) => void;
-    enableBiometric?: () => void;
+    saveToken?: (token: string, session?: string) => void;
+    enableBiometric?: (token?: string, session?: string) => void;
     disableBiometric?: () => void;
     checkBiometric?: () => void;
     authenticateBiometric?: (reason?: string) => void;
@@ -37,15 +37,15 @@ export const hapticFeedback = (style: 'light' | 'medium' | 'heavy' = 'light'): v
   }
 };
 
-export const saveAuthToken = (token: string): void => {
+export const saveAuthToken = (token: string, session?: string): void => {
   if (isExpoApp() && window.saveToken) {
-    window.saveToken(token);
+    window.saveToken(token, session);
   }
 };
 
-export const enableBiometricLogin = (): void => {
+export const enableBiometricLogin = (token?: string, session?: string): void => {
   if (isExpoApp() && window.enableBiometric) {
-    window.enableBiometric();
+    window.enableBiometric(token, session);
   }
 };
 

--- a/client/src/pages/mobile-app-login.tsx
+++ b/client/src/pages/mobile-app-login.tsx
@@ -8,6 +8,7 @@ import { useToast } from "@/hooks/use-toast";
 import { apiCall } from "@/lib/api";
 import { persistConsumerAuth } from "@/lib/consumer-auth";
 import { biometricAuth } from "@/lib/biometric-auth";
+import { enableBiometricLogin, saveAuthToken } from "@/lib/expo-bridge";
 import { pushNotificationService } from "@/lib/push-notifications";
 
 interface AgencyContext {
@@ -130,14 +131,17 @@ export default function MobileAppLogin() {
       const data = await response.json();
 
       if (data.token && data.tenant) {
+        const session = {
+          email: savedEmail,
+          tenantSlug: data.tenant.slug,
+          consumerData: data.consumer,
+        };
+
         persistConsumerAuth({
-          session: {
-            email: savedEmail,
-            tenantSlug: data.tenant.slug,
-            consumerData: data.consumer,
-          },
+          session,
           token: data.token,
         });
+        saveAuthToken(data.token, JSON.stringify(session));
 
         // Push notifications disabled - will be enabled after Firebase setup
         // await pushNotificationService.registerPendingToken();
@@ -227,19 +231,23 @@ export default function MobileAppLogin() {
       // Handle successful login
       if (data.token && data.tenant) {
         // Store auth and redirect
+        const session = {
+          email,
+          tenantSlug: data.tenant.slug,
+          consumerData: data.consumer,
+        };
+
         persistConsumerAuth({
-          session: {
-            email,
-            tenantSlug: data.tenant.slug,
-            consumerData: data.consumer,
-          },
+          session,
           token: data.token,
         });
+        saveAuthToken(data.token, JSON.stringify(session));
 
         // Save credentials for biometric authentication
         if (biometricAvailable) {
           localStorage.setItem('biometric_email', email);
           localStorage.setItem('biometric_dob', dateOfBirth);
+          enableBiometricLogin(data.token, JSON.stringify(session));
         }
 
         // Push notifications disabled - will be enabled after Firebase setup

--- a/mobile-app/App.js
+++ b/mobile-app/App.js
@@ -17,58 +17,53 @@ import {
   SafeAreaProvider,
   useSafeAreaInsets,
 } from 'react-native-safe-area-context';
-import { useEffect, useState, useRef, useCallback } from 'react';
+import { Component, useEffect, useState, useRef, useCallback, useMemo } from 'react';
 
 const API_BASE_URL = 'https://chain-admin-production.up.railway.app';
+const LOGIN_PATH = '/consumer-login';
 const LOAD_TIMEOUT_MS = 15000;
 
 SplashScreen.preventAutoHideAsync().catch(() => {});
 
+class NativeErrorBoundary extends Component {
+  state = { hasError: false };
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error) {
+    console.log('Native app render error:', error);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <View style={styles.loadingContainer}>
+          <Text style={styles.errorTitle}>Chain couldn't start</Text>
+          <Text style={styles.errorBody}>
+            Please close and reopen the app. If this keeps happening, install
+            the latest update from the App Store or Google Play.
+          </Text>
+        </View>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
 function ChainApp() {
   const insets = useSafeAreaInsets();
   const [isBootstrapping, setIsBootstrapping] = useState(true);
-  const [biometricToken, setBiometricToken] = useState(null);
   const [status, setStatus] = useState('loading');
   const [reloadKey, setReloadKey] = useState(0);
   const webViewRef = useRef(null);
   const loadTimerRef = useRef(null);
-  const redirectedRef = useRef(false);
 
   useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const savedToken = await SecureStore.getItemAsync('consumerToken');
-        const biometricEnabled = await SecureStore.getItemAsync('biometricEnabled');
-
-        if (savedToken && biometricEnabled === 'true') {
-          const hasHardware = await LocalAuthentication.hasHardwareAsync();
-          const isEnrolled = await LocalAuthentication.isEnrolledAsync();
-
-          if (hasHardware && isEnrolled) {
-            const result = await LocalAuthentication.authenticateAsync({
-              promptMessage: 'Log in to Chain',
-              cancelLabel: 'Cancel',
-              disableDeviceFallback: false,
-            });
-
-            if (!cancelled && result.success) {
-              setBiometricToken(savedToken);
-            }
-          }
-        }
-      } catch (error) {
-        console.log('Biometric check error:', error);
-      } finally {
-        if (!cancelled) {
-          setIsBootstrapping(false);
-          SplashScreen.hideAsync().catch(() => {});
-        }
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
+    setIsBootstrapping(false);
+    SplashScreen.hideAsync().catch(() => {});
   }, []);
 
   const sendToWeb = useCallback((payload) => {
@@ -97,16 +92,28 @@ function ChainApp() {
         }
 
         case 'SAVE_TOKEN':
-          await SecureStore.setItemAsync('consumerToken', data.token);
+          if (typeof data.token === 'string' && data.token.length > 0) {
+            await SecureStore.setItemAsync('consumerToken', data.token);
+          }
+          if (typeof data.session === 'string' && data.session.length > 0) {
+            await SecureStore.setItemAsync('consumerSession', data.session);
+          }
           break;
 
         case 'ENABLE_BIOMETRIC':
           await SecureStore.setItemAsync('biometricEnabled', 'true');
+          if (typeof data.token === 'string' && data.token.length > 0) {
+            await SecureStore.setItemAsync('consumerToken', data.token);
+          }
+          if (typeof data.session === 'string' && data.session.length > 0) {
+            await SecureStore.setItemAsync('consumerSession', data.session);
+          }
           break;
 
         case 'DISABLE_BIOMETRIC':
           await SecureStore.deleteItemAsync('biometricEnabled');
           await SecureStore.deleteItemAsync('consumerToken');
+          await SecureStore.deleteItemAsync('consumerSession');
           break;
 
         case 'CHECK_BIOMETRIC': {
@@ -155,9 +162,8 @@ function ChainApp() {
 
         case 'LOGOUT':
           await SecureStore.deleteItemAsync('consumerToken');
+          await SecureStore.deleteItemAsync('consumerSession');
           await SecureStore.deleteItemAsync('biometricEnabled');
-          redirectedRef.current = false;
-          setBiometricToken(null);
           break;
       }
     } catch (error) {
@@ -167,7 +173,7 @@ function ChainApp() {
 
   const safePlatform = JSON.stringify(Platform.OS);
 
-  const injectedJavaScript = `
+  const injectedJavaScript = useMemo(() => `
     (function() {
       try {
         window.isExpoApp = true;
@@ -182,11 +188,11 @@ function ChainApp() {
         window.hapticFeedback = function(style) {
           window.sendToNative({ type: 'HAPTIC_FEEDBACK', style: style || 'light' });
         };
-        window.saveToken = function(token) {
-          window.sendToNative({ type: 'SAVE_TOKEN', token: token });
+        window.saveToken = function(token, session) {
+          window.sendToNative({ type: 'SAVE_TOKEN', token: token, session: session });
         };
-        window.enableBiometric = function() {
-          window.sendToNative({ type: 'ENABLE_BIOMETRIC' });
+        window.enableBiometric = function(token, session) {
+          window.sendToNative({ type: 'ENABLE_BIOMETRIC', token: token, session: session });
         };
         window.disableBiometric = function() {
           window.sendToNative({ type: 'DISABLE_BIOMETRIC' });
@@ -213,7 +219,7 @@ function ChainApp() {
       }
     })();
     true;
-  `;
+  `, [safePlatform]);
 
   const clearLoadTimer = () => {
     if (loadTimerRef.current) {
@@ -237,25 +243,6 @@ function ChainApp() {
   const onWebViewLoadEnd = () => {
     clearLoadTimer();
     setStatus('ok');
-
-    if (biometricToken && !redirectedRef.current && webViewRef.current) {
-      redirectedRef.current = true;
-      const tokenJson = JSON.stringify(biometricToken);
-      const escaped = tokenJson.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
-      webViewRef.current.injectJavaScript(`
-        (function(){
-          try {
-            localStorage.setItem('consumerAuth', JSON.stringify({ token: ${escaped} }));
-          } catch(e){}
-          try {
-            if (window.location.pathname.indexOf('/consumer/dashboard') === -1) {
-              window.location.replace('/consumer/dashboard');
-            }
-          } catch(e){}
-        })();
-        true;
-      `);
-    }
   };
 
   const onWebViewError = () => {
@@ -274,7 +261,6 @@ function ChainApp() {
 
   const onRetry = () => {
     setStatus('loading');
-    redirectedRef.current = false;
     setReloadKey((k) => k + 1);
   };
 
@@ -293,7 +279,7 @@ function ChainApp() {
       <WebView
         key={reloadKey}
         ref={webViewRef}
-        source={{ uri: `${API_BASE_URL}/consumer/login` }}
+        source={{ uri: `${API_BASE_URL}${LOGIN_PATH}` }}
         style={styles.webview}
         injectedJavaScript={injectedJavaScript}
         onMessage={handleMessage}
@@ -344,9 +330,11 @@ function ChainApp() {
 
 export default function App() {
   return (
-    <SafeAreaProvider>
-      <ChainApp />
-    </SafeAreaProvider>
+    <NativeErrorBoundary>
+      <SafeAreaProvider>
+        <ChainApp />
+      </SafeAreaProvider>
+    </NativeErrorBoundary>
   );
 }
 

--- a/mobile-app/README.md
+++ b/mobile-app/README.md
@@ -36,8 +36,8 @@ Run through this every time before uploading to the App Store / Play Store.
 - [ ] Test on a real device:
   - [ ] App launches without a white flash (splash → login)
   - [ ] If backend is unreachable, error card with "Try again" appears (toggle airplane mode to test)
-  - [ ] Face ID / Touch ID prompt appears for returning users
-  - [ ] After login, `/consumer/dashboard` loads and stays put on rotation
+  - [ ] Face ID / Touch ID prompt appears after tapping biometric sign-in
+  - [ ] After login, `/consumer-dashboard` loads and stays put on rotation
   - [ ] Logout fully clears saved credentials
 - [ ] No `console.error` output on launch in Metro
 
@@ -63,9 +63,9 @@ Run through this every time before uploading to the App Store / Play Store.
 
 ## Architecture
 
-- `App.js` — single `WebView` pointed at `${API_BASE_URL}/consumer/login` wrapped in a `loading | ok | error` state machine. Shows a friendly "Couldn't reach Chain → Try again" card if the page fails to load within 15s, errors, or returns a 5xx.
+- `App.js` — single `WebView` pointed at `${API_BASE_URL}/consumer-login` wrapped in a `loading | ok | error` state machine. Shows a friendly "Couldn't reach Chain → Try again" card if the page fails to load within 15s, errors, or returns a 5xx.
 - `client/src/lib/expo-bridge.ts` (in the main app) — web-side bridge that calls into native via `window.ReactNativeWebView.postMessage` and listens to `MessageEvent` for native → web responses.
-- Splash is held by `SplashScreen.preventAutoHideAsync()` and only hidden after the biometric check resolves, so users never see a flash of white.
+- Splash is held by `SplashScreen.preventAutoHideAsync()` and hidden as soon as the native shell is ready; biometric prompts are initiated by the loaded web login screen instead of during native startup.
 - Notch / Dynamic Island handled by `react-native-safe-area-context`.
 - Native → web messaging uses `injectJavaScript` (current API) instead of the deprecated `webViewRef.postMessage`.
 

--- a/mobile-app/app.json
+++ b/mobile-app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Chain",
     "slug": "chain",
-    "version": "1.1.4",
+    "version": "1.1.5",
     "scheme": "chain",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
@@ -10,25 +10,33 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.chainsoftware.platform",
-      "buildNumber": "10",
+      "buildNumber": "11",
       "newArchEnabled": false,
       "privacyManifests": {
         "NSPrivacyAccessedAPITypes": [
           {
             "NSPrivacyAccessedAPIType": "NSPrivacyAccessedAPICategoryUserDefaults",
-            "NSPrivacyAccessedAPITypeReasons": ["CA92.1"]
+            "NSPrivacyAccessedAPITypeReasons": [
+              "CA92.1"
+            ]
           },
           {
             "NSPrivacyAccessedAPIType": "NSPrivacyAccessedAPICategoryFileTimestamp",
-            "NSPrivacyAccessedAPITypeReasons": ["C617.1"]
+            "NSPrivacyAccessedAPITypeReasons": [
+              "C617.1"
+            ]
           },
           {
             "NSPrivacyAccessedAPIType": "NSPrivacyAccessedAPICategorySystemBootTime",
-            "NSPrivacyAccessedAPITypeReasons": ["35F9.1"]
+            "NSPrivacyAccessedAPITypeReasons": [
+              "35F9.1"
+            ]
           },
           {
             "NSPrivacyAccessedAPIType": "NSPrivacyAccessedAPICategoryDiskSpace",
-            "NSPrivacyAccessedAPITypeReasons": ["E174.1"]
+            "NSPrivacyAccessedAPITypeReasons": [
+              "E174.1"
+            ]
           }
         ],
         "NSPrivacyTracking": false,
@@ -42,7 +50,7 @@
     },
     "android": {
       "newArchEnabled": false,
-      "versionCode": 10,
+      "versionCode": 11,
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ffffff"

--- a/mobile-app/package-lock.json
+++ b/mobile-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chain-mobile",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chain-mobile",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "dependencies": {
         "babel-preset-expo": "~54.0.10",
         "expo": "^54.0.33",

--- a/mobile-app/package.json
+++ b/mobile-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chain-mobile",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "main": "App.js",
   "scripts": {
     "start": "expo start",


### PR DESCRIPTION
### Motivation
- Preserve session metadata alongside the auth token in native secure storage and include it during biometric enrollment so the web app has access to full consumer context.
- Move biometric prompts out of native startup to avoid splash delays and prevent startup white-flash, and protect the native shell with an error boundary.
- Align the WebView login path and bump mobile app version/build metadata for the release.

### Description
- Extended the web/native bridge API in `client/src/lib/expo-bridge.ts` to accept an optional `session` string and updated `saveAuthToken` and `enableBiometricLogin` to forward the `session` value to native.
- Updated `client/src/pages/mobile-app-login.tsx` to construct a `session` object and pass `JSON.stringify(session)` into `persistConsumerAuth`, `saveAuthToken`, and `enableBiometricLogin` after successful login.
- Modified the native Expo app (`mobile-app/App.js`) to store and delete `consumerSession` in `SecureStore` for `SAVE_TOKEN`, `ENABLE_BIOMETRIC`, `DISABLE_BIOMETRIC`, and `LOGOUT` message handlers, to stop performing biometric auth during native bootstrap, to memoize `injectedJavaScript`, and to add a `NativeErrorBoundary` around the app.
- Updated the WebView source path to use `'/consumer-login'`, bumped `mobile-app` versions/ build numbers in `app.json`, `package.json`, and `package-lock.json`, and updated `mobile-app/README.md` to reflect behavioral and path changes.

### Testing
- Ran local client and mobile build smoke checks by starting the dev servers (`npm install` and `expo start`) and observed no build-time or injection-script errors.
- Executed automated type/lint checks present in the repo and observed no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f6436c1a4832aaf0ed72dbc9b3572)