### PR TITLE
Add iOS camera & photo library usage descriptions

### DIFF
--- a/mobile-app/app.json
+++ b/mobile-app/app.json
@@ -37,6 +37,8 @@
       },
       "infoPlist": {
         "NSFaceIDUsageDescription": "Use Face ID to quickly and securely log in to your account",
+        "NSCameraUsageDescription": "Allow Chain to use the camera to photograph documents for upload.",
+        "NSPhotoLibraryUsageDescription": "Allow Chain to select documents and images from your photo library for upload.",
         "ITSAppUsesNonExemptEncryption": false
       }
     },


### PR DESCRIPTION
### Motivation
- Fix a crash triggered when a reviewer tapped `Documents` → `Take Photo` on iPad, which occurs because the iOS binary accessed the camera/photo library without the required privacy keys causing the OS to terminate the app.

### Description
- Add `NSCameraUsageDescription` and `NSPhotoLibraryUsageDescription` to the Expo iOS `infoPlist` in `mobile-app/app.json` so the native iOS build includes the required document-capture privacy strings.

### Testing
- Verified the keys are present with `node -e "const c=require('./app.json'); const p=c.expo.ios.infoPlist; if (!p.NSCameraUsageDescription || !p.NSPhotoLibraryUsageDescription) process.exit(1); console.log(p)"` and with `npx expo config --type public --json` and both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7532601bcc832a9bf3d76393584acf)