### PR TITLE
Add monthly payment audit CSV export and sequence integrity audit

### DIFF
--- a/client/src/pages/__tests__/paymentAuditHelpers.test.ts
+++ b/client/src/pages/__tests__/paymentAuditHelpers.test.ts
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { buildPaymentAuditCsv, paymentsForMonth } from "../paymentAuditHelpers";
+
+test("paymentsForMonth uses processed date and includes every status", () => {
+  const payments = [
+    { id: "1", status: "completed", createdAt: "2026-01-01T00:00:00Z", processedAt: "2026-02-03T12:00:00Z" },
+    { id: "2", status: "failed", createdAt: "2026-02-28T12:00:00Z" },
+    { id: "3", status: "completed", createdAt: "2026-03-01T00:00:00Z" },
+  ];
+  assert.deepEqual(paymentsForMonth(payments, "2026-02").map((p) => p.id), ["1", "2"]);
+});
+
+test("buildPaymentAuditCsv formats cents and escapes audit fields", () => {
+  const csv = buildPaymentAuditCsv([{ amountCents: 12345, consumerName: 'Doe, "Jane"', status: "completed" }]);
+  assert.match(csv, /"123\.45"/);
+  assert.match(csv, /"Doe, ""Jane"""/);
+});

--- a/client/src/pages/communications.tsx
+++ b/client/src/pages/communications.tsx
@@ -725,6 +725,11 @@ export default function Communications() {
     enabled: !!userData,
   });
 
+  const { data: sequenceAudit, isLoading: sequenceAuditLoading, refetch: refetchSequenceAudit } = useQuery({
+    queryKey: ['/api/sequences-audit'],
+    enabled: !!userData,
+  });
+
   const { data: sequenceEnrollments } = useQuery({
     queryKey: ['/api/sequences', viewingEnrollmentsSequenceId, 'enrollments'],
     enabled: viewingEnrollmentsSequenceId !== null,
@@ -5413,6 +5418,35 @@ export default function Communications() {
           </TabsContent>
 
           <TabsContent value="sequences" className="space-y-10 text-white">
+            <Card className="border-white/15 bg-white/5 text-blue-50" data-testid="sequence-integrity-audit">
+              <CardHeader className="flex flex-row items-center justify-between">
+                <div>
+                  <CardTitle className="flex items-center gap-2"><ShieldCheck className="h-5 w-5 text-emerald-300" /> Sequence Integrity Audit</CardTitle>
+                  <p className="mt-2 text-sm text-blue-100/70">Checks step numbering, enrollment pointers, send times, and overdue messages.</p>
+                </div>
+                <Button variant="outline" onClick={() => refetchSequenceAudit()} disabled={sequenceAuditLoading} className="border-white/20 bg-white/10 text-white hover:bg-white/20">
+                  <RefreshCw className={cn("mr-2 h-4 w-4", sequenceAuditLoading && "animate-spin")} /> Run audit
+                </Button>
+              </CardHeader>
+              <CardContent>
+                {sequenceAuditLoading ? <p className="text-blue-100/70">Auditing sequences…</p> : sequenceAudit ? (
+                  <div className="space-y-4">
+                    <div className="flex flex-wrap items-center gap-3">
+                      <Badge className={(sequenceAudit as any).healthy ? "bg-emerald-600" : "bg-amber-600"}>{(sequenceAudit as any).healthy ? "All checks passed" : "Attention required"}</Badge>
+                      <span className="text-sm text-blue-100/70">{(sequenceAudit as any).errorCount} errors · {(sequenceAudit as any).warningCount} warnings · checked {new Date((sequenceAudit as any).checkedAt).toLocaleString()}</span>
+                    </div>
+                    {(sequenceAudit as any).sequences.filter((item: any) => item.issues.length > 0).map((item: any) => (
+                      <div key={item.id} className="rounded-xl border border-amber-400/25 bg-amber-500/10 p-4">
+                        <p className="font-semibold">{item.name} <span className="font-normal text-blue-100/60">({item.stepCount} steps, {item.enrollmentCount} enrollments)</span></p>
+                        <ul className="mt-2 space-y-1 text-sm">
+                          {item.issues.map((issue: any, index: number) => <li key={index} className={issue.severity === 'error' ? 'text-rose-200' : 'text-amber-200'}>• {issue.message}</li>)}
+                        </ul>
+                      </div>
+                    ))}
+                  </div>
+                ) : <p className="text-blue-100/70">Sequence audit is unavailable.</p>}
+              </CardContent>
+            </Card>
             <div className="flex items-center justify-between">
               <h2 className="text-xl font-semibold">Communication Sequences</h2>
               <Dialog open={showSequenceModal} onOpenChange={setShowSequenceModal}>

--- a/client/src/pages/paymentAuditHelpers.ts
+++ b/client/src/pages/paymentAuditHelpers.ts
@@ -1,0 +1,38 @@
+export function paymentAuditDate(payment: any): Date | null {
+  const value = payment.processedAt || payment.createdAt;
+  if (!value) return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+export function paymentsForMonth(payments: any[], month: string): any[] {
+  if (!/^\d{4}-\d{2}$/.test(month)) return [];
+  return payments.filter((payment) => {
+    const date = paymentAuditDate(payment);
+    if (!date) return false;
+    return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}` === month;
+  });
+}
+
+function csvCell(value: unknown): string {
+  const text = value == null ? "" : String(value);
+  return `"${text.replace(/"/g, '""')}"`;
+}
+
+export function buildPaymentAuditCsv(payments: any[]): string {
+  const headers = ["Date", "Consumer", "Email", "Account", "Status", "Method", "Amount", "Transaction ID"];
+  const rows = payments.map((payment) => {
+    const date = paymentAuditDate(payment);
+    return [
+      date?.toISOString() || "",
+      payment.consumerName,
+      payment.consumerEmail,
+      payment.accountCreditor,
+      payment.status,
+      payment.paymentMethod,
+      ((payment.amountCents || 0) / 100).toFixed(2),
+      payment.transactionId,
+    ].map(csvCell).join(",");
+  });
+  return [headers.map(csvCell).join(","), ...rows].join("\n");
+}

--- a/client/src/pages/payments.tsx
+++ b/client/src/pages/payments.tsx
@@ -16,13 +16,18 @@ import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
-import { CreditCard, DollarSign, TrendingUp, Clock, CheckCircle, Calendar, User, Building2, Lock, Trash2, ThumbsUp, ThumbsDown, RefreshCw, History, Check, XCircle, Search, Settings, Edit, Mail, MessageSquare, AlertTriangle, Phone } from "lucide-react";
+import { CreditCard, DollarSign, TrendingUp, Clock, CheckCircle, Calendar, User, Building2, Lock, Trash2, ThumbsUp, ThumbsDown, RefreshCw, History, Check, XCircle, Search, Settings, Edit, Mail, MessageSquare, AlertTriangle, Phone, Download } from "lucide-react";
 import { PaymentSchedulingCalendar } from "@/components/payment-scheduling-calendar";
+import { buildPaymentAuditCsv, paymentsForMonth } from "./paymentAuditHelpers";
 
 export default function Payments() {
   const { toast } = useToast();
   const queryClient = useQueryClient();
   const [filterStatus, setFilterStatus] = useState("all");
+  const [auditMonth, setAuditMonth] = useState(() => {
+    const date = new Date();
+    return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
+  });
   const [showPayNowModal, setShowPayNowModal] = useState(false);
   const [paymentToDelete, setPaymentToDelete] = useState<string | null>(null);
   const [selectedConsumerForArrangement, setSelectedConsumerForArrangement] = useState<any | null>(null);
@@ -427,26 +432,22 @@ export default function Payments() {
     return payment.status === filterStatus;
   }) || [];
 
-  const now = new Date();
-  const currentMonth = now.getMonth();
-  const currentYear = now.getFullYear();
-  const monthName = now.toLocaleString('en-US', { month: 'long', year: 'numeric' });
-
-  const isCurrentMonth = (dateStr: any) => {
-    if (!dateStr) return false;
-    const d = new Date(dateStr);
-    if (isNaN(d.getTime())) return false;
-    return d.getMonth() === currentMonth && d.getFullYear() === currentYear;
-  };
-
-  const thisMonthPayments = (payments as any[])?.filter((payment: any) =>
-    isCurrentMonth(payment.processedAt || payment.createdAt) && payment.status === 'completed'
-  ) || [];
+  const auditPayments = paymentsForMonth((payments as any[]) || [], auditMonth);
+  const thisMonthPayments = auditPayments.filter((payment: any) => payment.status === 'completed');
 
   const thisMonthTotal = thisMonthPayments.reduce((sum: number, p: any) => sum + (p.amountCents || 0), 0);
-  const thisMonthFailed = (payments as any[])?.filter((payment: any) =>
-    isCurrentMonth(payment.processedAt || payment.createdAt) && payment.status === 'failed'
-  )?.length || 0;
+  const thisMonthFailed = auditPayments.filter((payment: any) => payment.status === 'failed').length;
+  const monthName = new Date(`${auditMonth}-01T12:00:00`).toLocaleString('en-US', { month: 'long', year: 'numeric' });
+
+  const downloadMonthlyAudit = () => {
+    const blob = new Blob([buildPaymentAuditCsv(auditPayments)], { type: "text/csv;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = `payment-audit-${auditMonth}.csv`;
+    link.click();
+    URL.revokeObjectURL(url);
+  };
 
   const stats = (paymentStats as any) || {
     totalProcessed: 0,
@@ -562,19 +563,25 @@ export default function Payments() {
         </section>
 
         <section className={cn(glassPanelClass, "p-6")}>
-          <div className="flex items-center justify-between mb-4">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between mb-4">
             <div className="flex items-center gap-3">
               <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-emerald-500/20">
                 <TrendingUp className="h-5 w-5 text-emerald-300" />
               </div>
               <div>
-                <h2 className="text-lg font-semibold text-white">Processed This Month</h2>
+                <h2 className="text-lg font-semibold text-white">Monthly Payment Audit</h2>
                 <p className="text-xs text-blue-100/60">{monthName}</p>
               </div>
             </div>
-            <div className="text-right">
+            <div className="flex flex-wrap items-center justify-end gap-3">
+              <Input type="month" value={auditMonth} onChange={(event) => setAuditMonth(event.target.value)} className="w-44 border-white/20 bg-white/10 text-white" data-testid="input-audit-month" />
+              <Button variant="outline" onClick={downloadMonthlyAudit} className="border-white/20 bg-white/10 text-white hover:bg-white/20" data-testid="button-export-payment-audit">
+                <Download className="mr-2 h-4 w-4" /> Export CSV
+              </Button>
+              <div className="text-right">
               <p className="text-2xl font-bold text-emerald-300">{formatCurrency(thisMonthTotal)}</p>
-              <p className="text-xs text-blue-100/60">{thisMonthPayments.length} successful{thisMonthFailed > 0 ? ` / ${thisMonthFailed} failed` : ''}</p>
+              <p className="text-xs text-blue-100/60">{auditPayments.length} total / {thisMonthPayments.length} successful{thisMonthFailed > 0 ? ` / ${thisMonthFailed} failed` : ''}</p>
+              </div>
             </div>
           </div>
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -6697,6 +6697,46 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  // Read-only integrity audit for sequence configuration and active enrollment progress.
+  app.get('/api/sequences-audit', authenticateUser, async (req: any, res) => {
+    try {
+      const tenantId = req.user.tenantId;
+      if (!tenantId) return res.status(403).json({ message: "No tenant access" });
+
+      const sequences = await storage.getCommunicationSequencesByTenant(tenantId);
+      const now = Date.now();
+      const results = await Promise.all(sequences.map(async (sequence: any) => {
+        const [steps, enrollments] = await Promise.all([
+          storage.getSequenceSteps(sequence.id),
+          storage.getSequenceEnrollments(sequence.id),
+        ]);
+        const issues: Array<{ severity: 'error' | 'warning'; message: string }> = [];
+        const orders = steps.map((step: any) => Number(step.stepOrder));
+        const expected = steps.map((_: any, index: number) => index + 1);
+        if (sequence.isActive && steps.length === 0) issues.push({ severity: 'error', message: 'Active sequence has no steps.' });
+        if (orders.some((order: number, index: number) => order !== expected[index])) {
+          issues.push({ severity: 'error', message: `Step order must be contiguous from 1 (found: ${orders.join(', ') || 'none'}).` });
+        }
+
+        for (const enrollment of enrollments.filter((item: any) => item.status === 'active')) {
+          const current = steps.find((step: any) => step.id === enrollment.currentStepId);
+          const consumerName = `${enrollment.consumer?.firstName || ''} ${enrollment.consumer?.lastName || ''}`.trim() || enrollment.consumerId;
+          if (!current) issues.push({ severity: 'error', message: `${consumerName}: current step is missing.` });
+          else if (Number(current.stepOrder) !== Number(enrollment.currentStepOrder)) issues.push({ severity: 'error', message: `${consumerName}: saved step number does not match the current step.` });
+          if (!enrollment.nextMessageAt) issues.push({ severity: 'warning', message: `${consumerName}: active enrollment has no next send time.` });
+          else if (new Date(enrollment.nextMessageAt).getTime() < now - 30 * 60 * 1000) issues.push({ severity: 'warning', message: `${consumerName}: next message is overdue by more than 30 minutes.` });
+        }
+        return { id: sequence.id, name: sequence.name, isActive: sequence.isActive, stepCount: steps.length, enrollmentCount: enrollments.length, issues };
+      }));
+      const errorCount = results.reduce((total, item) => total + item.issues.filter((issue) => issue.severity === 'error').length, 0);
+      const warningCount = results.reduce((total, item) => total + item.issues.filter((issue) => issue.severity === 'warning').length, 0);
+      res.json({ checkedAt: new Date().toISOString(), healthy: errorCount === 0 && warningCount === 0, errorCount, warningCount, sequences: results });
+    } catch (error) {
+      console.error("Error auditing sequences:", error);
+      res.status(500).json({ message: "Failed to audit sequences" });
+    }
+  });
+
   app.get('/api/sequences/:id', authenticateUser, async (req: any, res) => {
     try {
       const tenantId = req.user.tenantId;


### PR DESCRIPTION
### Motivation

- Provide admins with an easy way to audit all payments for a given month from the web/admin UI and export them as CSV for recordkeeping and reconciliation.
- Give operators a lightweight integrity check to verify that communication sequences and enrollments are correctly ordered and that active enrollments are not stalled or mis-pointed.

### Description

- Added `client/src/pages/paymentAuditHelpers.ts` with `paymentAuditDate`, `paymentsForMonth`, and `buildPaymentAuditCsv` to standardize month filtering (prefer `processedAt`) and produce a safely-escaped CSV.
- Updated `client/src/pages/payments.tsx` to add a month picker (`input[type=month]`), monthly audit totals, and an `Export CSV` button that uses `buildPaymentAuditCsv` to download `payment-audit-<YYYY-MM>.csv`.
- Added unit tests `client/src/pages/__tests__/paymentAuditHelpers.test.ts` for `paymentsForMonth` and `buildPaymentAuditCsv` to validate date selection, status inclusion, cents formatting, and CSV escaping.
- Implemented a read-only server endpoint `GET /api/sequences-audit` in `server/routes.ts` that inspects sequences, their steps, and enrollments and reports errors/warnings (missing steps for active sequences, non-contiguous step order, missing/mismatched current step pointers, missing `nextMessageAt`, and overdue sends).
- Exposed an on-demand Sequence Integrity Audit panel in `client/src/pages/communications.tsx` that displays health status, error/warning counts, per-sequence findings, and a `Run audit` button that re-triggers the endpoint.

### Testing

- Ran unit tests with `npm test` and all tests passed (12 tests passed). 
- Ran TypeScript validation with `npm run check` and `tsc` completed without errors. 
- Built production bundles with `npm run build` and the client/server bundles were produced successfully. 
- Performed lint/whitespace check via `git diff --check` with no reported issues and the new tests exercised the monthly filtering and CSV formatting behavior successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a74a49d7938832aab4a5cdfb9e94db8)