### PR TITLE
Mobile: add sliding page transitions and anchor privacy links in mobile login

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,7 @@
-import { Switch, Route } from "wouter";
+import { Switch, Route, useLocation } from "wouter";
 import { useEffect } from "react";
-import type { ComponentType, JSX } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import type { ComponentType, JSX, ReactNode } from "react";
 import { queryClient } from "./lib/queryClient";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { Toaster } from "@/components/ui/toaster";
@@ -49,6 +50,25 @@ import Info from "@/pages/info";
 import Phones from "@/pages/phones";
 import Softphone from "@/pages/softphone";
 import InstallPage from "@/pages/install";
+
+function MobilePageTransition({ children }: { children: ReactNode }) {
+  const [location] = useLocation();
+
+  return (
+    <AnimatePresence mode="wait" initial={false}>
+      <motion.div
+        key={location}
+        className="min-h-screen"
+        initial={{ opacity: 0, x: 36 }}
+        animate={{ opacity: 1, x: 0 }}
+        exit={{ opacity: 0, x: -24 }}
+        transition={{ duration: 0.32, ease: [0.22, 1, 0.36, 1] }}
+      >
+        {children}
+      </motion.div>
+    </AnimatePresence>
+  );
+}
 
 function Router() {
   const { isAuthenticated, isLoading, user, isJwtAuth } = useAuth();
@@ -205,7 +225,11 @@ function Router() {
       );
     }
 
-    return <Switch>{mobileRoutes}</Switch>;
+    return (
+      <MobilePageTransition>
+        <Switch>{mobileRoutes}</Switch>
+      </MobilePageTransition>
+    );
   }
 
   if (shouldShowLoader) {

--- a/client/src/pages/mobile-app-login.tsx
+++ b/client/src/pages/mobile-app-login.tsx
@@ -281,14 +281,15 @@ export default function MobileAppLogin() {
   };
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-slate-950 text-white p-4">
+    <div className="flex min-h-[100dvh] flex-col overflow-x-hidden bg-slate-950 text-white p-4">
       {/* Background gradients */}
       <div className="pointer-events-none fixed inset-0 overflow-hidden">
         <div className="absolute -top-32 right-0 h-96 w-96 rounded-full bg-blue-500/30 blur-3xl" />
         <div className="absolute bottom-0 left-0 h-[28rem] w-[28rem] rounded-full bg-indigo-500/20 blur-3xl" />
       </div>
 
-      <div className="relative w-full max-w-md space-y-8 mt-72">
+      <main className="relative z-10 flex w-full flex-1 items-center justify-center py-8">
+        <div className="w-full max-w-md space-y-8">
         {/* Agency Logo */}
         {agencyContext?.logoUrl ? (
           <div className="flex justify-center">
@@ -417,11 +418,23 @@ export default function MobileAppLogin() {
           </p>
         </div>
 
-        {/* Footer */}
         <p className="text-center text-sm text-blue-100/70">
           Need help? Contact your agency
         </p>
-      </div>
+        </div>
+      </main>
+
+      <footer className="relative z-10 mt-auto border-t border-white/10 pt-4 text-xs text-blue-100/60">
+        <div className="flex flex-wrap items-center justify-center gap-3">
+          <a href="/terms-of-service" className="transition hover:text-white hover:underline">
+            Terms of Service
+          </a>
+          <span>•</span>
+          <a href="/privacy-policy" className="transition hover:text-white hover:underline">
+            Privacy Policy
+          </a>
+        </div>
+      </footer>
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Improve the user experience for the native `/mobile-app` flow by making page changes feel like sliding pages instead of abrupt swaps. 
- Ensure the Privacy Policy and Terms of Service links are anchored to the bottom of the mobile login screen so they are not lost when the page content is vertically centered.

### Description
- Added a `MobilePageTransition` wrapper in `client/src/App.tsx` that uses `framer-motion` (`AnimatePresence` + `motion`) and `useLocation` to animate mobile route changes with opacity and horizontal `x` offsets. 
- Wrapped the mobile-only route set in the new `MobilePageTransition` so mobile routes animate on enter/exit. 
- Reworked the mobile login layout in `client/src/pages/mobile-app-login.tsx` to use a full-height flex layout with a centered `main` region and a dedicated bottom `footer` containing `Terms of Service` and `Privacy Policy` links. 
- Adjusted imports and types in `client/src/App.tsx` to include `useLocation`, `AnimatePresence`, `motion`, and `ReactNode` for the transition component.

### Testing
- Ran `npm test`, which completed successfully (all tests passed). 
- Attempted `npm run check` / `tsc`, which surfaced existing TypeScript errors elsewhere in the repository unrelated to these mobile UI changes and therefore blocked a clean type-check across the whole repo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4dbdd2b414832aa6de68af5e7c3750)