### PR TITLE
Bump mobile iOS and Android build numbers to 19

### DIFF
--- a/mobile-app/app.json
+++ b/mobile-app/app.json
@@ -10,7 +10,7 @@
     "ios": {
       "supportsTablet": false,
       "bundleIdentifier": "com.chainsoftware.platform",
-      "buildNumber": "18",
+      "buildNumber": "19",
       "newArchEnabled": true,
       "privacyManifests": {
         "NSPrivacyAccessedAPITypes": [
@@ -44,7 +44,7 @@
     },
     "android": {
       "newArchEnabled": true,
-      "versionCode": 18,
+      "versionCode": 19,
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ffffff"


### PR DESCRIPTION
### Motivation
- Prepare the mobile apps for a new release by incrementing the platform build identifiers so app store submissions will be accepted.

### Description
- Update `mobile-app/app.json` to set `expo.ios.buildNumber` from "18" to "19" and `expo.android.versionCode` from `18` to `19`.

### Testing
- Ran `git diff --check` and validated the configuration with `node -e "const config=require('./mobile-app/app.json'); if(config.expo.ios.buildNumber !== '19' || config.expo.android.versionCode !== 19) throw new Error('Unexpected build versions'); console.log('iOS buildNumber:', config.expo.ios.buildNumber); console.log('Android versionCode:', config.expo.android.versionCode);"`, both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a754e232da4832a96774efb6116cd8f)