### PR TITLE
Add Chain Campus module foundation

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -50,6 +50,7 @@ import Info from "@/pages/info";
 import Phones from "@/pages/phones";
 import Softphone from "@/pages/softphone";
 import InstallPage from "@/pages/install";
+import Campus from "@/pages/campus";
 
 function MobilePageTransition({ children }: { children: ReactNode }) {
   const [location] = useLocation();
@@ -302,7 +303,8 @@ function Router() {
         <Route key="agency-billing" path="/billing" component={Billing} />,
         <Route key="agency-settings" path="/settings" component={Settings} />,
         <Route key="agency-documents" path="/documents" component={Documents} />,
-        <Route key="agency-phones" path="/phones" component={Phones} />
+        <Route key="agency-phones" path="/phones" component={Phones} />,
+        <Route key="agency-campus" path="/campus" component={Campus} />
       );
     }
 
@@ -399,6 +401,7 @@ function Router() {
     <Route key="auth-phones" path="/phones" component={Phones} />,
     <Route key="auth-softphone" path="/softphone" component={Softphone} />,
     <Route key="auth-install" path="/install" component={InstallPage} />,
+    <Route key="auth-campus" path="/campus" component={Campus} />,
     ...createRouteElements(adminRoutePaths, GlobalAdmin, "auth-admin"),
     <Route key="auth-agency-login" path="/agency-login" component={AgencyLogin} />,
     <Route key="auth-agency-register" path="/agency-register" component={AgencyRegistration} />,

--- a/client/src/components/admin-layout.tsx
+++ b/client/src/components/admin-layout.tsx
@@ -128,6 +128,7 @@ export default function AdminLayout({ children }: AdminLayoutProps) {
   
   const navigationItems = [
     { name: "Dashboard", href: buildNavHref("/dashboard"), icon: "fas fa-chart-bar" },
+    ...((tenantSettings as any)?.businessType === "higher_education" ? [{ name: "Chain Campus", href: buildNavHref("/campus"), icon: "fas fa-university" }] : []),
     { name: "Accounts", href: buildNavHref("/accounts"), icon: "fas fa-file-invoice-dollar" },
     { name: "Communications", href: buildNavHref("/communications"), icon: "fas fa-comments" },
     { name: "Inbox", href: buildNavHref("/email-inbox"), icon: "fas fa-inbox" },

--- a/client/src/pages/__tests__/campus-organization.test.ts
+++ b/client/src/pages/__tests__/campus-organization.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { CAMPUS_DEPARTMENTS } from "@shared/campus";
+import { insertCampusDepartmentSchema } from "@shared/schema";
+import { getTerminology } from "@shared/terminology";
+
+test("Campus terminology maps existing entities without changing the shared model", () => {
+  const terms = getTerminology("higher_education");
+  assert.equal(terms.consumer, "Student");
+  assert.equal(terms.creditor, "Department");
+  assert.equal(terms.settlement, "Payment Plan");
+});
+
+test("Campus provides the requested university department examples", () => {
+  for (const name of ["Student Accounts", "Housing", "Parking", "Admissions", "Dining", "Athletics", "Bookstore", "Financial Aid", "Registrar", "Continuing Education"]) {
+    assert.ok(CAMPUS_DEPARTMENTS.includes(name as typeof CAMPUS_DEPARTMENTS[number]));
+  }
+});
+
+test("department input accepts organization fields but never a caller-supplied tenant", () => {
+  const parsed = insertCampusDepartmentSchema.parse({
+    name: "Student Accounts",
+    code: "STUACCT",
+    description: "University receivables",
+    color: "#2563eb",
+    tenantId: "00000000-0000-0000-0000-000000000000",
+  });
+  assert.equal(parsed.name, "Student Accounts");
+  assert.equal("tenantId" in parsed, false);
+  assert.throws(() => insertCampusDepartmentSchema.parse({ name: "Housing", code: "not valid!" }));
+});

--- a/client/src/pages/agency-registration.tsx
+++ b/client/src/pages/agency-registration.tsx
@@ -20,7 +20,7 @@ const registrationWithCredentialsSchema = agencyTrialRegistrationSchema.extend({
   username: z.string().min(3, "Username must be at least 3 characters").max(50),
   password: z.string().min(8, "Password must be at least 8 characters").max(100),
   confirmPassword: z.string(),
-  businessType: z.enum(['call_center', 'billing_service', 'subscription_provider', 'freelancer_consultant', 'property_management']).default('call_center'),
+  businessType: z.enum(['call_center', 'billing_service', 'subscription_provider', 'freelancer_consultant', 'property_management', 'nonprofit_organization', 'higher_education']).default('call_center'),
   billingMode: z.enum(['subscription', 'wallet']).default('subscription'),
 }).refine(data => data.password === data.confirmPassword, {
   message: "Passwords don't match",

--- a/client/src/pages/campus.tsx
+++ b/client/src/pages/campus.tsx
@@ -1,12 +1,19 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
 import { Link } from "wouter";
 import AdminLayout from "@/components/admin-layout";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Building2, CreditCard, GraduationCap, Landmark, Plug, ReceiptText, RotateCcw, Users } from "lucide-react";
-import { CAMPUS_DEPARTMENTS, CAMPUS_INTEGRATIONS, CAMPUS_NOTIFICATION_TEMPLATES, DEFAULT_CAMPUS_CONFIG, type CampusConfig } from "@shared/campus";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Building2, CreditCard, GraduationCap, Landmark, Loader2, Plug, Plus, ReceiptText, RotateCcw, Users } from "lucide-react";
+import { CAMPUS_INTEGRATIONS, CAMPUS_NOTIFICATION_TEMPLATES, DEFAULT_CAMPUS_CONFIG, type CampusConfig } from "@shared/campus";
+import { apiRequest } from "@/lib/queryClient";
+import { useToast } from "@/hooks/use-toast";
 
 const workspaceLinks = [
   { title: "Students", description: "Search student profiles and communication history.", href: "/consumers", icon: Users },
@@ -18,7 +25,6 @@ const workspaceLinks = [
 export default function Campus() {
   const { data: settings } = useQuery<any>({ queryKey: ["/api/settings"] });
   const config: CampusConfig = settings?.campusConfig || {};
-  const departments = config.departments?.length ? config.departments : DEFAULT_CAMPUS_CONFIG.departments;
   const universityName = config.universityName || "Your University";
   const primaryColor = config.primaryColor || DEFAULT_CAMPUS_CONFIG.primaryColor;
 
@@ -52,7 +58,7 @@ export default function Campus() {
               {["Today’s Payments", "Outstanding Balances", "Active Payment Plans", "Refund Queue", "Declined Payments", "Department Revenue", "Past Due Students", "Recent Activity"].map((label) => <Card key={label} className="border-white/10 bg-slate-900 text-white"><CardContent className="p-5"><p className="text-sm text-slate-400">{label}</p><p className="mt-3 text-2xl font-semibold">—</p><p className="mt-1 text-xs text-slate-500">Uses existing reporting data</p></CardContent></Card>)}
             </div>
           </TabsContent>
-          <TabsContent value="departments" className="mt-5"><div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">{departments.map((name) => <Card key={name} className="border-white/10 bg-white/5 text-white"><CardHeader className="flex-row items-center gap-3"><Building2 className="h-6 w-6 text-sky-300" /><div><CardTitle className="text-base">{name}</CardTitle><CardDescription className="text-slate-400">Revenue · Payments · Balances · Reports</CardDescription></div></CardHeader></Card>)}</div></TabsContent>
+          <TabsContent value="departments" className="mt-5"><DepartmentsPanel /></TabsContent>
           <TabsContent value="cashiering" className="mt-5"><FeaturePanel icon={Landmark} title="Campus Cashiering" description="Extends manual payments with cash, check, money order, card and other tenders." items={["Open Shift", "Record Payment", "Close Shift", "Daily Reconciliation", "Deposit Report", "Printable Receipt"]} /></TabsContent>
           <TabsContent value="refunds" className="mt-5"><FeaturePanel icon={RotateCcw} title="Refund Center" description="A controlled workflow reusing payment records and processor references." items={["Pending", "Approved", "Rejected", "Processed", "Completed"]} /></TabsContent>
           <TabsContent value="integrations" className="mt-5"><div className="grid gap-4 md:grid-cols-2">{CAMPUS_INTEGRATIONS.map((integration) => { const enabled = config.integrations?.[integration.id]?.enabled; return <Card key={integration.id} className="border-white/10 bg-white/5 text-white"><CardHeader className="flex-row items-center justify-between"><div className="flex items-center gap-3"><Plug className="h-5 w-5 text-sky-300" /><div><CardTitle className="text-base">{integration.name}</CardTitle><CardDescription className="text-slate-400">{integration.category}</CardDescription></div></div><Badge variant="outline" className={enabled ? "border-emerald-400/40 text-emerald-300" : "border-slate-600 text-slate-400"}>{enabled ? "Configured" : "Interface ready"}</Badge></CardHeader></Card>; })}</div><p className="mt-4 text-sm text-slate-400">Providers are configuration hooks only; no integration is hard-coded.</p></TabsContent>
@@ -61,6 +67,55 @@ export default function Campus() {
       </main>
     </AdminLayout>
   );
+}
+
+type Department = {
+  id: string; name: string; code: string; description: string | null; color: string;
+  isActive: boolean; accountCount: number; outstandingBalanceCents: number;
+};
+
+function DepartmentsPanel() {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  const [open, setOpen] = useState(false);
+  const [form, setForm] = useState({ name: "", code: "", description: "", color: "#2563eb" });
+  const { data: departments = [], isLoading } = useQuery<Department[]>({ queryKey: ["/api/campus/departments"] });
+
+  const createDepartment = useMutation({
+    mutationFn: async () => (await apiRequest("POST", "/api/campus/departments", form)).json(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/campus/departments"] });
+      setForm({ name: "", code: "", description: "", color: "#2563eb" });
+      setOpen(false);
+      toast({ title: "Department created", description: "The department was added under this university." });
+    },
+    onError: (error: Error) => toast({ title: "Unable to create department", description: error.message, variant: "destructive" }),
+  });
+  const updateDepartment = useMutation({
+    mutationFn: async ({ id, isActive }: Pick<Department, "id" | "isActive">) =>
+      (await apiRequest("PATCH", `/api/campus/departments/${id}`, { isActive })).json(),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["/api/campus/departments"] }),
+    onError: (error: Error) => toast({ title: "Unable to update department", description: error.message, variant: "destructive" }),
+  });
+
+  return <div>
+    <div className="mb-5 flex flex-col justify-between gap-3 sm:flex-row sm:items-center">
+      <div><h2 className="text-xl font-semibold">University departments</h2><p className="mt-1 text-sm text-slate-400">Departments share this university’s tenant, authentication, billing, branding, and data boundary.</p></div>
+      <Dialog open={open} onOpenChange={setOpen}><DialogTrigger asChild><Button className="bg-blue-600 hover:bg-blue-500"><Plus className="mr-2 h-4 w-4" />Add department</Button></DialogTrigger>
+        <DialogContent className="border-white/10 bg-slate-900 text-white"><DialogHeader><DialogTitle>Add university department</DialogTitle><DialogDescription className="text-slate-400">This creates a department inside the current university—not a separate organization.</DialogDescription></DialogHeader>
+          <div className="space-y-4">
+            <div><Label htmlFor="department-name">Name</Label><Input id="department-name" className="mt-1 border-white/15 bg-slate-950" value={form.name} onChange={(event) => setForm({ ...form, name: event.target.value })} placeholder="Student Accounts" /></div>
+            <div><Label htmlFor="department-code">Code</Label><Input id="department-code" className="mt-1 border-white/15 bg-slate-950 uppercase" value={form.code} onChange={(event) => setForm({ ...form, code: event.target.value })} placeholder="STUACCT" /></div>
+            <div><Label htmlFor="department-description">Description</Label><Textarea id="department-description" className="mt-1 border-white/15 bg-slate-950" value={form.description} onChange={(event) => setForm({ ...form, description: event.target.value })} /></div>
+            <div><Label htmlFor="department-color">Dashboard color</Label><div className="mt-1 flex gap-2"><Input id="department-color" type="color" className="h-10 w-14 border-white/15 bg-slate-950 p-1" value={form.color} onChange={(event) => setForm({ ...form, color: event.target.value })} /><Input className="border-white/15 bg-slate-950" value={form.color} onChange={(event) => setForm({ ...form, color: event.target.value })} /></div></div>
+            <Button className="w-full bg-blue-600" disabled={!form.name.trim() || !form.code.trim() || createDepartment.isPending} onClick={() => createDepartment.mutate()}>{createDepartment.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}Create department</Button>
+          </div>
+        </DialogContent></Dialog>
+    </div>
+    {isLoading ? <div className="flex justify-center p-12"><Loader2 className="h-7 w-7 animate-spin text-sky-300" /></div> : departments.length === 0 ?
+      <Card className="border-dashed border-white/15 bg-white/5 text-center text-white"><CardContent className="p-10"><Building2 className="mx-auto h-9 w-9 text-slate-500" /><p className="mt-3 font-medium">No departments yet</p><p className="mt-1 text-sm text-slate-400">Add Student Accounts, Housing, Parking, or another university department.</p></CardContent></Card> :
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">{departments.map((department) => <Card key={department.id} className={`border-white/10 bg-white/5 text-white ${!department.isActive ? "opacity-60" : ""}`}><CardHeader><div className="flex items-start justify-between"><div className="flex items-center gap-3"><span className="h-10 w-1 rounded-full" style={{ backgroundColor: department.color }} /><div><CardTitle className="text-base">{department.name}</CardTitle><CardDescription className="text-slate-400">{department.code}</CardDescription></div></div><Badge variant="outline" className={department.isActive ? "border-emerald-400/30 text-emerald-300" : "border-slate-500 text-slate-400"}>{department.isActive ? "Active" : "Inactive"}</Badge></div></CardHeader><CardContent><p className="min-h-10 text-sm text-slate-400">{department.description || "University department"}</p><div className="mt-4 grid grid-cols-2 gap-3 rounded-xl bg-slate-950/50 p-3"><div><p className="text-xs text-slate-500">Student accounts</p><p className="font-semibold">{department.accountCount}</p></div><div><p className="text-xs text-slate-500">Outstanding</p><p className="font-semibold">${(Number(department.outstandingBalanceCents) / 100).toLocaleString(undefined, { minimumFractionDigits: 2 })}</p></div></div><Button variant="outline" size="sm" className="mt-4 w-full border-white/15 bg-transparent" disabled={updateDepartment.isPending} onClick={() => updateDepartment.mutate({ id: department.id, isActive: !department.isActive })}>{department.isActive ? "Deactivate" : "Reactivate"}</Button></CardContent></Card>)}</div>}
+  </div>;
 }
 
 function FeaturePanel({ icon: Icon, title, description, items }: { icon: typeof Landmark; title: string; description: string; items: string[] }) {

--- a/client/src/pages/campus.tsx
+++ b/client/src/pages/campus.tsx
@@ -1,0 +1,68 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "wouter";
+import AdminLayout from "@/components/admin-layout";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Building2, CreditCard, GraduationCap, Landmark, Plug, ReceiptText, RotateCcw, Users } from "lucide-react";
+import { CAMPUS_DEPARTMENTS, CAMPUS_INTEGRATIONS, CAMPUS_NOTIFICATION_TEMPLATES, DEFAULT_CAMPUS_CONFIG, type CampusConfig } from "@shared/campus";
+
+const workspaceLinks = [
+  { title: "Students", description: "Search student profiles and communication history.", href: "/consumers", icon: Users },
+  { title: "Student Accounts", description: "Review balances and department-specific charges.", href: "/accounts", icon: GraduationCap },
+  { title: "Payments & Plans", description: "Use existing payments, saved methods and recurring plans.", href: "/payments", icon: CreditCard },
+  { title: "Documents", description: "Statements, uploads and signed student documents.", href: "/documents", icon: ReceiptText },
+];
+
+export default function Campus() {
+  const { data: settings } = useQuery<any>({ queryKey: ["/api/settings"] });
+  const config: CampusConfig = settings?.campusConfig || {};
+  const departments = config.departments?.length ? config.departments : DEFAULT_CAMPUS_CONFIG.departments;
+  const universityName = config.universityName || "Your University";
+  const primaryColor = config.primaryColor || DEFAULT_CAMPUS_CONFIG.primaryColor;
+
+  return (
+    <AdminLayout>
+      <main className="h-full overflow-y-auto bg-slate-950 px-4 py-6 text-slate-100 sm:px-8">
+        <section className="relative overflow-hidden rounded-3xl border border-white/10 bg-gradient-to-br from-blue-700/40 via-indigo-700/20 to-slate-900 p-7 shadow-2xl">
+          <div className="absolute -right-16 -top-20 h-64 w-64 rounded-full opacity-30 blur-3xl" style={{ backgroundColor: primaryColor }} />
+          <div className="relative flex flex-col justify-between gap-6 lg:flex-row lg:items-center">
+            <div>
+              <Badge className="mb-4 border-blue-300/30 bg-blue-400/15 text-blue-100">Higher Education module</Badge>
+              <div className="flex items-center gap-3"><GraduationCap className="h-9 w-9 text-sky-300" /><h1 className="text-3xl font-bold">Chain Campus</h1></div>
+              <p className="mt-2 text-lg text-blue-100">{universityName}</p>
+              <p className="mt-3 max-w-2xl text-sm text-slate-300">One university workspace for student accounts, departments, payment plans, cashiering, refunds and integrations—powered by the existing Chain platform.</p>
+            </div>
+            <Link href="/settings"><Button className="bg-white text-slate-950 hover:bg-blue-50">Configure university</Button></Link>
+          </div>
+        </section>
+
+        <Tabs defaultValue="overview" className="mt-6">
+          <TabsList className="h-auto flex-wrap justify-start bg-white/5 p-1">
+            <TabsTrigger value="overview">Overview</TabsTrigger><TabsTrigger value="departments">Departments</TabsTrigger>
+            <TabsTrigger value="cashiering">Cashiering</TabsTrigger><TabsTrigger value="refunds">Refund Center</TabsTrigger>
+            <TabsTrigger value="integrations">Integrations</TabsTrigger><TabsTrigger value="notifications">Notifications</TabsTrigger>
+          </TabsList>
+          <TabsContent value="overview" className="mt-5">
+            <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+              {workspaceLinks.map(({ title, description, href, icon: Icon }) => <Link href={href} key={title}><Card className="h-full cursor-pointer border-white/10 bg-white/5 text-white transition hover:-translate-y-0.5 hover:bg-white/10"><CardHeader><Icon className="h-6 w-6 text-sky-300" /><CardTitle className="pt-2 text-lg">{title}</CardTitle><CardDescription className="text-slate-400">{description}</CardDescription></CardHeader></Card></Link>)}
+            </div>
+            <div className="mt-5 grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+              {["Today’s Payments", "Outstanding Balances", "Active Payment Plans", "Refund Queue", "Declined Payments", "Department Revenue", "Past Due Students", "Recent Activity"].map((label) => <Card key={label} className="border-white/10 bg-slate-900 text-white"><CardContent className="p-5"><p className="text-sm text-slate-400">{label}</p><p className="mt-3 text-2xl font-semibold">—</p><p className="mt-1 text-xs text-slate-500">Uses existing reporting data</p></CardContent></Card>)}
+            </div>
+          </TabsContent>
+          <TabsContent value="departments" className="mt-5"><div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">{departments.map((name) => <Card key={name} className="border-white/10 bg-white/5 text-white"><CardHeader className="flex-row items-center gap-3"><Building2 className="h-6 w-6 text-sky-300" /><div><CardTitle className="text-base">{name}</CardTitle><CardDescription className="text-slate-400">Revenue · Payments · Balances · Reports</CardDescription></div></CardHeader></Card>)}</div></TabsContent>
+          <TabsContent value="cashiering" className="mt-5"><FeaturePanel icon={Landmark} title="Campus Cashiering" description="Extends manual payments with cash, check, money order, card and other tenders." items={["Open Shift", "Record Payment", "Close Shift", "Daily Reconciliation", "Deposit Report", "Printable Receipt"]} /></TabsContent>
+          <TabsContent value="refunds" className="mt-5"><FeaturePanel icon={RotateCcw} title="Refund Center" description="A controlled workflow reusing payment records and processor references." items={["Pending", "Approved", "Rejected", "Processed", "Completed"]} /></TabsContent>
+          <TabsContent value="integrations" className="mt-5"><div className="grid gap-4 md:grid-cols-2">{CAMPUS_INTEGRATIONS.map((integration) => { const enabled = config.integrations?.[integration.id]?.enabled; return <Card key={integration.id} className="border-white/10 bg-white/5 text-white"><CardHeader className="flex-row items-center justify-between"><div className="flex items-center gap-3"><Plug className="h-5 w-5 text-sky-300" /><div><CardTitle className="text-base">{integration.name}</CardTitle><CardDescription className="text-slate-400">{integration.category}</CardDescription></div></div><Badge variant="outline" className={enabled ? "border-emerald-400/40 text-emerald-300" : "border-slate-600 text-slate-400"}>{enabled ? "Configured" : "Interface ready"}</Badge></CardHeader></Card>; })}</div><p className="mt-4 text-sm text-slate-400">Providers are configuration hooks only; no integration is hard-coded.</p></TabsContent>
+          <TabsContent value="notifications" className="mt-5"><Card className="border-white/10 bg-white/5 text-white"><CardHeader><CardTitle>Campus notification templates</CardTitle><CardDescription className="text-slate-400">Delivered through Chain’s existing email and SMS notification engine.</CardDescription></CardHeader><CardContent className="flex flex-wrap gap-2">{CAMPUS_NOTIFICATION_TEMPLATES.map((name) => <Badge key={name} className="bg-blue-400/15 text-blue-100">{name}</Badge>)}</CardContent></Card></TabsContent>
+        </Tabs>
+      </main>
+    </AdminLayout>
+  );
+}
+
+function FeaturePanel({ icon: Icon, title, description, items }: { icon: typeof Landmark; title: string; description: string; items: string[] }) {
+  return <Card className="border-white/10 bg-white/5 text-white"><CardHeader><Icon className="h-7 w-7 text-sky-300" /><CardTitle className="pt-2">{title}</CardTitle><CardDescription className="text-slate-400">{description}</CardDescription></CardHeader><CardContent className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">{items.map((item) => <div key={item} className="rounded-xl border border-white/10 bg-slate-950/50 p-4 text-sm">{item}<p className="mt-1 text-xs text-slate-500">Planned incremental workflow</p></div>)}</CardContent></Card>;
+}

--- a/docs/CHAIN-CAMPUS-DEVELOPMENT-PLAN.md
+++ b/docs/CHAIN-CAMPUS-DEVELOPMENT-PLAN.md
@@ -1,0 +1,26 @@
+# Chain Campus development plan
+
+## Reuse map
+
+| Campus requirement | Existing Chain capability | Approach |
+| --- | --- | --- |
+| Students and student accounts | Consumers and accounts | Apply module terminology; keep IDs, imports, search, history and APIs. |
+| Departments | Account creditor plus tenant scoping | Introduce configurable department directory first; normalize only when department-level authorization requires it. |
+| Payment plans and AutoPay | Arrangement options, schedules and recurring processing | Relabel for Campus; do not fork payment logic. |
+| Portal, documents, receipts and payment methods | Consumer portal, document service, payments and wallet | Reuse the existing portal and processor abstractions. |
+| Staff, roles and logs | Platform users, restricted services and event service | Add authorized-payer and department scopes through the existing permission model. |
+| Email and SMS | Template/campaign engines | Seed seven Campus templates rather than introduce a second notification service. |
+| Dashboards and reports | Admin dashboard, stats, payments and reporting | Compose Campus and department views from existing tenant-filtered data. |
+| Branding | Tenant custom branding and logo upload | Add Campus title and configurable university identity; retain the Chain logo. |
+
+## Gaps and increments
+
+1. **Module foundation (this increment):** register Higher Education terminology and proposal metadata; add tenant-scoped Campus configuration, the Campus workspace, department defaults, notification inventory, and integration interface hooks.
+2. **Department authorization:** normalize departments and memberships when row-level department access is implemented; retain university tenant boundaries.
+3. **Authorized payer:** add invitations, consented per-student grants, expiration/revocation, and audit events on top of portal authentication and saved payment methods.
+4. **Cashiering:** extend manual payments with shifts, receipt/reference metadata, reconciliation/deposit reports, and printable receipts.
+5. **Refund center:** add state transitions (pending through completed), approver policy, processor adapters, audit events and notifications.
+6. **Portal composition:** expose department charge grouping, statements, payer management and Campus labels through the existing responsive/mobile portal.
+7. **Integration adapters:** implement provider adapters behind the settings hooks. Secrets must use the platform secret mechanism and adapters must remain optional.
+
+Each increment must preserve tenant filters, role checks, event logging, notification preferences, processor idempotency, and existing API compatibility.

--- a/docs/CHAIN-CAMPUS-DEVELOPMENT-PLAN.md
+++ b/docs/CHAIN-CAMPUS-DEVELOPMENT-PLAN.md
@@ -5,7 +5,7 @@
 | Campus requirement | Existing Chain capability | Approach |
 | --- | --- | --- |
 | Students and student accounts | Consumers and accounts | Apply module terminology; keep IDs, imports, search, history and APIs. |
-| Departments | Account creditor plus tenant scoping | Introduce configurable department directory first; normalize only when department-level authorization requires it. |
+| Departments | Account creditor plus tenant scoping | Use normalized, tenant-owned Campus departments and optionally assign student accounts without creating child tenants. |
 | Payment plans and AutoPay | Arrangement options, schedules and recurring processing | Relabel for Campus; do not fork payment logic. |
 | Portal, documents, receipts and payment methods | Consumer portal, document service, payments and wallet | Reuse the existing portal and processor abstractions. |
 | Staff, roles and logs | Platform users, restricted services and event service | Add authorized-payer and department scopes through the existing permission model. |
@@ -16,7 +16,7 @@
 ## Gaps and increments
 
 1. **Module foundation (this increment):** register Higher Education terminology and proposal metadata; add tenant-scoped Campus configuration, the Campus workspace, department defaults, notification inventory, and integration interface hooks.
-2. **Department authorization:** normalize departments and memberships when row-level department access is implemented; retain university tenant boundaries.
+2. **Campus organization (Phase 1, implemented):** normalized departments belong to one university tenant, support lifecycle management, and provide a tenant-safe student-account relationship. Department user memberships remain part of the authorization increment.
 3. **Authorized payer:** add invitations, consented per-student grants, expiration/revocation, and audit events on top of portal authentication and saved payment methods.
 4. **Cashiering:** extend manual payments with shifts, receipt/reference metadata, reconciliation/deposit reports, and printable receipts.
 5. **Refund center:** add state transitions (pending through completed), approver policy, processor adapters, audit events and notifications.

--- a/migrations/20260806120000_chain_campus_foundation.sql
+++ b/migrations/20260806120000_chain_campus_foundation.sql
@@ -1,0 +1,7 @@
+-- Chain Campus is tenant-scoped and reuses students (consumers), student accounts
+-- (accounts), payment plans (arrangements), payments, documents and notifications.
+ALTER TABLE tenant_settings
+  ADD COLUMN IF NOT EXISTS campus_config JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+COMMENT ON COLUMN tenant_settings.campus_config IS
+  'Chain Campus module configuration: departments, integration hooks, branding and cashiering preferences';

--- a/migrations/20260806130000_campus_departments.sql
+++ b/migrations/20260806130000_campus_departments.sql
@@ -1,0 +1,29 @@
+CREATE TABLE IF NOT EXISTS campus_departments (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  code TEXT NOT NULL,
+  description TEXT,
+  color TEXT NOT NULL DEFAULT '#2563eb',
+  is_active BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS campus_departments_tenant_code_unique
+  ON campus_departments (tenant_id, code);
+CREATE UNIQUE INDEX IF NOT EXISTS campus_departments_tenant_id_id_unique
+  ON campus_departments (tenant_id, id);
+CREATE INDEX IF NOT EXISTS campus_departments_tenant_idx
+  ON campus_departments (tenant_id);
+
+ALTER TABLE accounts ADD COLUMN IF NOT EXISTS department_id UUID;
+DO $$ BEGIN
+  ALTER TABLE accounts ADD CONSTRAINT accounts_tenant_department_fk
+    FOREIGN KEY (tenant_id, department_id) REFERENCES campus_departments(tenant_id, id);
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+CREATE INDEX IF NOT EXISTS accounts_department_id_idx ON accounts (department_id);
+
+COMMENT ON TABLE campus_departments IS
+  'Departments belonging to a Higher Education university tenant; departments are never separate tenants';

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -7652,7 +7652,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const registrationWithCredentialsSchema = agencyTrialRegistrationSchema.extend({
         username: z.string().min(3).max(50),
         password: z.string().min(8).max(100),
-        businessType: z.enum(['call_center', 'billing_service', 'subscription_provider', 'freelancer_consultant', 'property_management']).optional().default('call_center'),
+        businessType: z.enum(['call_center', 'billing_service', 'subscription_provider', 'freelancer_consultant', 'property_management', 'nonprofit_organization', 'higher_education']).optional().default('call_center'),
         billingMode: z.enum(['subscription', 'wallet']).optional().default('subscription'),
       });
       
@@ -22149,7 +22149,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       
       // Validate input with known module IDs only
       const businessConfigSchema = z.object({
-        businessType: z.enum(['call_center', 'billing_service', 'subscription_provider', 'freelancer_consultant', 'property_management']),
+        businessType: z.enum(['call_center', 'billing_service', 'subscription_provider', 'freelancer_consultant', 'property_management', 'nonprofit_organization', 'higher_education']),
         enabledModules: z.array(z.enum(['billing', 'subscriptions', 'work_orders', 'client_crm', 'messaging_center']))
       });
       

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -15,6 +15,8 @@ import {
   tenants,
   tenantSettings,
   consumers,
+  campusDepartments,
+  insertCampusDepartmentSchema,
   accounts as accountsTable,
   paymentSchedules as paymentSchedulesTable,
   payments,
@@ -40,7 +42,7 @@ import {
   type SmsTracking,
 } from "@shared/schema";
 import { db } from "./db";
-import { and, eq, sql, desc, gte, lte, isNull } from "drizzle-orm";
+import { and, eq, sql, desc, gte, lte, isNull, asc } from "drizzle-orm";
 import { z } from "zod";
 import multer from "multer";
 import path from "path";
@@ -9996,6 +9998,124 @@ export async function registerRoutes(app: Express): Promise<Server> {
     } catch (error) {
       console.error('Error fetching campaign log detail:', error);
       res.status(500).json({ message: 'Failed to fetch campaign log' });
+    }
+  });
+
+  // Chain Campus departments are children of the authenticated university tenant.
+  // Tenant IDs are always derived from auth and never accepted from request data.
+  app.get('/api/campus/departments', authenticateUser, async (req: any, res) => {
+    try {
+      const tenantId = await getTenantId(req, storage);
+      if (!tenantId) return res.status(403).json({ message: 'No tenant access' });
+
+      const [settings] = await db.select({ businessType: tenantSettings.businessType })
+        .from(tenantSettings).where(eq(tenantSettings.tenantId, tenantId)).limit(1);
+      if (settings?.businessType !== 'higher_education') {
+        return res.status(404).json({ message: 'Chain Campus is not enabled for this tenant' });
+      }
+
+      const rows = await db.select({
+        id: campusDepartments.id,
+        name: campusDepartments.name,
+        code: campusDepartments.code,
+        description: campusDepartments.description,
+        color: campusDepartments.color,
+        isActive: campusDepartments.isActive,
+        createdAt: campusDepartments.createdAt,
+        accountCount: sql<number>`count(${accountsTable.id})::int`,
+        outstandingBalanceCents: sql<number>`coalesce(sum(${accountsTable.balanceCents}) filter (where ${accountsTable.status} = 'active'), 0)::bigint`,
+      }).from(campusDepartments)
+        .leftJoin(accountsTable, and(
+          eq(accountsTable.departmentId, campusDepartments.id),
+          eq(accountsTable.tenantId, tenantId),
+        ))
+        .where(eq(campusDepartments.tenantId, tenantId))
+        .groupBy(campusDepartments.id)
+        .orderBy(asc(campusDepartments.name));
+      res.json(rows);
+    } catch (error) {
+      console.error('Error fetching Campus departments:', error);
+      res.status(500).json({ message: 'Failed to fetch departments' });
+    }
+  });
+
+  app.post('/api/campus/departments', authenticateUser, requireOwner, async (req: any, res) => {
+    try {
+      const tenantId = await getTenantId(req, storage);
+      if (!tenantId) return res.status(403).json({ message: 'No tenant access' });
+      const [settings] = await db.select({ businessType: tenantSettings.businessType })
+        .from(tenantSettings).where(eq(tenantSettings.tenantId, tenantId)).limit(1);
+      if (settings?.businessType !== 'higher_education') {
+        return res.status(404).json({ message: 'Chain Campus is not enabled for this tenant' });
+      }
+      const input = insertCampusDepartmentSchema.parse(req.body);
+      const [department] = await db.insert(campusDepartments).values({
+        ...input,
+        tenantId,
+        name: input.name.trim(),
+        code: input.code.trim().toUpperCase(),
+      }).returning();
+      res.status(201).json(department);
+    } catch (error: any) {
+      if (error instanceof z.ZodError) return res.status(400).json({ message: 'Invalid department', errors: error.errors });
+      if (error?.code === '23505') return res.status(409).json({ message: 'Department code already exists in this university' });
+      console.error('Error creating Campus department:', error);
+      res.status(500).json({ message: 'Failed to create department' });
+    }
+  });
+
+  app.patch('/api/campus/departments/:id', authenticateUser, requireOwner, async (req: any, res) => {
+    try {
+      const tenantId = await getTenantId(req, storage);
+      if (!tenantId) return res.status(403).json({ message: 'No tenant access' });
+      const [settings] = await db.select({ businessType: tenantSettings.businessType })
+        .from(tenantSettings).where(eq(tenantSettings.tenantId, tenantId)).limit(1);
+      if (settings?.businessType !== 'higher_education') {
+        return res.status(404).json({ message: 'Chain Campus is not enabled for this tenant' });
+      }
+      const id = z.string().uuid().parse(req.params.id);
+      const input = insertCampusDepartmentSchema.partial().parse(req.body);
+      const updates = {
+        ...input,
+        ...(input.name !== undefined ? { name: input.name.trim() } : {}),
+        ...(input.code !== undefined ? { code: input.code.trim().toUpperCase() } : {}),
+        updatedAt: new Date(),
+      };
+      const [department] = await db.update(campusDepartments).set(updates)
+        .where(and(eq(campusDepartments.id, id), eq(campusDepartments.tenantId, tenantId))).returning();
+      if (!department) return res.status(404).json({ message: 'Department not found' });
+      res.json(department);
+    } catch (error: any) {
+      if (error instanceof z.ZodError) return res.status(400).json({ message: 'Invalid department', errors: error.errors });
+      if (error?.code === '23505') return res.status(409).json({ message: 'Department code already exists in this university' });
+      console.error('Error updating Campus department:', error);
+      res.status(500).json({ message: 'Failed to update department' });
+    }
+  });
+
+  app.delete('/api/campus/departments/:id', authenticateUser, requireOwner, async (req: any, res) => {
+    try {
+      const tenantId = await getTenantId(req, storage);
+      if (!tenantId) return res.status(403).json({ message: 'No tenant access' });
+      const [settings] = await db.select({ businessType: tenantSettings.businessType })
+        .from(tenantSettings).where(eq(tenantSettings.tenantId, tenantId)).limit(1);
+      if (settings?.businessType !== 'higher_education') {
+        return res.status(404).json({ message: 'Chain Campus is not enabled for this tenant' });
+      }
+      const id = z.string().uuid().parse(req.params.id);
+      const [usage] = await db.select({ count: sql<number>`count(*)::int` }).from(accountsTable)
+        .where(and(eq(accountsTable.tenantId, tenantId), eq(accountsTable.departmentId, id)));
+      if (usage.count > 0) {
+        return res.status(409).json({ message: 'Deactivate this department instead; student accounts are assigned to it' });
+      }
+      const [deleted] = await db.delete(campusDepartments)
+        .where(and(eq(campusDepartments.id, id), eq(campusDepartments.tenantId, tenantId))).returning({ id: campusDepartments.id });
+      if (!deleted) return res.status(404).json({ message: 'Department not found' });
+      res.status(204).send();
+    } catch (error) {
+      if (error instanceof z.ZodError) return res.status(400).json({ message: 'Invalid department ID' });
+      console.error('Error deleting Campus department:', error);
+      res.status(500).json({ message: 'Failed to delete department' });
     }
   });
 

--- a/shared/billing-plans.ts
+++ b/shared/billing-plans.ts
@@ -242,6 +242,7 @@ export const businessTypePlans: Record<BusinessType, Record<MessagingPlanId, Mes
   freelancer_consultant: freelancerPlans,
   billing_service: billingServicePlans,
   nonprofit_organization: nonprofitPlans,
+  higher_education: callCenterPlans,
 };
 
 // Helper function to get plans for a specific business type

--- a/shared/campus.ts
+++ b/shared/campus.ts
@@ -1,6 +1,6 @@
 export const CAMPUS_DEPARTMENTS = [
   "Admissions", "Housing", "Parking", "Dining", "Athletics", "Bookstore",
-  "Library", "Registrar", "Financial Aid", "Student Accounts",
+  "Library", "Registrar", "Financial Aid", "Student Accounts", "Continuing Education",
 ] as const;
 
 export const CAMPUS_INTEGRATIONS = [

--- a/shared/campus.ts
+++ b/shared/campus.ts
@@ -1,0 +1,33 @@
+export const CAMPUS_DEPARTMENTS = [
+  "Admissions", "Housing", "Parking", "Dining", "Athletics", "Bookstore",
+  "Library", "Registrar", "Financial Aid", "Student Accounts",
+] as const;
+
+export const CAMPUS_INTEGRATIONS = [
+  { id: "banner", name: "Ellucian Banner", category: "Student information system" },
+  { id: "ethos", name: "Ellucian Ethos", category: "Integration platform" },
+  { id: "sso", name: "Single Sign-On", category: "Identity provider" },
+  { id: "stripe", name: "Stripe", category: "Payments" },
+  { id: "bank", name: "Bank APIs", category: "Banking" },
+  { id: "housing", name: "Housing Systems", category: "Campus systems" },
+  { id: "parking", name: "Parking Systems", category: "Campus systems" },
+  { id: "dining", name: "Dining Systems", category: "Campus systems" },
+] as const;
+
+export const CAMPUS_NOTIFICATION_TEMPLATES = [
+  "Payment Due", "Payment Received", "Declined Payment", "Payment Plan Created",
+  "Payment Plan Missed", "Refund Issued", "Statement Available",
+] as const;
+
+export type CampusIntegrationId = typeof CAMPUS_INTEGRATIONS[number]["id"];
+export type CampusConfig = {
+  universityName?: string;
+  primaryColor?: string;
+  departments?: string[];
+  integrations?: Partial<Record<CampusIntegrationId, { enabled: boolean; endpoint?: string }>>;
+};
+
+export const DEFAULT_CAMPUS_CONFIG: Required<Pick<CampusConfig, "primaryColor" | "departments">> = {
+  primaryColor: "#2563eb",
+  departments: [...CAMPUS_DEPARTMENTS],
+};

--- a/shared/globalDocumentHelpers.ts
+++ b/shared/globalDocumentHelpers.ts
@@ -10,6 +10,7 @@ export function getModuleNameForBusinessType(businessType: BusinessType): string
     freelancer_consultant: 'Client & Project Management Module',
     property_management: 'Property & Tenant Management Module',
     nonprofit_organization: 'Donor & Campaign Management Module',
+    higher_education: 'Chain Campus',
   };
 
   return moduleMap[businessType] || 'Call Center Module';
@@ -24,6 +25,7 @@ export function getModuleDescriptionForBusinessType(businessType: BusinessType):
     freelancer_consultant: 'client project tracking, time and invoice management, payment collection, and professional service delivery tools',
     property_management: 'tenant management, lease tracking, rent collection, maintenance request handling, and property communication features',
     nonprofit_organization: 'donor relationship management, donation tracking, campaign automation, volunteer coordination, and fundraising tools',
+    higher_education: 'student account management, department reporting, payment plans, campus cashiering, refunds, and student communications',
   };
 
   return descriptionMap[businessType] || descriptionMap.call_center;

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -13,6 +13,7 @@ import {
   boolean,
   uuid,
   uniqueIndex,
+  foreignKey,
 } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
@@ -217,6 +218,25 @@ export const consumers = pgTable("consumers", {
   createdAt: timestamp("created_at").defaultNow(),
 });
 
+// Chain Campus departments live inside a university tenant. They are not tenants
+// themselves, so authentication, billing, branding, and data isolation continue
+// to be managed at the university level.
+export const campusDepartments = pgTable("campus_departments", {
+  id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+  tenantId: uuid("tenant_id").references(() => tenants.id, { onDelete: "cascade" }).notNull(),
+  name: text("name").notNull(),
+  code: text("code").notNull(),
+  description: text("description"),
+  color: text("color").default("#2563eb").notNull(),
+  isActive: boolean("is_active").default(true).notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at").defaultNow().notNull(),
+}, (table) => [
+  uniqueIndex("campus_departments_tenant_code_unique").on(table.tenantId, table.code),
+  uniqueIndex("campus_departments_tenant_id_id_unique").on(table.tenantId, table.id),
+  index("campus_departments_tenant_idx").on(table.tenantId),
+]);
+
 // Folders for organizing accounts
 export const folders = pgTable("folders", {
   id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
@@ -235,6 +255,7 @@ export const accounts = pgTable("accounts", {
   tenantId: uuid("tenant_id").references(() => tenants.id, { onDelete: "cascade" }).notNull(),
   consumerId: uuid("consumer_id").references(() => consumers.id, { onDelete: "cascade" }).notNull(),
   folderId: uuid("folder_id").references(() => folders.id, { onDelete: "set null" }),
+  departmentId: uuid("department_id"),
   accountNumber: text("account_number"),
   filenumber: text("filenumber"), // Required for SMAX integration (nullable for migration)
   creditor: text("creditor").notNull(),
@@ -245,7 +266,14 @@ export const accounts = pgTable("accounts", {
   additionalData: jsonb("additional_data").default(sql`'{}'::jsonb`), // Store custom CSV columns
   returnedAt: timestamp("returned_at"), // Timestamp when account was moved to Returned folder (for auto-deletion after 7 days)
   createdAt: timestamp("created_at").defaultNow(),
-});
+}, (table) => [
+  index("accounts_department_id_idx").on(table.departmentId),
+  foreignKey({
+    columns: [table.tenantId, table.departmentId],
+    foreignColumns: [campusDepartments.tenantId, campusDepartments.id],
+    name: "accounts_tenant_department_fk",
+  }),
+]);
 
 // Push device tokens
 export const pushDevices = pgTable("push_devices", {
@@ -1662,6 +1690,17 @@ export const agencyTrialRegistrationSchema = createInsertSchema(tenants).pick({
 });
 export const insertPlatformUserSchema = createInsertSchema(platformUsers).omit({ id: true, createdAt: true });
 export const insertConsumerSchema = createInsertSchema(consumers).omit({ id: true, createdAt: true });
+export const insertCampusDepartmentSchema = createInsertSchema(campusDepartments).omit({
+  id: true,
+  tenantId: true,
+  createdAt: true,
+  updatedAt: true,
+}).extend({
+  name: z.string().trim().min(1).max(120),
+  code: z.string().trim().min(1).max(20).regex(/^[A-Za-z0-9_-]+$/),
+  description: z.string().trim().max(500).nullable().optional(),
+  color: z.string().regex(/^#[0-9a-fA-F]{6}$/).optional(),
+});
 export const insertAccountSchema = createInsertSchema(accounts).omit({ id: true, createdAt: true });
 export const insertEmailTemplateSchema = createInsertSchema(emailTemplates).omit({ id: true, createdAt: true });
 export const insertDocumentSchema = createInsertSchema(documents).omit({ id: true, createdAt: true, updatedAt: true });

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -730,7 +730,7 @@ export const arrangementOptions = pgTable("arrangement_options", {
 export const tenantSettings = pgTable("tenant_settings", {
   id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
   tenantId: uuid("tenant_id").references(() => tenants.id, { onDelete: "cascade" }).notNull().unique(),
-  businessType: text("business_type").default("call_center"), // call_center, property_management, subscription_provider, freelancer_consultant, billing_service
+  businessType: text("business_type").default("call_center"), // Includes higher_education for the Chain Campus module
   privacyPolicy: text("privacy_policy"),
   termsOfService: text("terms_of_service"),
   contactEmail: text("contact_email"),
@@ -780,6 +780,7 @@ export const tenantSettings = pgTable("tenant_settings", {
   campaignIntegrationEnabled: boolean("campaign_integration_enabled").default(false),
   blockedAccountStatuses: text("blocked_account_statuses").array().default(sql`ARRAY['inactive', 'recalled', 'closed']::text[]`), // Account statuses that block communications and payments
   forceArrangement: boolean("force_arrangement").default(false), // When true, consumers must set up payment arrangement (no one-time payments)
+  campusConfig: jsonb("campus_config").default(sql`'{}'::jsonb`), // Chain Campus departments, integrations, cashiering and branding configuration
 });
 
 // External campaign integration log (Debt Manager Pro -> Chain)

--- a/shared/terminology.ts
+++ b/shared/terminology.ts
@@ -7,7 +7,8 @@ export type BusinessType =
   | 'subscription_provider' 
   | 'freelancer_consultant' 
   | 'property_management'
-  | 'nonprofit_organization';
+  | 'nonprofit_organization'
+  | 'higher_education';
 
 export interface TerminologyMap {
   // Person/Entity terms
@@ -229,6 +230,35 @@ const terminologyMaps: Record<BusinessType, TerminologyMap> = {
     statusInProgress: 'In Progress',
     statusCompleted: 'Completed',
   },
+  // Chain Campus / Higher Education
+  higher_education: {
+    consumer: 'Student',
+    consumerPlural: 'Students',
+    creditor: 'Department',
+    creditorPlural: 'Departments',
+    account: 'Student Account',
+    accountPlural: 'Student Accounts',
+    placement: 'Charge',
+    placementPlural: 'Charges',
+    balance: 'Balance',
+    payment: 'Payment',
+    paymentPlural: 'Payments',
+    settlement: 'Payment Plan',
+    settlementPlural: 'Payment Plans',
+    collect: 'Receive Payment',
+    collecting: 'Receiving Payments',
+    collection: 'Student Accounts',
+    delinquent: 'Past Due',
+    current: 'Current',
+    paidOff: 'Paid',
+    callbackRequest: 'Student Request',
+    callbackRequestPlural: 'Student Requests',
+    statusCalled: 'Contacted',
+    statusNoAnswer: 'No Response',
+    statusScheduled: 'Scheduled',
+    statusInProgress: 'In Progress',
+    statusCompleted: 'Resolved',
+  },
 };
 
 /**
@@ -257,6 +287,7 @@ export function getBusinessTypeName(businessType: BusinessType): string {
     freelancer_consultant: 'Freelancer / Consultant',
     property_management: 'Property Management',
     nonprofit_organization: 'Non-Profit Organization',
+    higher_education: 'Higher Education (Chain Campus)',
   };
   return names[businessType] || 'Debt Collection / Call Center';
 }
@@ -272,5 +303,6 @@ export function getBusinessTypes(): { value: BusinessType; label: string }[] {
     { value: 'freelancer_consultant', label: 'Freelancer / Consultant' },
     { value: 'property_management', label: 'Property Management' },
     { value: 'nonprofit_organization', label: 'Non-Profit Organization' },
+    { value: 'higher_education', label: 'Higher Education (Chain Campus)' },
   ];
 }


### PR DESCRIPTION
### Motivation
- Introduce a configurable Higher Education module (Chain Campus) that reuses existing platform features (auth, payments, arrangements, notifications, documents, reporting, multi-tenant model) while mapping campus terminology and workflows to the current codebase.
- Provide a minimal, non-invasive foundation to register the new business type, tenant-scoped Campus configuration, department defaults, integration hooks, notification templates, and a workspace UI so subsequent increments can add cashiering, authorized payer flows, and refund workflows without rewriting core systems.

### Description
- Registered a new business type `higher_education` and added Campus-specific terminology (Student, Department, Student Account, Payment Plan, etc.) in `shared/terminology.ts` and display/description mappings in `shared/globalDocumentHelpers.ts`.
- Added tenant-scoped Campus configuration support by adding `campusConfig` to `tenant_settings` (schema change) and a database migration `migrations/20260806120000_chain_campus_foundation.sql` to add the `campus_config` JSONB column; also introduced `shared/campus.ts` with default departments, integration hooks, and notification template constants.
- Added a new Campus workspace page at `client/src/pages/campus.tsx`, wired routing entries in `client/src/App.tsx`, and conditional navigation for tenants using `higher_education` in `client/src/components/admin-layout.tsx` so Campus appears as a module without forking existing workflows.
- Reused billing/proposal plumbing by mapping `higher_education` to existing plans in `shared/billing-plans.ts` and updated server-side tenant registration and admin business-config validation to accept `higher_education` in `client/src/pages/agency-registration.tsx` and `server/routes.ts`; also added a development plan document `docs/CHAIN-CAMPUS-DEVELOPMENT-PLAN.md` describing next increments.

### Testing
- Ran `npm test` and the client unit tests passed (`10` tests, `0` failures). 
- Ran `npm run build` and the production build (Vite + esbuild) completed successfully. 
- Ran `git diff --check` and basic repository checks completed without errors for the changed files. 
- Ran `npm run check` / `tsc` and found pre-existing TypeScript errors in unrelated code paths (several `client` and `server` files) that blocked a clean full typecheck; the PR contains only targeted changes and a small JSX syntax fix to resolve an immediate compile-time error introduced by the routing edit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a74d74bceac832ab70b8d35f0db9bc7)