### PR TITLE
Add bottom legal policy links

### DIFF
--- a/client/src/components/public-hero-layout.tsx
+++ b/client/src/components/public-hero-layout.tsx
@@ -15,6 +15,7 @@ interface PublicHeroLayoutProps {
   contentClassName?: string;
   mainContainerClassName?: string;
   disableSurface?: boolean;
+  showLegalFooter?: boolean;
 }
 
 export function PublicHeroLayout({
@@ -28,6 +29,7 @@ export function PublicHeroLayout({
   contentClassName,
   mainContainerClassName,
   disableSurface = false,
+  showLegalFooter = true,
 }: PublicHeroLayoutProps) {
   const defaultHeaderActions = (
     <>
@@ -48,14 +50,14 @@ export function PublicHeroLayout({
   );
 
   return (
-    <div className="relative min-h-screen overflow-hidden bg-slate-950 text-white">
+    <div className="relative flex min-h-screen flex-col overflow-hidden bg-slate-950 text-white">
       <div className="pointer-events-none absolute inset-0 overflow-hidden">
         <div className="absolute -top-32 right-0 h-96 w-96 rounded-full bg-blue-500/30 blur-3xl" />
         <div className="absolute bottom-0 left-0 h-[28rem] w-[28rem] rounded-full bg-indigo-500/20 blur-3xl" />
         <div className="absolute top-1/2 left-1/2 h-72 w-72 -translate-x-1/2 -translate-y-1/2 rounded-full bg-blue-400/10 blur-3xl" />
       </div>
 
-      <div className="relative">
+      <div className="relative flex flex-1 flex-col">
         <header className="border-b border-white/10 bg-slate-950/60 backdrop-blur">
           <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-6">
             <div className="flex items-center gap-3">
@@ -71,7 +73,7 @@ export function PublicHeroLayout({
           </div>
         </header>
 
-        <main className={cn("px-6 py-12 sm:py-20", mainContainerClassName)}>
+        <main className={cn("flex-1 px-6 py-12 sm:py-20", mainContainerClassName)}>
           <section className="mx-auto grid max-w-6xl gap-12 lg:grid-cols-[1.1fr_0.9fr] lg:items-start">
             <div>
               {badgeText ? (
@@ -108,6 +110,23 @@ export function PublicHeroLayout({
             ) : null}
           </section>
         </main>
+
+        {showLegalFooter ? (
+          <footer className="mt-auto border-t border-white/10 bg-slate-950/70 px-6 py-5 text-xs text-blue-100/60 backdrop-blur">
+            <div className="mx-auto flex max-w-6xl flex-col items-center justify-between gap-3 sm:flex-row">
+              <div className="flex items-center gap-3">
+                <a href="/terms-of-service" className="transition hover:text-white hover:underline">
+                  Terms of Service
+                </a>
+                <span>•</span>
+                <a href="/privacy-policy" className="transition hover:text-white hover:underline">
+                  Privacy Policy
+                </a>
+              </div>
+              <p>Secure access powered by Chain Software Group</p>
+            </div>
+          </footer>
+        ) : null}
       </div>
     </div>
   );

--- a/client/src/pages/consumer-login.tsx
+++ b/client/src/pages/consumer-login.tsx
@@ -609,19 +609,6 @@ export default function ConsumerLogin() {
             </div>
           </div>
         </div>
-
-        <div className="flex flex-wrap items-center justify-between gap-3 text-xs text-blue-100/60">
-          <div className="flex items-center gap-3">
-            <a href="/terms-of-service" className="transition hover:text-white hover:underline">
-              Terms of Service
-            </a>
-            <span>•</span>
-            <a href="/privacy-policy" className="transition hover:text-white hover:underline">
-              Privacy Policy
-            </a>
-          </div>
-          <p>Secure access powered by Chain Software Group</p>
-        </div>
       </div>
     </PublicHeroLayout>
   );

--- a/client/src/pages/consumer-registration.tsx
+++ b/client/src/pages/consumer-registration.tsx
@@ -558,19 +558,6 @@ export default function ConsumerRegistration() {
             )}
           </Button>
         </form>
-
-        <div className="flex flex-wrap items-center justify-between gap-3 text-xs text-blue-100/60">
-          <div className="flex items-center gap-3">
-            <a href="/terms-of-service" className="transition hover:text-white hover:underline">
-              Terms of Service
-            </a>
-            <span>•</span>
-            <a href="/privacy-policy" className="transition hover:text-white hover:underline">
-              Privacy Policy
-            </a>
-          </div>
-          <p>Need help? Contact your agency’s support team anytime.</p>
-        </div>
       </div>
     </PublicHeroLayout>
   );

--- a/client/src/pages/mobile-app-register.tsx
+++ b/client/src/pages/mobile-app-register.tsx
@@ -203,7 +203,7 @@ export default function MobileAppRegister() {
       </div>
 
       {/* Registration Form */}
-      <div className="relative z-10 flex items-start justify-center pb-8">
+      <div className="relative z-10 flex flex-1 items-start justify-center pb-8">
         <div className="w-full max-w-md min-w-0 space-y-6">
           {/* Header */}
           <div className="text-center space-y-2">
@@ -401,7 +401,15 @@ export default function MobileAppRegister() {
                   htmlFor="agreeToTerms"
                   className="text-sm text-white/70 leading-relaxed cursor-pointer"
                 >
-                  I agree to the Terms of Service and Privacy Policy *
+                  I agree to the {" "}
+                  <a href="/terms-of-service" target="_blank" rel="noreferrer" className="text-blue-300 underline hover:text-blue-200">
+                    Terms of Service
+                  </a>{" "}
+                  and {" "}
+                  <a href="/privacy-policy" target="_blank" rel="noreferrer" className="text-blue-300 underline hover:text-blue-200">
+                    Privacy Policy
+                  </a>{" "}
+                  *
                 </Label>
               </div>
 
@@ -434,6 +442,18 @@ export default function MobileAppRegister() {
           </form>
         </div>
       </div>
+
+      <footer className="relative z-10 mt-auto border-t border-white/10 pt-4 text-xs text-blue-100/60">
+        <div className="flex flex-wrap items-center justify-center gap-3">
+          <a href="/terms-of-service" className="transition hover:text-white hover:underline">
+            Terms of Service
+          </a>
+          <span>•</span>
+          <a href="/privacy-policy" className="transition hover:text-white hover:underline">
+            Privacy Policy
+          </a>
+        </div>
+      </footer>
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Make Terms of Service and Privacy Policy links consistently available at the bottom of public-facing screens so users can easily tap them.
- Expose clickable policy links in the mobile registration agreement text so users can open the documents before accepting.

### Description
- Add a `showLegalFooter` prop and a shared bottom legal footer to `PublicHeroLayout`, and switch the layout to a column flex container so the footer docks to the bottom of the viewport when content is short.
- Remove duplicate inline legal link blocks from `consumer-login.tsx` and `consumer-registration.tsx` so the shared footer controls bottom placement.
- Update `mobile-app-register.tsx` to render clickable anchor links for Terms of Service and Privacy Policy inside the agreement label and add a bottom legal footer to that screen.

### Testing
- Ran `npm test`, which executed the client unit tests and all tests passed (10/10).
- Ran `npm run check` (`tsc`), which failed due to pre-existing TypeScript errors in unrelated files outside this change (these failures are not introduced by this PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4da3761fb8832aa88dd7888e1eb21a)