### PR TITLE
Fix document signing: consumer auth, canvas scaling, signed-copy persistence, and receipts

### DIFF
--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -5,7 +5,10 @@ import { getStoredConsumerToken } from "./consumer-auth";
 
 function isConsumerEndpoint(url: string): boolean {
   const normalized = url.toLowerCase();
-  return normalized.includes("/consumer/") || normalized.includes("/consumer-");
+  return normalized.includes("/consumer/") ||
+    normalized.includes("/consumer-") ||
+    normalized.includes("/signature-requests/") ||
+    normalized.includes("/signed-documents/");
 }
 
 export class ApiError extends Error {

--- a/client/src/pages/sign-document.tsx
+++ b/client/src/pages/sign-document.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useMemo } from "react";
 import { useQuery, useMutation } from "@tanstack/react-query";
-import { queryClient } from "@/lib/queryClient";
+import { apiRequest, queryClient } from "@/lib/queryClient";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -29,19 +29,11 @@ export default function SignDocumentPage() {
 
   const signMutation = useMutation({
     mutationFn: async (data: { signatureData: string; initialsData: string }) => {
-      const response = await fetch(`/api/signature-requests/${requestId}/sign`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ 
+      const response = await apiRequest("POST", `/api/signature-requests/${requestId}/sign`, {
           signatureData: data.signatureData,
           initialsData: data.initialsData,
           legalConsent: true 
-        }),
-      });
-      if (!response.ok) {
-        const error = await response.json();
-        throw new Error(error.message || "Failed to sign document");
-      }
+        });
       return await response.json();
     },
     onSuccess: () => {
@@ -126,13 +118,13 @@ export default function SignDocumentPage() {
     if ('touches' in e) {
       const touch = e.touches[0];
       return {
-        x: touch.clientX - rect.left,
-        y: touch.clientY - rect.top,
+        x: (touch.clientX - rect.left) * (canvas.width / rect.width),
+        y: (touch.clientY - rect.top) * (canvas.height / rect.height),
       };
     } else {
       return {
-        x: e.clientX - rect.left,
-        y: e.clientY - rect.top,
+        x: (e.clientX - rect.left) * (canvas.width / rect.width),
+        y: (e.clientY - rect.top) * (canvas.height / rect.height),
       };
     }
   };
@@ -309,7 +301,7 @@ export default function SignDocumentPage() {
     );
   }
 
-  if (request.status === "completed") {
+  if (request.status === "signed" || request.status === "completed") {
     return (
       <div className="min-h-screen flex items-center justify-center bg-gray-50">
         <Card className="max-w-md shadow-lg">
@@ -355,7 +347,7 @@ export default function SignDocumentPage() {
     <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-slate-100">
       {/* Top Header Bar - DocuSign Style */}
       <div className="bg-white border-b border-slate-200 sticky top-0 z-10 shadow-sm">
-        <div className="max-w-[1800px] mx-auto px-8 py-5">
+        <div className="max-w-[1600px] mx-auto px-4 sm:px-6 py-4">
           <div className="flex items-center justify-between">
             <div className="flex items-center space-x-5">
               <div className="bg-gradient-to-br from-blue-600 to-blue-700 rounded-xl p-2.5 shadow-md">
@@ -371,12 +363,12 @@ export default function SignDocumentPage() {
               </div>
             </div>
             <div className="flex items-center space-x-6">
-              <div className="flex items-center bg-amber-50 border border-amber-200 rounded-lg px-4 py-2">
+              {request.expiresAt && <div className="hidden sm:flex items-center bg-amber-50 border border-amber-200 rounded-lg px-4 py-2">
                 <Clock className="w-4 h-4 mr-2 text-amber-600" />
                 <span className="text-sm font-medium text-amber-700" data-testid="text-expiration">
                   Expires {new Date(request.expiresAt).toLocaleDateString()}
                 </span>
-              </div>
+              </div>}
             </div>
           </div>
           
@@ -391,7 +383,7 @@ export default function SignDocumentPage() {
       </div>
 
       {/* Two-Panel Layout */}
-      <div className="max-w-[1800px] mx-auto p-6">
+      <div className="max-w-[1600px] mx-auto p-3 sm:p-6">
         <div className="flex flex-col lg:flex-row gap-6 min-h-[calc(100vh-180px)]">
           {/* Left Panel - Document Viewer (65% width) */}
           <div className="flex-1 lg:w-[65%]">
@@ -407,13 +399,13 @@ export default function SignDocumentPage() {
               </div>
               
               {/* Document Content */}
-              <div className="p-8 h-[calc(100%-90px)] overflow-auto bg-slate-50">
+              <div className="p-3 sm:p-6 h-[calc(100%-90px)] overflow-auto bg-slate-50">
                 {documentUrlWithSignatures && (
                   <div className="bg-white border-2 border-slate-200 rounded-xl shadow-lg overflow-hidden">
                     <iframe
                       key={documentUrlWithSignatures}
                       src={documentUrlWithSignatures}
-                      className="w-full h-[800px]"
+                      className="w-full h-[60vh] lg:h-[720px]"
                       title="Document Content"
                       sandbox="allow-same-origin"
                       data-testid="iframe-document-content"
@@ -426,7 +418,7 @@ export default function SignDocumentPage() {
 
           {/* Right Panel - Signature Panel (35% width) */}
           <div className="lg:w-[35%]">
-            <div className="bg-white rounded-2xl shadow-xl border border-slate-200 p-8 overflow-y-auto max-h-[calc(100vh-180px)] sticky top-32">
+            <div className="bg-white rounded-2xl shadow-xl border border-slate-200 p-5 sm:p-7 lg:overflow-y-auto lg:max-h-[calc(100vh-150px)] lg:sticky lg:top-24">
               <div className="space-y-7">
               {/* Sign Here Header */}
               <div className="text-center pb-6 border-b border-slate-200">

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -201,6 +201,39 @@ const VALIDATION_NOTICE = `Unless you notify this office within 30 days after re
 
 const ESIGN_CONSENT = `By clicking "I Agree" and signing this document electronically, you consent to conduct this transaction by electronic means. You acknowledge that your electronic signature is the legal equivalent of your manual signature and that you intend to be legally bound by the terms of this agreement. You have the right to request a paper copy of this document.`;
 
+function renderSignedDocumentHtml(fileUrl: string, signatureData: string, initialsData?: string | null): string | null {
+  const urlEncodedMatch = fileUrl.match(/^data:text\/html(?:;charset=utf-8)?,(.+)$/i);
+  const base64Match = fileUrl.match(/^data:text\/html;base64,(.+)$/i);
+  let htmlContent: string;
+
+  try {
+    if (urlEncodedMatch) {
+      htmlContent = decodeURIComponent(urlEncodedMatch[1]);
+    } else if (base64Match) {
+      htmlContent = Buffer.from(base64Match[1], 'base64').toString('utf-8');
+    } else {
+      return null;
+    }
+  } catch {
+    return null;
+  }
+
+  const signatureHtml = `<span style="display:inline-block;border-bottom:1px solid #000;padding:2px 5px"><img src="${signatureData}" alt="Signature" style="max-width:150px;max-height:40px;height:auto;display:inline-block;vertical-align:middle" /></span>`;
+  let signedHtml = htmlContent
+    .replace(/______________/g, signatureHtml)
+    .replace(/\{\{signature\}\}/gi, signatureHtml)
+    .replace(/\{\{SIGNATURE_LINE\}\}/gi, signatureHtml);
+
+  if (initialsData) {
+    const initialsHtml = `<span style="display:inline-block;border-bottom:1px solid #000;padding:2px 5px"><img src="${initialsData}" alt="Initials" style="max-width:50px;max-height:30px;height:auto;display:inline-block;vertical-align:middle" /></span>`;
+    signedHtml = signedHtml
+      .replace(/____(?!_)/g, initialsHtml)
+      .replace(/\{\{initials?\}\}/gi, initialsHtml);
+  }
+
+  return signedHtml;
+}
+
 // Helper function to replace template variables for both email and SMS content
 function replaceTemplateVariables(
   template: string,
@@ -23602,23 +23635,61 @@ export async function registerRoutes(app: Express): Promise<Server> {
         consentText: request.consentText || 'I agree to sign this document electronically.',
       });
 
-      // After successful signature, create a document record so it appears in consumer's Documents section
+      const signedHtml = request.document?.fileUrl
+        ? renderSignedDocumentHtml(request.document.fileUrl, signatureData, initialsData)
+        : null;
+
+      // Store a self-contained signed copy so consumers can view it from their Documents section.
       try {
-        const template = await storage.getDocumentTemplateById(request.documentId, request.tenantId);
         await storage.createDocument({
           tenantId: request.tenantId,
-          title: `Signed: ${request.title || template?.name || 'Document'}`,
+          title: `Signed: ${request.title || 'Document'}`,
           description: `Electronically signed on ${new Date().toLocaleDateString()}`,
-          fileName: `signed-${request.title || 'document'}.pdf`,
-          fileUrl: `/api/signed-documents/${result.signedDocument.id}`, // Link to the signed document
-          fileSize: 0, // Can be updated later if needed
-          mimeType: 'application/pdf',
+          fileName: `signed-${request.title || 'document'}.html`,
+          fileUrl: signedHtml
+            ? `data:text/html;charset=utf-8,${encodeURIComponent(signedHtml)}`
+            : request.document.fileUrl,
+          fileSize: signedHtml?.length || request.document.fileSize || 0,
+          mimeType: 'text/html',
           isPublic: false,
           accountId: request.accountId,
         });
       } catch (docError) {
         console.error("Error creating document record after signature:", docError);
         // Don't fail the signature if document creation fails - signature is more important
+      }
+
+      // Deliver receipt links to both parties after the legal record has been saved.
+      try {
+        const tenant = await storage.getTenant(request.tenantId);
+        const settings = await storage.getTenantSettings(request.tenantId);
+        const portalUrl = resolveConsumerPortalUrl({
+          tenantSlug: tenant?.slug,
+          consumerPortalSettings: settings?.consumerPortalSettings,
+          baseUrl: ensureBaseUrl(req),
+        });
+        const receiptHtml = `<p>The document <strong>${request.title}</strong> was electronically signed on ${new Date(result.signedDocument.signedAt).toLocaleString()}.</p><p>A signed copy is available in the customer's Documents section.</p><p><a href="${portalUrl}">Open the customer portal</a></p>`;
+
+        if (consumer.email) {
+          await emailService.sendEmail({
+            to: consumer.email,
+            subject: `Signed document copy: ${request.title}`,
+            html: `<p>Hello ${consumer.firstName || 'there'},</p>${receiptHtml}`,
+            tenantId: request.tenantId,
+            consumerId: consumer.id,
+          });
+        }
+        if (settings?.contactEmail && settings.contactEmail.toLowerCase() !== consumer.email?.toLowerCase()) {
+          await emailService.sendEmail({
+            to: settings.contactEmail,
+            subject: `Document signed: ${request.title}`,
+            html: receiptHtml,
+            tenantId: request.tenantId,
+            consumerId: consumer.id,
+          });
+        }
+      } catch (emailError) {
+        console.error("Error sending signed document receipts:", emailError);
       }
 
       res.json(result);


### PR DESCRIPTION
### Motivation

- Users were unable to complete signatures because signing submissions were not sent with the consumer authentication token and the signed copy was not persisted into the customer's Documents list.
- Touch and mouse input produced inaccurate strokes when the canvas was rendered at a different CSS size than its internal resolution.
- Completed signatures were not consistently recognized by the UI and the signer/company did not receive a receipt with the signed copy link.

### Description

- Ensure client requests to signature endpoints use the consumer token by expanding `isConsumerEndpoint` in `client/src/lib/queryClient.ts` and switching the signing submission to the shared `apiRequest` client in `client/src/pages/sign-document.tsx` so Authorization headers are applied.
- Fix pointer scaling by converting mouse/touch coordinates to canvas pixel coordinates in `client/src/pages/sign-document.tsx` so strokes track accurately when the canvas is resized.
- Treat the server `signed` state as a completed request in the UI and improve the signing page responsive layout and iframe sizing for mobile and desktop in `client/src/pages/sign-document.tsx`.
- Add server-side rendering of a self-contained signed HTML (embedding signature/initials images) via `renderSignedDocumentHtml`, persist the signed copy with `storage.createDocument` (HTML data URL), and send email receipts to the signer and company contact in `server/routes.ts` so signed documents appear in the customer's Documents section and both parties receive notifications.

### Testing

- Ran TypeScript checks with `npm run check`, which completed successfully.
- Ran unit tests with `npm test`, all tests passed (10 tests, 0 failures).
- Built the production assets with `npm run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7210050510832a9b82dc8bd9cf5995)