### PR TITLE
Target Android 16 (API 36), bump app versionCode to 20 and versionName 1.1.5

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "com.chainsoftware.platform"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1
-        versionName "1.0"
+        versionCode 20
+        versionName "1.1.5"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.7.2'
+        classpath 'com.android.tools.build:gradle:8.9.1'
         classpath 'com.google.gms:google-services:4.4.2'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/android/variables.gradle
+++ b/android/variables.gradle
@@ -1,7 +1,7 @@
 ext {
     minSdkVersion = 23
-    compileSdkVersion = 35
-    targetSdkVersion = 35
+    compileSdkVersion = 36
+    targetSdkVersion = 36
     androidxActivityVersion = '1.9.2'
     androidxAppCompatVersion = '1.7.0'
     androidxCoordinatorLayoutVersion = '1.2.0'

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Chain",
     "slug": "chain",
-    "version": "1.0.0",
+    "version": "1.1.5",
     "orientation": "portrait",
     "icon": "./client/public/chain-logo.png",
     "userInterfaceStyle": "light",
@@ -22,7 +22,7 @@
         "backgroundColor": "#ffffff"
       },
       "package": "com.chainsoftware.platform",
-      "versionCode": 6
+      "versionCode": 20
     },
     "web": {
       "bundler": "metro",

--- a/mobile-app/app.json
+++ b/mobile-app/app.json
@@ -44,7 +44,7 @@
     },
     "android": {
       "newArchEnabled": true,
-      "versionCode": 19,
+      "versionCode": 20,
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ffffff"
@@ -74,7 +74,9 @@
             "deploymentTarget": "16.0"
           },
           "android": {
-            "newArchEnabled": true
+            "newArchEnabled": true,
+            "compileSdkVersion": 36,
+            "targetSdkVersion": 36
           }
         }
       ]


### PR DESCRIPTION
### Motivation

- Bring the Android native project up to Play Store requirements by targeting Android 16 / API level 36.
- Ensure the released apps have incremented build numbers so a new production upload can be published.

### Description

- Update `android/variables.gradle` to set `compileSdkVersion` and `targetSdkVersion` to `36`.
- Upgrade the Android Gradle Plugin in `android/build.gradle` to `8.9.1` for API 36 compatibility.
- Bump the native app `versionCode` to `20` and `versionName` to `1.1.5` in `android/app/build.gradle`.
- Update `app.json` and `mobile-app/app.json` to version `1.1.5`, set `android.versionCode` to `20`, and add `compileSdkVersion`/`targetSdkVersion` 36 to the `expo-build-properties` android config.

### Testing

- `node` JSON parse checks for `app.json` and `mobile-app/app.json` succeeded and both files are valid JSON.
- `npx expo config --type public` for the mobile app resolved `android.compileSdkVersion: 36`, `android.targetSdkVersion: 36`, and `versionCode: 20` as expected.
- `npm test` ran the unit tests and all tests passed (`10` tests, `0` failures).
- `tsc` (`npm run check`) returned successfully, while `./gradlew :app:assembleDebug` failed in this environment with `Unsupported class file major version 69` under OpenJDK 25, indicating a JDK/Gradle runtime mismatch; run the Android build with a supported JDK (for example JDK 17) or an environment matching the project's Gradle/JDK requirements to produce the `.aab` for Play Console upload.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a75591fccfc832aaddc54167b959396)