### PR TITLE
Add municipality tenant type with departments, UI, API, and billing visibility controls

### DIFF
--- a/api/_lib/schema.ts
+++ b/api/_lib/schema.ts
@@ -38,6 +38,7 @@ export const tenants = pgTable("tenants", {
   id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
   name: text("name").notNull(),
   slug: text("slug").unique().notNull(),
+  businessType: text("business_type").default('call_center'), // Tenant classification, including municipality
   brand: jsonb("brand").default(sql`'{}'::jsonb`),
   isActive: boolean("is_active").default(true), // Can be suspended by platform owner
   suspendedAt: timestamp("suspended_at"),
@@ -72,10 +73,21 @@ export const tenants = pgTable("tenants", {
   createdAt: timestamp("created_at").defaultNow(),
 });
 
+export const tenantDepartments = pgTable("tenant_departments", {
+  id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+  tenantId: uuid("tenant_id").references(() => tenants.id, { onDelete: "cascade" }).notNull(),
+  name: text("name").notNull(),
+  description: text("description"),
+  isActive: boolean("is_active").default(true).notNull(),
+  createdAt: timestamp("created_at").defaultNow(),
+  updatedAt: timestamp("updated_at").defaultNow(),
+});
+
 // Agency credentials (for username/password auth)
 export const agencyCredentials = pgTable("agency_credentials", {
   id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
   tenantId: uuid("tenant_id").references(() => tenants.id, { onDelete: "cascade" }).notNull(),
+  departmentId: uuid("department_id").references(() => tenantDepartments.id, { onDelete: "set null" }),
   username: text("username").unique().notNull(),
   passwordHash: text("password_hash").notNull(), // Hashed password using bcrypt
   email: text("email").notNull(),

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,7 +3,7 @@ import { useEffect } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import type { ComponentType, JSX, ReactNode } from "react";
 import { queryClient } from "./lib/queryClient";
-import { QueryClientProvider } from "@tanstack/react-query";
+import { QueryClientProvider, useQuery } from "@tanstack/react-query";
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { MobileOptimizations } from "@/components/mobile-optimizations";
@@ -50,6 +50,32 @@ import Info from "@/pages/info";
 import Phones from "@/pages/phones";
 import Softphone from "@/pages/softphone";
 import InstallPage from "@/pages/install";
+import MunicipalityDashboard from "@/pages/municipality-dashboard";
+import MunicipalityAdmin from "@/pages/municipality-admin";
+
+function TenantDashboard() {
+  const { data: settings, isLoading } = useQuery<any>({ queryKey: ['/api/settings'] });
+  if (isLoading) return null;
+  return settings?.businessType === 'municipality' ? <MunicipalityDashboard /> : <AdminDashboard />;
+}
+
+function TenantAccountsRoute() {
+  const { data: settings, isLoading } = useQuery<any>({ queryKey: ['/api/settings'] });
+  const [, navigate] = useLocation();
+  const blocked = settings?.businessType === 'municipality' && !settings?.enabledModules?.includes('billing');
+  useEffect(() => { if (blocked) navigate('/dashboard', { replace: true }); }, [blocked, navigate]);
+  if (isLoading || blocked) return null;
+  return <Accounts />;
+}
+
+function TenantPaymentsRoute() {
+  const { data: settings, isLoading } = useQuery<any>({ queryKey: ['/api/settings'] });
+  const [, navigate] = useLocation();
+  const blocked = settings?.businessType === 'municipality' && !settings?.enabledModules?.includes('billing');
+  useEffect(() => { if (blocked) navigate('/dashboard', { replace: true }); }, [blocked, navigate]);
+  if (isLoading || blocked) return null;
+  return <Payments />;
+}
 
 function MobilePageTransition({ children }: { children: ReactNode }) {
   const [location] = useLocation();
@@ -268,12 +294,12 @@ function Router() {
       <Route
         key="agency-dashboard"
         path="/dashboard"
-        component={isJwtAuth ? AdminDashboard : AgencyLogin}
+        component={isJwtAuth ? TenantDashboard : AgencyLogin}
       />,
       <Route
         key="agency-admin-dashboard"
         path="/admin-dashboard"
-        component={isJwtAuth ? AdminDashboard : AgencyLogin}
+        component={isJwtAuth ? TenantDashboard : AgencyLogin}
       />,
       <Route
         key="agency-register"
@@ -290,7 +316,7 @@ function Router() {
     if (isJwtAuth) {
       agencySubdomainRoutes.push(
         <Route key="agency-consumers" path="/consumers" component={Consumers} />,
-        <Route key="agency-accounts" path="/accounts" component={Accounts} />,
+        <Route key="agency-accounts" path="/accounts" component={TenantAccountsRoute} />,
         <Route
           key="agency-communications"
           path="/communications"
@@ -298,10 +324,11 @@ function Router() {
         />,
         <Route key="agency-email-inbox" path="/email-inbox" component={EmailInbox} />,
         <Route key="agency-requests" path="/requests" component={Requests} />,
-        <Route key="agency-payments" path="/payments" component={Payments} />,
+        <Route key="agency-payments" path="/payments" component={TenantPaymentsRoute} />,
         <Route key="agency-billing" path="/billing" component={Billing} />,
         <Route key="agency-settings" path="/settings" component={Settings} />,
         <Route key="agency-documents" path="/documents" component={Documents} />,
+        <Route key="agency-municipality-admin" path="/municipality-admin" component={MunicipalityAdmin} />,
         <Route key="agency-phones" path="/phones" component={Phones} />
       );
     }
@@ -384,18 +411,19 @@ function Router() {
   }
 
   const authenticatedRoutes: JSX.Element[] = [
-    <Route key="auth-home" path="/" component={AdminDashboard} />,
-    <Route key="auth-dashboard" path="/dashboard" component={AdminDashboard} />,
-    <Route key="auth-admin-dashboard" path="/admin-dashboard" component={AdminDashboard} />,
+    <Route key="auth-home" path="/" component={TenantDashboard} />,
+    <Route key="auth-dashboard" path="/dashboard" component={TenantDashboard} />,
+    <Route key="auth-admin-dashboard" path="/admin-dashboard" component={TenantDashboard} />,
     <Route key="auth-consumers" path="/consumers" component={Consumers} />,
-    <Route key="auth-accounts" path="/accounts" component={Accounts} />,
+    <Route key="auth-accounts" path="/accounts" component={TenantAccountsRoute} />,
     <Route key="auth-communications" path="/communications" component={Communications} />,
     <Route key="auth-email-inbox" path="/email-inbox" component={EmailInbox} />,
     <Route key="auth-requests" path="/requests" component={Requests} />,
-    <Route key="auth-payments" path="/payments" component={Payments} />,
+    <Route key="auth-payments" path="/payments" component={TenantPaymentsRoute} />,
     <Route key="auth-billing" path="/billing" component={Billing} />,
     <Route key="auth-settings" path="/settings" component={Settings} />,
     <Route key="auth-documents" path="/documents" component={Documents} />,
+    <Route key="auth-municipality-admin" path="/municipality-admin" component={MunicipalityAdmin} />,
     <Route key="auth-phones" path="/phones" component={Phones} />,
     <Route key="auth-softphone" path="/softphone" component={Softphone} />,
     <Route key="auth-install" path="/install" component={InstallPage} />,

--- a/client/src/components/admin-layout.tsx
+++ b/client/src/components/admin-layout.tsx
@@ -21,6 +21,7 @@ import { cn } from "@/lib/utils";
 import { clearAuth } from "@/lib/cookies";
 import { useServiceAccess } from "@/hooks/useServiceAccess";
 import { MessageSquare, Mail } from "lucide-react";
+import { canTenantViewBilling } from "@shared/tenantAccess";
 
 interface AdminLayoutProps {
   children: React.ReactNode;
@@ -94,6 +95,8 @@ export default function AdminLayout({ children }: AdminLayoutProps) {
     ? (user as any)?.tenantSlug || 'agency-pro'
     : (userData as any)?.platformUser?.tenant?.slug || 'agency-pro';
 
+  const showTenantBilling = canTenantViewBilling((tenantSettings as any)?.businessType, (tenantSettings as any)?.enabledModules);
+
   // Only show company section for platform owners
   const isOwner = isJwtAuth 
     ? (user as any)?.role === 'owner'
@@ -126,7 +129,7 @@ export default function AdminLayout({ children }: AdminLayoutProps) {
     return restrictedServices.includes(serviceKey);
   };
   
-  const navigationItems = [
+  const standardNavigationItems = [
     { name: "Dashboard", href: buildNavHref("/dashboard"), icon: "fas fa-chart-bar" },
     { name: "Accounts", href: buildNavHref("/accounts"), icon: "fas fa-file-invoice-dollar" },
     { name: "Communications", href: buildNavHref("/communications"), icon: "fas fa-comments" },
@@ -134,9 +137,30 @@ export default function AdminLayout({ children }: AdminLayoutProps) {
     { name: "Phones", href: buildNavHref("/phones"), icon: "fas fa-phone-alt" },
     { name: "Requests", href: buildNavHref("/requests"), icon: "fas fa-phone" },
     { name: "Payments", href: buildNavHref("/payments"), icon: "fas fa-credit-card" },
-    ...(isOwner ? [{ name: "Billing", href: buildNavHref("/billing"), icon: "fas fa-receipt" }] : []),
+    ...(isOwner && showTenantBilling ? [{ name: "Billing", href: buildNavHref("/billing"), icon: "fas fa-receipt" }] : []),
     { name: "Settings", href: buildNavHref("/settings"), icon: "fas fa-cog" },
   ].filter(item => !isServiceRestricted(item.name));
+
+  const municipalityNavigationItems = [
+    { name: "Dashboard", href: buildNavHref("/dashboard"), icon: "fas fa-chart-bar" },
+    { name: "Contacts", href: buildNavHref("/consumers"), icon: "fas fa-address-book" },
+    { name: "Email Campaigns", href: buildNavHref("/communications?tab=campaigns"), icon: "fas fa-envelope" },
+    { name: "SMS Campaigns", href: buildNavHref("/communications?tab=campaigns"), icon: "fas fa-comment-alt" },
+    { name: "Templates", href: buildNavHref("/communications?tab=templates"), icon: "fas fa-file-alt" },
+    { name: "Lists / Segments", href: buildNavHref("/consumers"), icon: "fas fa-list" },
+    { name: "Communications History", href: buildNavHref("/communications?tab=overview"), icon: "fas fa-history" },
+    { name: "Reports / Analytics", href: buildNavHref("/communications?tab=overview"), icon: "fas fa-chart-line" },
+    { name: "Documents", href: buildNavHref("/documents"), icon: "fas fa-file-signature" },
+    ...((tenantSettings as any)?.enabledModules?.includes('billing') ? [
+      { name: "Payments", href: buildNavHref("/payments"), icon: "fas fa-credit-card" },
+      ...(isOwner ? [{ name: "Billing", href: buildNavHref("/billing"), icon: "fas fa-receipt" }] : []),
+    ] : []),
+    ...(isOwner ? [{ name: "Users & Departments", href: buildNavHref("/municipality-admin"), icon: "fas fa-users-cog" }] : []),
+    { name: "Settings", href: buildNavHref("/settings"), icon: "fas fa-cog" },
+  ];
+  const navigationItems = (tenantSettings as any)?.businessType === 'municipality'
+    ? municipalityNavigationItems
+    : standardNavigationItems;
 
   const isActiveRoute = (href: string) => {
     return location === href;

--- a/client/src/components/municipality-departments.tsx
+++ b/client/src/components/municipality-departments.tsx
@@ -1,0 +1,28 @@
+import { useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { apiRequest } from '@/lib/queryClient';
+import { useToast } from '@/hooks/use-toast';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Building2, Plus, Trash2 } from 'lucide-react';
+
+type Department = { id: string; name: string; description?: string | null; isActive: boolean };
+
+export default function MunicipalityDepartments() {
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  const { data: departments = [] } = useQuery<Department[]>({ queryKey: ['/api/municipality/departments'] });
+  const refresh = () => queryClient.invalidateQueries({ queryKey: ['/api/municipality/departments'] });
+  const create = useMutation({ mutationFn: () => apiRequest('POST', '/api/municipality/departments', { name, description }), onSuccess: () => { setName(''); setDescription(''); refresh(); toast({ title: 'Department created' }); } });
+  const remove = useMutation({ mutationFn: (id: string) => apiRequest('DELETE', `/api/municipality/departments/${id}`), onSuccess: () => { refresh(); toast({ title: 'Department deleted' }); } });
+  const update = useMutation({ mutationFn: ({ id, data }: { id: string; data: Partial<Department> }) => apiRequest('PATCH', `/api/municipality/departments/${id}`, data), onSuccess: () => { refresh(); toast({ title: 'Department updated' }); } });
+
+  return <Card className="border-white/10 bg-white/5 text-white"><CardHeader><CardTitle className="flex items-center gap-2"><Building2 className="h-5 w-5" />Departments</CardTitle></CardHeader><CardContent className="space-y-6">
+    <div className="grid gap-3 md:grid-cols-[1fr_2fr_auto]"><div><Label>Name</Label><Input value={name} onChange={e => setName(e.target.value)} placeholder="Public Works" className="mt-2" /></div><div><Label>Description</Label><Input value={description} onChange={e => setDescription(e.target.value)} placeholder="Optional department description" className="mt-2" /></div><Button className="self-end" disabled={!name.trim() || create.isPending} onClick={() => create.mutate()}><Plus className="mr-2 h-4 w-4" />Add</Button></div>
+    <div className="space-y-2">{departments.map(department => <div key={department.id} className="flex items-center justify-between rounded-xl border border-white/10 p-4"><div><p className="font-medium">{department.name}</p>{department.description && <p className="text-sm text-blue-100/60">{department.description}</p>}<p className="text-xs text-blue-100/50">{department.isActive ? 'Active' : 'Inactive'}</p></div><div className="flex gap-2"><Button variant="outline" size="sm" onClick={() => update.mutate({ id: department.id, data: { isActive: !department.isActive } })}>{department.isActive ? 'Deactivate' : 'Reactivate'}</Button><Button variant="ghost" size="sm" onClick={() => remove.mutate(department.id)}><Trash2 className="h-4 w-4 text-red-300" /></Button></div></div>)}{!departments.length && <p className="py-6 text-center text-blue-100/60">Create departments that match your municipality's organization.</p>}</div>
+  </CardContent></Card>;
+}

--- a/client/src/components/team-members-section.tsx
+++ b/client/src/components/team-members-section.tsx
@@ -25,8 +25,9 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { UserPlus, Trash2, Edit, Users, Lock, Eye, EyeOff } from "lucide-react";
+import { UserPlus, Trash2, Edit, Users, Lock, Eye, EyeOff, KeyRound } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 
 interface TeamMember {
   id: string;
@@ -38,6 +39,7 @@ interface TeamMember {
   isActive: boolean;
   restrictedServices: string[] | null;
   voipAccess: boolean;
+  departmentId?: string | null;
   lastLoginAt: string | null;
   createdAt: string;
 }
@@ -74,15 +76,20 @@ export default function TeamMembersSection({ cardBaseClasses, inputClasses }: Te
     lastName: "",
     restrictedServices: [] as string[],
     voipAccess: false,
+    role: 'agent',
+    departmentId: '',
   });
 
   const { data: teamMembers = [], isLoading } = useQuery<TeamMember[]>({
     queryKey: ["/api/team-members"],
   });
+  const { data: settings } = useQuery<any>({ queryKey: ["/api/settings"] });
+  const isMunicipality = settings?.businessType === 'municipality';
+  const { data: departments = [] } = useQuery<any[]>({ queryKey: ["/api/municipality/departments"], enabled: isMunicipality });
 
   const createMutation = useMutation({
     mutationFn: async (data: typeof formData) => {
-      const res = await apiRequest("POST", "/api/team-members", data);
+      const res = await apiRequest("POST", "/api/team-members", { ...data, departmentId: data.departmentId || null });
       return res.json();
     },
     onSuccess: () => {
@@ -147,6 +154,11 @@ export default function TeamMembersSection({ cardBaseClasses, inputClasses }: Te
       });
     },
   });
+  const resetPasswordMutation = useMutation({
+    mutationFn: (id: string) => apiRequest('POST', `/api/team-members/${id}/password-reset`, {}),
+    onSuccess: () => toast({ title: 'Password reset email sent' }),
+    onError: (error: any) => toast({ title: 'Unable to send password reset', description: error.message, variant: 'destructive' }),
+  });
 
   const resetForm = () => {
     setFormData({
@@ -157,6 +169,8 @@ export default function TeamMembersSection({ cardBaseClasses, inputClasses }: Te
       lastName: "",
       restrictedServices: [],
       voipAccess: false,
+      role: 'agent',
+      departmentId: '',
     });
     setShowPassword(false);
   };
@@ -173,6 +187,8 @@ export default function TeamMembersSection({ cardBaseClasses, inputClasses }: Te
       lastName: formData.lastName,
       restrictedServices: formData.restrictedServices,
       voipAccess: formData.voipAccess,
+      role: formData.role,
+      departmentId: formData.departmentId || null,
     };
     if (formData.password) {
       updateData.password = formData.password;
@@ -195,6 +211,8 @@ export default function TeamMembersSection({ cardBaseClasses, inputClasses }: Te
       lastName: member.lastName || "",
       restrictedServices: member.restrictedServices || [],
       voipAccess: member.voipAccess || false,
+      role: member.role === 'owner' ? 'manager' : member.role,
+      departmentId: member.departmentId || '',
     });
     setShowEditModal(true);
   };
@@ -225,7 +243,8 @@ export default function TeamMembersSection({ cardBaseClasses, inputClasses }: Te
 
   const owners = teamMembers.filter(m => m.role === 'owner');
   const subUsers = teamMembers.filter(m => m.role !== 'owner');
-  const canAddSubUser = subUsers.length < 1;
+  const activeUsers = teamMembers.filter(member => member.isActive !== false).length;
+  const canAddSubUser = activeUsers < (settings?.maxActiveUsers || 2);
 
   return (
     <Card className={cardBaseClasses}>
@@ -237,7 +256,7 @@ export default function TeamMembersSection({ cardBaseClasses, inputClasses }: Te
               Team Members
             </CardTitle>
             <CardDescription className="text-blue-100/70">
-              Manage access for your team. You can add 1 additional user who will have access to all features except billing.
+              {isMunicipality ? `Manage municipal administrators and staff (${activeUsers}/${settings?.maxActiveUsers || 2} active users).` : 'Manage access for your team. Team members cannot access billing.'}
             </CardDescription>
           </div>
           {canAddSubUser && (
@@ -284,7 +303,7 @@ export default function TeamMembersSection({ cardBaseClasses, inputClasses }: Te
                     </div>
                     <Badge className="bg-amber-500/20 text-amber-200 border-amber-500/30">
                       <Lock className="h-3 w-3 mr-1" />
-                      Owner
+                      {isMunicipality ? 'Primary Administrator' : 'Owner'}
                     </Badge>
                   </div>
                 ))}
@@ -324,6 +343,7 @@ export default function TeamMembersSection({ cardBaseClasses, inputClasses }: Te
                           )}
                         </div>
                         <div className="text-sm text-blue-100/70">{member.email}</div>
+                        {isMunicipality && <div className="text-xs text-blue-100/50 mt-1">{member.role === 'manager' ? 'Administrator' : member.role === 'agent' ? 'Communications Staff' : member.role}{member.departmentId ? ` · ${departments.find((d: any) => d.id === member.departmentId)?.name || 'Department'}` : ''}</div>}
                         {member.restrictedServices && member.restrictedServices.length > 0 && (
                           <div className="text-xs text-blue-100/50 mt-1">
                             Restricted: {member.restrictedServices.filter(s => s !== 'billing').join(', ') || 'None'}
@@ -332,6 +352,7 @@ export default function TeamMembersSection({ cardBaseClasses, inputClasses }: Te
                       </div>
                     </div>
                     <div className="flex items-center gap-2">
+                      {isMunicipality && <Button variant="ghost" size="sm" title="Send password reset" onClick={() => resetPasswordMutation.mutate(member.id)} className="text-blue-100 hover:text-white hover:bg-white/10"><KeyRound className="h-4 w-4" /></Button>}
                       <Button
                         variant="ghost"
                         size="sm"
@@ -412,6 +433,7 @@ export default function TeamMembersSection({ cardBaseClasses, inputClasses }: Te
                 data-testid="input-username"
               />
             </div>
+            {isMunicipality && <div className="grid grid-cols-2 gap-4"><div className="space-y-2"><Label className="text-blue-100">Role</Label><Select value={formData.role} onValueChange={role => setFormData(prev => ({ ...prev, role }))}><SelectTrigger><SelectValue /></SelectTrigger><SelectContent><SelectItem value="manager">Administrator</SelectItem><SelectItem value="agent">Communications Staff</SelectItem><SelectItem value="viewer">Viewer</SelectItem><SelectItem value="uploader">Contact Importer</SelectItem></SelectContent></Select></div><div className="space-y-2"><Label className="text-blue-100">Department</Label><Select value={formData.departmentId || 'none'} onValueChange={departmentId => setFormData(prev => ({ ...prev, departmentId: departmentId === 'none' ? '' : departmentId }))}><SelectTrigger><SelectValue placeholder="No department" /></SelectTrigger><SelectContent><SelectItem value="none">No department</SelectItem>{departments.map((department: any) => <SelectItem key={department.id} value={department.id}>{department.name}</SelectItem>)}</SelectContent></Select></div></div>}
             <div className="space-y-2">
               <Label className="text-blue-100">Email *</Label>
               <Input
@@ -556,7 +578,8 @@ export default function TeamMembersSection({ cardBaseClasses, inputClasses }: Te
                 className={inputClasses}
               />
             </div>
-            <div className="space-y-2">
+            {isMunicipality && <div className="grid grid-cols-2 gap-4"><div className="space-y-2"><Label className="text-blue-100">Role</Label><Select value={formData.role} onValueChange={role => setFormData(prev => ({ ...prev, role }))}><SelectTrigger><SelectValue /></SelectTrigger><SelectContent><SelectItem value="manager">Administrator</SelectItem><SelectItem value="agent">Communications Staff</SelectItem><SelectItem value="viewer">Viewer</SelectItem><SelectItem value="uploader">Contact Importer</SelectItem></SelectContent></Select></div><div className="space-y-2"><Label className="text-blue-100">Department</Label><Select value={formData.departmentId || 'none'} onValueChange={departmentId => setFormData(prev => ({ ...prev, departmentId: departmentId === 'none' ? '' : departmentId }))}><SelectTrigger><SelectValue placeholder="No department" /></SelectTrigger><SelectContent><SelectItem value="none">No department</SelectItem>{departments.map((department: any) => <SelectItem key={department.id} value={department.id}>{department.name}</SelectItem>)}</SelectContent></Select></div></div>}
+            {!isMunicipality && <div className="space-y-2">
               <Label className="text-blue-100">New Password (leave blank to keep current)</Label>
               <div className="relative">
                 <Input
@@ -574,7 +597,7 @@ export default function TeamMembersSection({ cardBaseClasses, inputClasses }: Te
                   {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
                 </button>
               </div>
-            </div>
+            </div>}
 
             <div className="flex items-center justify-between p-3 rounded-lg bg-white/5 border border-white/10">
               <div>

--- a/client/src/pages/__tests__/enterprise-readiness.test.ts
+++ b/client/src/pages/__tests__/enterprise-readiness.test.ts
@@ -2,6 +2,14 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import { activeSeatUsage, canActivateUser, processCursorBatches } from '../../../../shared/enterpriseCapacity';
 import { buildConsumersPageUrl } from '../../hooks/use-paginated-consumers';
+import { canTenantViewBilling } from '../../../../shared/tenantAccess';
+
+test('municipal tenants hide self-service billing without changing other tenant types', () => {
+  assert.equal(canTenantViewBilling('municipality'), false);
+  assert.equal(canTenantViewBilling('municipality', ['billing']), true);
+  assert.equal(canTenantViewBilling('collection_agency'), true);
+  assert.equal(canTenantViewBilling(undefined), true);
+});
 
 test('a tenant configured for 100 users accepts 66 active users and more', () => {
   const users = Array.from({ length: 66 }, () => ({ isActive: true }));

--- a/client/src/pages/billing.tsx
+++ b/client/src/pages/billing.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query";
 import { apiRequest } from "@/lib/queryClient";
-import { Link } from "wouter";
+import { Link, useLocation } from "wouter";
 import AdminLayout from "@/components/admin-layout";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -55,6 +55,7 @@ import {
 import { SiVisa, SiMastercard, SiAmericanexpress, SiDiscover } from "react-icons/si";
 import { loadStripe } from "@stripe/stripe-js";
 import { Elements, CardElement, useStripe, useElements } from "@stripe/react-stripe-js";
+import { canTenantViewBilling } from "@shared/tenantAccess";
 
 const stripePromise = loadStripe(import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY || "");
 
@@ -374,6 +375,7 @@ function StripePayInvoiceForm({ totalBill, invoiceId, onSuccess }: { totalBill: 
 
 export default function Billing() {
   const { toast } = useToast();
+  const [, navigate] = useLocation();
   const queryClient = useQueryClient();
   const [updateBillingOpen, setUpdateBillingOpen] = useState(false);
   const [isSavingBilling, setIsSavingBilling] = useState(false);
@@ -429,6 +431,11 @@ export default function Billing() {
   });
   const enabledAddons = (settingsData as any)?.enabledAddons || [];
   const isTrialAccount = (settingsData as any)?.isTrialAccount ?? true;
+  const isMunicipality = !canTenantViewBilling((settingsData as any)?.businessType, (settingsData as any)?.enabledModules);
+
+  useEffect(() => {
+    if (isMunicipality) navigate('/dashboard', { replace: true });
+  }, [isMunicipality, navigate]);
 
   // Fetch VoIP billing summary
   const { data: voipBillingSummary } = useQuery<{
@@ -787,6 +794,10 @@ export default function Billing() {
       setUpdatingPlanId(null);
     }
   };
+
+  // Municipal invoices are managed and emailed by Chain; municipal users never
+  // see the self-service billing surface, including on a direct URL visit.
+  if (isMunicipality) return null;
 
   if (statsLoading || subscriptionLoading) {
     return (

--- a/client/src/pages/consumers.tsx
+++ b/client/src/pages/consumers.tsx
@@ -35,6 +35,10 @@ import {
 } from "@/components/ui/select";
 
 export default function Consumers() {
+  const { data: tenantSettings } = useQuery<any>({ queryKey: ['/api/settings'] });
+  const isMunicipality = tenantSettings?.businessType === 'municipality';
+  const contactLabel = isMunicipality ? 'Contact' : 'Consumer';
+  const contactsLabel = isMunicipality ? 'Contacts' : 'Consumers';
   const [selectedConsumer, setSelectedConsumer] = useState<any>(null);
   const [showEditDialog, setShowEditDialog] = useState(false);
   const [showViewDialog, setShowViewDialog] = useState(false);
@@ -231,9 +235,9 @@ export default function Consumers() {
     <AdminLayout>
       <div className="py-6">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 md:px-8">
-          <h1 className="text-2xl font-bold text-gray-900">Consumers</h1>
+          <h1 className="text-2xl font-bold text-gray-900">{contactsLabel}</h1>
           <p className="mt-1 text-sm text-gray-500">
-            Manage your consumer database
+            Manage your {isMunicipality ? 'resident and community contact list' : 'consumer database'}
           </p>
         </div>
 
@@ -248,7 +252,7 @@ export default function Consumers() {
                       <Users className="h-5 w-5 text-blue-600" />
                     </div>
                     <div>
-                      <p className="text-sm text-gray-500">Total Consumers</p>
+                      <p className="text-sm text-gray-500">Total {contactsLabel}</p>
                       <p className="text-2xl font-bold text-gray-900">{totalConsumers}</p>
                     </div>
                   </div>
@@ -288,7 +292,7 @@ export default function Consumers() {
           <Card>
             <CardHeader>
               <div className="flex items-center justify-between">
-                <CardTitle>Consumer List</CardTitle>
+                <CardTitle>{contactLabel} List</CardTitle>
                 <div className="flex items-center gap-2">
                   <Label htmlFor="registration-filter" className="text-sm text-gray-600">
                     Filter:
@@ -298,10 +302,10 @@ export default function Consumers() {
                     onValueChange={(value) => { setRegistrationFilter(value); setCursor(null); setCursorHistory([]); }}
                   >
                     <SelectTrigger id="registration-filter" className="w-[180px]" data-testid="select-registration-filter">
-                      <SelectValue placeholder="All Consumers" />
+                      <SelectValue placeholder={`All ${contactsLabel}`} />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="all" data-testid="option-all">All Consumers</SelectItem>
+                      <SelectItem value="all" data-testid="option-all">All {contactsLabel}</SelectItem>
                       <SelectItem value="registered" data-testid="option-registered">Registered Only</SelectItem>
                       <SelectItem value="not_registered" data-testid="option-not-registered">Not Registered</SelectItem>
                     </SelectContent>
@@ -322,8 +326,8 @@ export default function Consumers() {
               ) : filteredConsumers.length === 0 ? (
                 <div className="text-center py-8 text-gray-500">
                   {totalConsumers === 0 
-                    ? "No consumers found. Import account data to get started."
-                    : "No consumers match the selected filter."}
+                    ? `No ${contactsLabel.toLowerCase()} found. Import contact data to get started.`
+                    : `No ${contactsLabel.toLowerCase()} match the selected filter.`}
                 </div>
               ) : (
                 <div className="space-y-4">
@@ -433,7 +437,7 @@ export default function Consumers() {
       <Dialog open={showViewDialog} onOpenChange={setShowViewDialog}>
         <DialogContent className="max-w-2xl max-h-[85vh] overflow-y-auto bg-gradient-to-br from-[#0f172a] via-[#1e293b] to-[#334155] border-white/20 text-white">
           <DialogHeader>
-            <DialogTitle className="text-2xl font-bold text-white">Consumer Details</DialogTitle>
+            <DialogTitle className="text-2xl font-bold text-white">{contactLabel} Details</DialogTitle>
           </DialogHeader>
           {selectedConsumer && (
             <div className="space-y-4">
@@ -532,7 +536,7 @@ export default function Consumers() {
       <Dialog open={showEditDialog} onOpenChange={setShowEditDialog}>
         <DialogContent className="max-w-2xl max-h-[85vh] overflow-y-auto bg-gradient-to-br from-[#0f172a] via-[#1e293b] to-[#334155] border-white/20 text-white">
           <DialogHeader>
-            <DialogTitle className="text-2xl font-bold text-white">Edit Consumer Information</DialogTitle>
+            <DialogTitle className="text-2xl font-bold text-white">Edit {contactLabel} Information</DialogTitle>
           </DialogHeader>
           <form onSubmit={handleUpdateSubmit} className="space-y-4">
             <div className="grid grid-cols-2 gap-4">

--- a/client/src/pages/global-admin.tsx
+++ b/client/src/pages/global-admin.tsx
@@ -30,6 +30,7 @@ export default function GlobalAdmin() {
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
   const [newAgencyName, setNewAgencyName] = useState('');
   const [newAgencyEmail, setNewAgencyEmail] = useState('');
+  const [newAgencyBusinessType, setNewAgencyBusinessType] = useState('collection_agency');
   
   // SMS configuration state
   const [smsConfigDialogOpen, setSmsConfigDialogOpen] = useState(false);
@@ -287,14 +288,15 @@ export default function GlobalAdmin() {
 
   // Mutation to create new agency
   const createAgencyMutation = useMutation({
-    mutationFn: async ({ name, email }: { name: string; email: string }) => {
-      return apiRequest('POST', '/api/admin/agencies', { name, email });
+    mutationFn: async ({ name, email, businessType }: { name: string; email: string; businessType: string }) => {
+      return apiRequest('POST', '/api/admin/agencies', { name, email, businessType });
     },
     onSuccess: (data: any) => {
       queryClient.invalidateQueries({ queryKey: ['/api/admin/tenants'] });
       setIsCreateDialogOpen(false);
       setNewAgencyName('');
       setNewAgencyEmail('');
+      setNewAgencyBusinessType('collection_agency');
       toast({
         title: "Agency Created Successfully",
         description: `${data.tenant.name} has been created with dedicated Postmark email server`,
@@ -940,6 +942,7 @@ export default function GlobalAdmin() {
     createAgencyMutation.mutate({
       name: newAgencyName.trim(),
       email: newAgencyEmail.trim(),
+      businessType: newAgencyBusinessType,
     });
   };
   
@@ -1194,14 +1197,30 @@ export default function GlobalAdmin() {
               </DialogHeader>
               <div className="space-y-4 pt-4">
                 <div className="space-y-2">
-                  <Label htmlFor="agency-name">Agency Name</Label>
+                  <Label htmlFor="agency-name">Organization Name</Label>
                   <Input
                     id="agency-name"
                     value={newAgencyName}
                     onChange={(e) => setNewAgencyName(e.target.value)}
-                    placeholder="Enter agency name"
+                    placeholder="Enter organization name"
                     data-testid="input-agency-name"
                   />
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="organization-type">Organization Type</Label>
+                  <Select value={newAgencyBusinessType} onValueChange={setNewAgencyBusinessType}>
+                    <SelectTrigger id="organization-type" data-testid="select-organization-type">
+                      <SelectValue placeholder="Select organization type" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="collection_agency">Collection Agency</SelectItem>
+                      <SelectItem value="call_center">Call Center</SelectItem>
+                      <SelectItem value="law_firm">Law Firm</SelectItem>
+                      <SelectItem value="municipality">Municipality</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <p className="text-sm text-gray-500">This classifies the tenant; all platform features and large contact lists work the same.</p>
                 </div>
                 
                 <div className="space-y-2">
@@ -3032,6 +3051,9 @@ export default function GlobalAdmin() {
                       <div className="flex-1">
                         <div className="flex items-center space-x-3">
                           <h3 className="text-lg font-semibold text-blue-50" data-testid={`text-tenant-name-${tenant.id}`}>{tenant.name}</h3>
+                          <Badge variant="outline" className="capitalize">
+                            {(tenant.businessType || 'collection_agency').replaceAll('_', ' ')}
+                          </Badge>
                           {tenant.isTrialAccount && (
                             <Badge variant="secondary" data-testid={`badge-trial-${tenant.id}`}>Trial</Badge>
                           )}

--- a/client/src/pages/municipality-admin.tsx
+++ b/client/src/pages/municipality-admin.tsx
@@ -1,0 +1,7 @@
+import AdminLayout from '@/components/admin-layout';
+import MunicipalityDepartments from '@/components/municipality-departments';
+import TeamMembersSection from '@/components/team-members-section';
+
+export default function MunicipalityAdmin() {
+  return <AdminLayout><main className="mx-auto max-w-7xl space-y-8 px-4 py-8"><div className="text-white"><p className="text-sm font-semibold uppercase tracking-widest text-sky-300">Municipality administration</p><h1 className="mt-2 text-3xl font-bold">Users & departments</h1><p className="mt-2 text-blue-100/70">The Primary Administrator can manage municipal staff, access, and department organization.</p></div><MunicipalityDepartments /><TeamMembersSection cardBaseClasses="border-white/10 bg-white/5" inputClasses="border-white/10 bg-white/5 text-white" /></main></AdminLayout>;
+}

--- a/client/src/pages/municipality-dashboard.tsx
+++ b/client/src/pages/municipality-dashboard.tsx
@@ -1,0 +1,37 @@
+import { useQuery } from '@tanstack/react-query';
+import { Link } from 'wouter';
+import AdminLayout from '@/components/admin-layout';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Users, Mail, MessageSquare, CheckCircle, Eye, Megaphone } from 'lucide-react';
+
+type Stats = { totalContacts: number; email: { sent: number; opened: number; bounced: number }; sms: { sent: number; delivered: number; failed: number } };
+
+export default function MunicipalityDashboard() {
+  const { data: stats } = useQuery<Stats>({ queryKey: ['/api/municipality/dashboard-stats'] });
+  const { data: emailCampaigns = [] } = useQuery<any[]>({ queryKey: ['/api/email-campaigns'] });
+  const { data: smsCampaigns = [] } = useQuery<any[]>({ queryKey: ['/api/sms-campaigns'] });
+  const campaigns = [...emailCampaigns.map(c => ({ ...c, channel: 'Email' })), ...smsCampaigns.map(c => ({ ...c, channel: 'SMS' }))]
+    .sort((a, b) => new Date(b.createdAt || 0).getTime() - new Date(a.createdAt || 0).getTime());
+  const sent = (stats?.email.sent || 0) + (stats?.sms.sent || 0);
+  const delivered = Math.max(0, (stats?.email.sent || 0) - (stats?.email.bounced || 0)) + (stats?.sms.delivered || 0);
+  const deliveryRate = sent ? Math.round((delivered / sent) * 100) : 0;
+  const cards = [
+    { label: 'Total Contacts', value: stats?.totalContacts || 0, icon: Users },
+    { label: 'Emails Sent', value: stats?.email.sent || 0, icon: Mail },
+    { label: 'SMS Sent', value: stats?.sms.sent || 0, icon: MessageSquare },
+    { label: 'Delivery Rate', value: `${deliveryRate}%`, icon: CheckCircle },
+    { label: 'Email Opens', value: stats?.email.opened || 0, icon: Eye },
+  ];
+
+  return <AdminLayout><main className="mx-auto max-w-7xl space-y-8 px-4 py-8 text-white">
+    <section className="rounded-3xl border border-white/10 bg-gradient-to-br from-sky-900/70 to-indigo-950/80 p-8">
+      <p className="text-sm font-semibold uppercase tracking-widest text-sky-300">Municipality communications</p>
+      <h1 className="mt-2 text-3xl font-bold">Community communications dashboard</h1>
+      <p className="mt-2 max-w-2xl text-blue-100/70">Reach residents, manage notifications, and monitor campaign engagement.</p>
+      <div className="mt-6 flex gap-3"><Link href="/communications?tab=campaigns"><Button><Megaphone className="mr-2 h-4 w-4" />Campaigns</Button></Link><Link href="/consumers"><Button variant="outline">Manage contacts</Button></Link></div>
+    </section>
+    <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-5">{cards.map(({ label, value, icon: Icon }) => <Card key={label} className="border-white/10 bg-white/5 text-white"><CardContent className="pt-6"><Icon className="h-5 w-5 text-sky-300" /><p className="mt-4 text-sm text-blue-100/60">{label}</p><p className="mt-1 text-3xl font-semibold">{value.toLocaleString()}</p></CardContent></Card>)}</section>
+    <Card className="border-white/10 bg-white/5 text-white"><CardHeader><CardTitle>Recent campaigns</CardTitle></CardHeader><CardContent className="space-y-3">{campaigns.slice(0, 8).map(c => <div key={`${c.channel}-${c.id}`} className="flex items-center justify-between rounded-xl border border-white/10 p-4"><div><p className="font-medium">{c.name}</p><p className="text-sm text-blue-100/60">{c.channel} · {c.totalSent || 0} sent</p></div><span className="rounded-full bg-sky-500/15 px-3 py-1 text-xs text-sky-200">{c.status || 'draft'}</span></div>)}{!campaigns.length && <p className="py-8 text-center text-blue-100/60">No campaigns yet.</p>}</CardContent></Card>
+  </main></AdminLayout>;
+}

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -1305,17 +1305,16 @@ export default function Settings() {
         </section>
 
         <section className="rounded-3xl border border-white/10 bg-white/5 p-6 shadow-lg shadow-blue-900/20 backdrop-blur">
-          <Tabs defaultValue="general" className="space-y-8">
+          <Tabs defaultValue={localSettings?.businessType === 'municipality' ? 'documents' : 'general'} className="space-y-8">
             <TabsList className={cn(
               "grid w-full grid-cols-1 gap-2 p-2 text-blue-100",
-              localSettings?.businessType === 'call_center' ? "sm:grid-cols-8" : "sm:grid-cols-7"
+              localSettings?.businessType === 'municipality' ? "sm:grid-cols-4" : localSettings?.businessType === 'call_center' ? "sm:grid-cols-8" : "sm:grid-cols-7"
             )}>
-              <TabsTrigger value="general" className="px-4 py-2">
+              {localSettings?.businessType !== 'municipality' && <><TabsTrigger value="general" className="px-4 py-2">
                 General
-              </TabsTrigger>
-              <TabsTrigger value="merchant" className="px-4 py-2">
+              </TabsTrigger><TabsTrigger value="merchant" className="px-4 py-2">
                 Payment Processing
-              </TabsTrigger>
+              </TabsTrigger></>}
               {localSettings?.businessType === 'call_center' && (
                 <TabsTrigger value="integrations" className="px-4 py-2">
                   Integrations
@@ -1324,9 +1323,9 @@ export default function Settings() {
               <TabsTrigger value="documents" className="px-4 py-2">
                 Documents
               </TabsTrigger>
-              <TabsTrigger value="arrangements" className="px-4 py-2">
+              {localSettings?.businessType !== 'municipality' && <TabsTrigger value="arrangements" className="px-4 py-2">
                 Payment Plans
-              </TabsTrigger>
+              </TabsTrigger>}
               <TabsTrigger value="privacy" className="px-4 py-2">
                 Privacy & Legal
               </TabsTrigger>
@@ -1340,7 +1339,7 @@ export default function Settings() {
               )}
             </TabsList>
 
-            <TabsContent value="general" className="space-y-6">
+            {localSettings?.businessType !== 'municipality' && <TabsContent value="general" className="space-y-6">
               <Card className={cardBaseClasses}>
                 <CardHeader className="space-y-1 text-white">
                   <CardTitle className="text-xl font-semibold text-white">Consumer Portal Settings</CardTitle>
@@ -1893,9 +1892,9 @@ export default function Settings() {
                   )}
                 </CardContent>
               </Card>
-            </TabsContent>
+            </TabsContent>}
 
-            <TabsContent value="merchant" className="space-y-6">
+            {localSettings?.businessType !== 'municipality' && <TabsContent value="merchant" className="space-y-6">
               <Card className={cardBaseClasses}>
                 <CardHeader className="space-y-1 text-white">
                   <CardTitle className="text-xl font-semibold text-white">Payment Processing Settings</CardTitle>
@@ -2260,7 +2259,7 @@ export default function Settings() {
                   </CardFooter>
                 )}
               </Card>
-            </TabsContent>
+            </TabsContent>}
 
             {localSettings?.businessType === 'call_center' && (
               <TabsContent value="integrations" className="space-y-6">
@@ -3144,16 +3143,20 @@ export default function Settings() {
                       <FileText className="h-16 w-16 mx-auto mb-4 text-blue-400/60" />
                       <h3 className="text-lg font-semibold text-blue-100 mb-2">Document Signing Not Enabled</h3>
                       <p className="text-sm text-blue-200/70 mb-6 max-w-md mx-auto">
-                        Enable document signing in Billing → Services to create professional document templates for e-signatures, payment agreements, service contracts, and authorization forms.
+                        {(localSettings as any)?.businessType === 'municipality'
+                          ? 'Contact Chain support to enable document signing for this municipality.'
+                          : 'Enable document signing in Billing → Services to create professional document templates for e-signatures, payment agreements, service contracts, and authorization forms.'}
                       </p>
-                      <Button
-                        onClick={() => {
-                          window.location.href = '/billing?tab=services';
-                        }}
-                        className="rounded-xl bg-gradient-to-r from-sky-500/80 to-indigo-500/80 px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-blue-900/30 transition hover:from-sky-400/80 hover:to-indigo-400/80"
-                      >
-                        Go to Billing Services
-                      </Button>
+                      {(localSettings as any)?.businessType !== 'municipality' && (
+                        <Button
+                          onClick={() => {
+                            window.location.href = '/billing?tab=services';
+                          }}
+                          className="rounded-xl bg-gradient-to-r from-sky-500/80 to-indigo-500/80 px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-blue-900/30 transition hover:from-sky-400/80 hover:to-indigo-400/80"
+                        >
+                          Go to Billing Services
+                        </Button>
+                      )}
                     </div>
                   ) : (
                     <div className="space-y-6">
@@ -3750,7 +3753,7 @@ export default function Settings() {
               </Dialog>
             </TabsContent>
 
-            <TabsContent value="arrangements" className="space-y-6">
+            {localSettings?.businessType !== 'municipality' && <TabsContent value="arrangements" className="space-y-6">
               {/* Minimum Monthly Payment */}
               <Card className={cardBaseClasses}>
                 <CardHeader className="text-white">
@@ -4189,7 +4192,7 @@ export default function Settings() {
                   )}
                 </CardContent>
               </Card>
-            </TabsContent>
+            </TabsContent>}
 
             <TabsContent value="privacy" className="space-y-6">
               <Card className={cardBaseClasses}>

--- a/docs/ENTERPRISE_READINESS.md
+++ b/docs/ENTERPRISE_READINESS.md
@@ -2,6 +2,10 @@
 
 ## Contact access and campaigns
 
+Municipalities are ordinary isolated tenants with `business_type=municipality`; the classification does not select a different contact store or code path. They use the same paginated contact access and bounded campaign processing described below.
+
+Municipal administrators do not see the self-service Billing navigation or page. Billing jobs and invoice email delivery remain enabled for platform administrators, so hiding the tenant-facing page does not interrupt invoicing.
+
 `GET /api/consumers` is database-paginated. It accepts `limit` (maximum 500), `cursor`, `search`, `folderId`, `registration`, and `format=page`. Page responses contain `items`, `nextCursor`, and `total`; compatibility array responses also expose `X-Total-Count` and `X-Next-Cursor`.
 
 Email campaign approval returns HTTP 202 after billing reservation. The worker selects at most 500 eligible consumers, selects accounts only for those consumer IDs, builds and submits that Postmark batch, persists progress, and advances by the consumer UUID cursor. It never constructs the complete campaign audience or email payload array.

--- a/docs/MUNICIPALITY_TENANT_EXPERIENCE.md
+++ b/docs/MUNICIPALITY_TENANT_EXPERIENCE.md
@@ -1,0 +1,31 @@
+# Municipality tenant experience
+
+The municipality experience activates only when the authoritative tenant record has `business_type = 'municipality'`. Other tenant types continue to use the existing dashboard, navigation, accounts, payments, billing, portal, and terminology.
+
+## Reused modules
+
+Municipalities reuse the paginated contact directory, email/SMS campaigns, templates, communication history, analytics, documents, authentication, and tenant-isolation controls. Navigation links open the relevant tab of the existing Communications workspace instead of duplicating campaign or template pages.
+
+The municipal dashboard reports only database-backed metrics: total contacts, emails and SMS sent, combined delivery rate, tracked email opens, and recent email/SMS campaigns. Its contact total uses a database aggregate and does not load contacts into application memory.
+
+## Default module visibility
+
+Accounts, Payments, Billing, payment plans, merchant settings, payment arrangements, payment-focused dashboards, and the consumer payment portal are absent by default. New municipal tenants have portal and payment processing access disabled. Chain can later enable the `billing` module explicitly; doing so restores the payment routes and navigation without changing the municipality classification.
+
+## Departments and users
+
+`tenant_departments` stores administrator-defined departments. The Primary Administrator can create, edit, deactivate, and delete departments. Credentials may optionally reference a department. The existing tenant credential model remains responsible for roles, activation, deletion, passwords, tenant isolation, and configurable active-seat limits.
+
+The owner is presented as the **Primary Administrator**. Municipal user roles are mapped onto the existing permission-compatible roles: Administrator (`manager`), Communications Staff (`agent`), Viewer, and Contact Importer (`uploader`). Password reset initiation emails a one-hour reset link; passwords remain hashed and are never returned to administrators.
+
+## Public experience
+
+Municipal tenant creation disables `portal_access_enabled` and `payment_processing_enabled` by default. Unsubscribe, communication-preference, and enabled document links remain available through their existing purpose-specific routes.
+
+## Current limitations
+
+* Lists/segments reuse the existing contact folders and campaign targeting; this release does not introduce a second segmentation engine.
+* Department activity analytics are not displayed because current communication records do not carry a department identifier.
+* Scheduled-campaign cards are not displayed because the existing email/SMS campaign records do not expose a common scheduled-send timestamp.
+* Email clicks are retained in campaign tracking but are not shown on the dashboard until a tenant-wide aggregate endpoint can calculate them consistently across all send paths.
+* The existing Communications workspace still contains optional account-summary/template controls. They are not placed in municipal navigation, but a future pass can simplify the editor itself when municipal payment modules are disabled.

--- a/server/migrations.ts
+++ b/server/migrations.ts
@@ -6,6 +6,20 @@ export async function runMigrations() {
   try {
     client = await pool.connect();
     console.log('🔄 Running database migrations...');
+
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS tenant_departments (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+        name TEXT NOT NULL,
+        description TEXT,
+        is_active BOOLEAN NOT NULL DEFAULT true,
+        created_at TIMESTAMP DEFAULT NOW(),
+        updated_at TIMESTAMP DEFAULT NOW(),
+        UNIQUE (tenant_id, name)
+      )
+    `);
+    await client.query(`ALTER TABLE agency_credentials ADD COLUMN IF NOT EXISTS department_id UUID REFERENCES tenant_departments(id) ON DELETE SET NULL`);
     
     // Add payment processor columns (USAePay, Authorize.net, and NMI)
     console.log('Adding payment processor columns...');

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -19,6 +19,7 @@ import {
   paymentSchedules as paymentSchedulesTable,
   payments,
   agencyCredentials,
+  tenantDepartments,
   users,
   subscriptionPlans,
   subscriptions,
@@ -2791,6 +2792,28 @@ export async function registerRoutes(app: Express): Promise<Server> {
       console.error("Error fetching stats:", error);
       res.status(500).json({ message: "Failed to fetch stats" });
     }
+  });
+
+  // Communications-only municipal metrics use database aggregates so a
+  // 500,000-contact municipality never materializes its contact list in memory.
+  app.get('/api/municipality/dashboard-stats', authenticateUser, async (req: any, res) => {
+    const tenantId = req.user.tenantId;
+    const tenant = await storage.getTenant(tenantId);
+    if (tenant?.businessType !== 'municipality') return res.status(404).json({ message: 'Not found' });
+    const [[contactStats], [emailStats], [smsStats]] = await Promise.all([
+      db.select({ totalContacts: sql<number>`count(*)::int` }).from(consumers).where(eq(consumers.tenantId, tenantId)),
+      db.select({
+        sent: sql<number>`count(*)::int`,
+        opened: sql<number>`count(*) FILTER (WHERE ${emailLogs.openedAt} IS NOT NULL)::int`,
+        bounced: sql<number>`count(*) FILTER (WHERE ${emailLogs.bouncedAt} IS NOT NULL)::int`,
+      }).from(emailLogs).where(eq(emailLogs.tenantId, tenantId)),
+      db.select({
+        sent: sql<number>`count(*)::int`,
+        delivered: sql<number>`count(*) FILTER (WHERE ${smsTracking.status} = 'delivered')::int`,
+        failed: sql<number>`count(*) FILTER (WHERE ${smsTracking.status} = 'failed')::int`,
+      }).from(smsTracking).where(eq(smsTracking.tenantId, tenantId)),
+    ]);
+    res.json({ totalContacts: contactStats.totalContacts, email: emailStats, sms: smsStats });
   });
 
   // CSV Import route
@@ -9663,6 +9686,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
         twilioCampaignId: tenant?.twilioCampaignId || '',
         customSenderEmail: tenant?.customSenderEmail || '',
         isTrialAccount: tenant?.isTrialAccount || false,
+        businessType: tenant?.businessType || 'call_center',
+        maxActiveUsers: tenant?.maxActiveUsers || 2,
         // Service access flags
         emailServiceEnabled: tenant?.emailServiceEnabled ?? true,
         smsServiceEnabled: tenant?.smsServiceEnabled ?? true,
@@ -10089,6 +10114,54 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // Available services that can be restricted for sub-users
   const AVAILABLE_SERVICES = ['billing', 'sms', 'payments', 'import', 'reports', 'documents', 'automations', 'email'];
 
+  const requireMunicipalityOwner = async (req: any, res: Response) => {
+    if (req.user.role !== 'owner' && req.user.role !== 'platform_admin') {
+      res.status(403).json({ message: 'Only the Primary Administrator can manage departments' });
+      return null;
+    }
+    const tenant = await storage.getTenant(req.user.tenantId);
+    if (tenant?.businessType !== 'municipality') {
+      res.status(404).json({ message: 'Department management is only available to municipality tenants' });
+      return null;
+    }
+    return tenant;
+  };
+
+  app.get('/api/municipality/departments', authenticateUser, async (req: any, res) => {
+    const tenant = await storage.getTenant(req.user.tenantId);
+    if (tenant?.businessType !== 'municipality') return res.status(404).json({ message: 'Not found' });
+    const rows = await db.select().from(tenantDepartments)
+      .where(eq(tenantDepartments.tenantId, tenant.id)).orderBy(tenantDepartments.name);
+    res.json(rows);
+  });
+
+  app.post('/api/municipality/departments', authenticateUser, async (req: any, res) => {
+    const tenant = await requireMunicipalityOwner(req, res);
+    if (!tenant) return;
+    const data = z.object({ name: z.string().trim().min(1).max(100), description: z.string().trim().max(500).optional() }).parse(req.body);
+    const [row] = await db.insert(tenantDepartments).values({ tenantId: tenant.id, ...data }).returning();
+    res.status(201).json(row);
+  });
+
+  app.patch('/api/municipality/departments/:id', authenticateUser, async (req: any, res) => {
+    const tenant = await requireMunicipalityOwner(req, res);
+    if (!tenant) return;
+    const data = z.object({ name: z.string().trim().min(1).max(100).optional(), description: z.string().trim().max(500).nullable().optional(), isActive: z.boolean().optional() }).parse(req.body);
+    const [row] = await db.update(tenantDepartments).set({ ...data, updatedAt: new Date() })
+      .where(and(eq(tenantDepartments.id, req.params.id), eq(tenantDepartments.tenantId, tenant.id))).returning();
+    if (!row) return res.status(404).json({ message: 'Department not found' });
+    res.json(row);
+  });
+
+  app.delete('/api/municipality/departments/:id', authenticateUser, async (req: any, res) => {
+    const tenant = await requireMunicipalityOwner(req, res);
+    if (!tenant) return;
+    const [row] = await db.delete(tenantDepartments)
+      .where(and(eq(tenantDepartments.id, req.params.id), eq(tenantDepartments.tenantId, tenant.id))).returning();
+    if (!row) return res.status(404).json({ message: 'Department not found' });
+    res.json({ message: 'Department deleted' });
+  });
+
   // Get all team members for tenant
   app.get('/api/team-members', authenticateUser, async (req: any, res) => {
     try {
@@ -10156,9 +10229,16 @@ export async function registerRoutes(app: Express): Promise<Server> {
         lastName: z.string().optional(),
         restrictedServices: z.array(z.string()).optional(),
         voipAccess: z.boolean().optional(),
+        role: z.enum(['manager', 'agent', 'viewer', 'uploader']).optional(),
+        departmentId: z.string().uuid().nullable().optional(),
       });
 
       const data = memberSchema.parse(req.body);
+      if (data.departmentId) {
+        const [department] = await db.select({ id: tenantDepartments.id }).from(tenantDepartments)
+          .where(and(eq(tenantDepartments.id, data.departmentId), eq(tenantDepartments.tenantId, tenantId)));
+        if (!department) return res.status(400).json({ message: 'Invalid department' });
+      }
       console.log("[TEAM-MEMBERS] Validated data - username:", data.username, "email:", data.email, "voipAccess:", data.voipAccess);
       
       // Check if username already exists
@@ -10184,7 +10264,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
         passwordHash,
         firstName: data.firstName || null,
         lastName: data.lastName || null,
-        role: 'agent', // Sub-users get 'agent' role, not 'owner'
+        role: data.role || 'agent',
+        departmentId: data.departmentId || null,
         isActive: true,
         restrictedServices,
         voipAccess: data.voipAccess || false,
@@ -10238,9 +10319,16 @@ export async function registerRoutes(app: Express): Promise<Server> {
         isActive: z.boolean().optional(),
         restrictedServices: z.array(z.string()).optional(),
         voipAccess: z.boolean().optional(),
+        role: z.enum(['manager', 'agent', 'viewer', 'uploader']).optional(),
+        departmentId: z.string().uuid().nullable().optional(),
       });
 
       const data = updateSchema.parse(req.body);
+      if (data.departmentId) {
+        const [department] = await db.select({ id: tenantDepartments.id }).from(tenantDepartments)
+          .where(and(eq(tenantDepartments.id, data.departmentId), eq(tenantDepartments.tenantId, tenantId)));
+        if (!department) return res.status(400).json({ message: 'Invalid department' });
+      }
 
       if (data.isActive === true && existingMember.isActive === false) {
         const [tenant, credentials] = await Promise.all([
@@ -10264,6 +10352,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
       if (data.lastName !== undefined) updates.lastName = data.lastName;
       if (data.isActive !== undefined) updates.isActive = data.isActive;
       if (data.voipAccess !== undefined) updates.voipAccess = data.voipAccess;
+      if (data.role !== undefined) updates.role = data.role;
+      if (data.departmentId !== undefined) updates.departmentId = data.departmentId;
       if (data.restrictedServices !== undefined) {
         // Ensure billing is always restricted for sub-users
         const services = data.restrictedServices;
@@ -10325,6 +10415,23 @@ export async function registerRoutes(app: Express): Promise<Server> {
       console.error("Error deleting team member:", error);
       res.status(500).json({ message: "Failed to delete team member" });
     }
+  });
+
+  app.post('/api/team-members/:id/password-reset', authenticateUser, async (req: any, res) => {
+    const tenantId = req.user.tenantId;
+    if (req.user.role !== 'owner' && req.user.role !== 'platform_admin') return res.status(403).json({ message: 'Only administrators can initiate password resets' });
+    const member = await storage.getAgencyCredentialsById(req.params.id);
+    if (!member || member.tenantId !== tenantId) return res.status(404).json({ message: 'Team member not found' });
+    const token = crypto.randomBytes(32).toString('hex');
+    await storage.createPasswordResetToken(member.id, token, new Date(Date.now() + 60 * 60 * 1000));
+    const baseUrl = process.env.BASE_URL || 'https://chainsoftwaregroup.com';
+    await emailService.sendEmail({
+      to: member.email,
+      subject: 'Set a new Chain password',
+      html: `<p>Hello${member.firstName ? ` ${member.firstName}` : ''},</p><p>Your organization administrator requested a password reset for your Chain account.</p><p><a href="${baseUrl}/agency/reset-password?token=${token}">Set a new password</a></p><p>This secure link expires in one hour. Your existing password has not been exposed.</p>`,
+      tag: 'password-reset',
+    });
+    res.json({ message: 'Password reset email sent' });
   });
 
   // Get available services that can be restricted
@@ -21639,11 +21746,15 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // Create new agency with Postmark server
   app.post('/api/admin/agencies', isPlatformAdmin, async (req: any, res) => {
     try {
-      const { name, email } = req.body;
-      
-      if (!name || !email) {
-        return res.status(400).json({ message: "Agency name and email are required" });
+      const creation = z.object({
+        name: z.string().trim().min(1).max(100),
+        email: z.string().trim().email(),
+        businessType: z.enum(['collection_agency', 'call_center', 'law_firm', 'municipality']).default('collection_agency'),
+      }).safeParse(req.body);
+      if (!creation.success) {
+        return res.status(400).json({ message: "Organization name, type, and a valid email are required", errors: creation.error.errors });
       }
+      const { name, email, businessType } = creation.data;
 
       // Check if agency with this email already exists
       const existingTenant = await storage.getTenantByEmail(email);
@@ -21676,6 +21787,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const tenant = await storage.createTenantWithPostmark({
         name,
         email,
+        businessType,
         postmarkServerId: server.ID.toString(),
         postmarkServerToken: server.ApiTokens[0],
         postmarkServerName: server.Name,
@@ -21700,6 +21812,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
           name: tenant.name,
           slug: tenant.slug,
           email: tenant.email,
+          businessType: tenant.businessType,
           postmarkServerId: tenant.postmarkServerId,
           postmarkServerName: tenant.postmarkServerName,
         },

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -207,6 +207,7 @@ export interface IStorage {
   createTenantWithPostmark(data: {
     name: string;
     email: string;
+    businessType?: string;
     postmarkServerId: string;
     postmarkServerToken: string;
     postmarkServerName: string;
@@ -727,6 +728,7 @@ export class DatabaseStorage implements IStorage {
   async createTenantWithPostmark(data: {
     name: string;
     email: string;
+    businessType?: string;
     postmarkServerId: string;
     postmarkServerToken: string;
     postmarkServerName: string;
@@ -738,6 +740,9 @@ export class DatabaseStorage implements IStorage {
       name: data.name,
       slug: slug,
       email: data.email,
+      businessType: data.businessType || 'collection_agency',
+      portalAccessEnabled: data.businessType === 'municipality' ? false : true,
+      paymentProcessingEnabled: data.businessType === 'municipality' ? false : true,
       isTrialAccount: false, // Created by admin as paid account
       isPaidAccount: true,
       postmarkServerId: data.postmarkServerId,

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -44,7 +44,7 @@ export const tenants = pgTable("tenants", {
   id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
   name: text("name").notNull(),
   slug: text("slug").unique().notNull(),
-  businessType: text("business_type").default('call_center'), // Type of business using the platform
+  businessType: text("business_type").default('call_center'), // Tenant classification: call_center, collection_agency, law_firm, or municipality
   brand: jsonb("brand").default(sql`'{}'::jsonb`),
   isActive: boolean("is_active").default(true), // Can be suspended by platform owner
   suspendedAt: timestamp("suspended_at"),
@@ -165,10 +165,23 @@ export const tenantAddons = pgTable("tenant_addons", {
   metadata: jsonb("metadata").default(sql`'{}'::jsonb`),
 });
 
+// Municipality departments are generic tenant-owned groupings. They are kept
+// separate from contact folders/lists so departments can organize staff.
+export const tenantDepartments = pgTable("tenant_departments", {
+  id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+  tenantId: uuid("tenant_id").references(() => tenants.id, { onDelete: "cascade" }).notNull(),
+  name: text("name").notNull(),
+  description: text("description"),
+  isActive: boolean("is_active").default(true).notNull(),
+  createdAt: timestamp("created_at").defaultNow(),
+  updatedAt: timestamp("updated_at").defaultNow(),
+});
+
 // Agency credentials (for username/password auth)
 export const agencyCredentials = pgTable("agency_credentials", {
   id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
   tenantId: uuid("tenant_id").references(() => tenants.id, { onDelete: "cascade" }).notNull(),
+  departmentId: uuid("department_id").references(() => tenantDepartments.id, { onDelete: "set null" }),
   username: text("username").unique().notNull(),
   passwordHash: text("password_hash").notNull(), // Hashed password using bcrypt
   email: text("email").notNull(),

--- a/shared/tenantAccess.ts
+++ b/shared/tenantAccess.ts
@@ -1,0 +1,3 @@
+export function canTenantViewBilling(businessType: string | null | undefined, enabledModules: string[] = []): boolean {
+  return businessType !== 'municipality' || enabledModules.includes('billing');
+}


### PR DESCRIPTION
### Motivation
- Introduce first-class support for municipal tenants (business_type = `municipality`) so municipalities can use the platform for large contact lists and communications while hiding payment surfaces by default.
- Provide tenant-scoped departments and map team members to departments to support municipal organizational structure and admin workflows.
- Prevent municipal users from accessing tenant self-service billing unless the `billing` module is explicitly enabled, reducing accidental exposure of payment flows for public-sector customers.

### Description
- Database and storage: add `businessType` on `tenants`, create `tenant_departments` table, add `departmentId` to `agency_credentials`, and add migration SQL in `server/migrations.ts`; update `storage` APIs and tenant creation to respect `businessType` and default module visibility.
- Server routes and logic: expose CRUD endpoints under `/api/municipality/departments`, add `/api/municipality/dashboard-stats` aggregate endpoint, validate department references when creating/updating team members, add a `/api/team-members/:id/password-reset` endpoint, and extend admin agency creation to accept `businessType`.
- Shared schema and helpers: add `tenantDepartments` to shared schema, annotate `agency_credentials` with `departmentId`, and add `canTenantViewBilling` in `shared/tenantAccess.ts` to centralize billing visibility logic.
- Frontend/UI: add municipality-specific pages and components (`municipality-dashboard`, `municipality-admin`, `municipality-departments`), adapt `AdminLayout`, `TeamMembersSection`, `Consumers`, `Billing`, and `Settings` to use `businessType` and `canTenantViewBilling` for navigation, tab visibility, terminology changes, department selection, and password-reset triggers.
- Documentation: add `MUNICIPALITY_TENANT_EXPERIENCE.md` and update `ENTERPRISE_READINESS.md` to document municipality behavior and large-contact handling.

### Testing
- Ran the automated unit test suite via `npm test`, including the updated `enterprise-readiness.test.ts` that asserts `canTenantViewBilling` behavior, and all tests passed.
- Verified TypeScript build and frontend compile (development build) to ensure new components and imports (`@shared/tenantAccess`, new pages) typecheck correctly and render without compile errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b518472d8832a812bbd3a3df80439)