### PR TITLE
Fix TypeScript shape mismatches and add runtime null checks

### DIFF
--- a/client/src/components/email-builder.tsx
+++ b/client/src/components/email-builder.tsx
@@ -47,9 +47,9 @@ export function EmailBuilder({ initialBlocks = [], onChange }: EmailBuilderProps
   };
 
   const updateBlock = (id: string, updates: Partial<EmailBlock>) => {
-    const updatedBlocks = blocks.map(b => 
+    const updatedBlocks: EmailBlock[] = blocks.map(b =>
       b.id === id ? { ...b, ...updates } : b
-    );
+    ) as EmailBlock[];
     setBlocks(updatedBlocks);
     onChange(updatedBlocks);
   };

--- a/client/src/pages/accounts.tsx
+++ b/client/src/pages/accounts.tsx
@@ -793,7 +793,6 @@ export default function Accounts() {
                     }`}
                     onClick={() => {
                       setSelectedFolderId("all");
-                      setDisplayLimit(50);
                     }}
                     data-testid="folder-all"
                   >
@@ -814,7 +813,6 @@ export default function Accounts() {
                         }`}
                         onClick={() => {
                           setSelectedFolderId(folder.id);
-                          setDisplayLimit(50);
                         }}
                         data-testid={`folder-${folder.id}`}
                       >
@@ -874,7 +872,6 @@ export default function Accounts() {
                 }`}
                 onClick={() => {
                   setRegistrationFilter("all");
-                  setDisplayLimit(50);
                 }}
                 data-testid="filter-all-registration"
               >
@@ -892,7 +889,6 @@ export default function Accounts() {
                 }`}
                 onClick={() => {
                   setRegistrationFilter("registered");
-                  setDisplayLimit(50);
                 }}
                 data-testid="filter-registered"
               >
@@ -911,7 +907,6 @@ export default function Accounts() {
                 }`}
                 onClick={() => {
                   setRegistrationFilter("not_registered");
-                  setDisplayLimit(50);
                 }}
                 data-testid="filter-not-registered"
               >
@@ -935,7 +930,6 @@ export default function Accounts() {
                 value={accountSearchText}
                 onChange={(e) => {
                   setAccountSearchText(e.target.value);
-                  setDisplayLimit(50);
                 }}
                 className="pl-9 bg-white/5 border-white/10 text-white placeholder:text-blue-100/40 rounded-xl"
                 data-testid="input-accounts-search"

--- a/client/src/pages/admin-dashboard.tsx
+++ b/client/src/pages/admin-dashboard.tsx
@@ -95,7 +95,7 @@ export default function AdminDashboard() {
     setShowComposeEmailDialog(true);
   };
 
-  const { data: emailTemplates } = useQuery({
+  const { data: emailTemplates } = useQuery<any[]>({
     queryKey: ["/api/email-templates"],
     enabled: showComposeEmailDialog,
   });

--- a/client/src/pages/payments.tsx
+++ b/client/src/pages/payments.tsx
@@ -655,7 +655,7 @@ export default function Payments() {
               <TabsTrigger value="today" data-testid="tab-today">
                 <Calendar className="w-4 h-4 mr-2" />
                 Today's Payments
-                {paymentSchedules && (() => {
+                {Boolean(paymentSchedules) && (() => {
                   const now = new Date();
                   const todayStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
                   const todayCount = (paymentSchedules as any[]).filter((s: any) => {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "NODE_ENV=development tsx server/index.ts",
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
-    "check": "tsc",
+    "check": "tsc && tsc -p api/tsconfig.json && tsc -p mobile-agency-app/tsconfig.json",
     "test": "node --test --import tsx ./client/src/pages/__tests__/*.test.ts",
     "load-test:500k": "tsx scripts/load-test-500k.ts",
     "db:push": "drizzle-kit push",

--- a/server/authMiddleware.ts
+++ b/server/authMiddleware.ts
@@ -196,7 +196,10 @@ export const getCurrentUser = async (req: any) => {
     tenantId: req.user.tenantId,
     tenantSlug: req.user.tenantSlug || tenant?.slug, // Include slug from token or tenant
     tenant: tenant,
-    isJwtAuth: true
+    isJwtAuth: true,
+    role: req.user.role,
+    voipAccess: req.user.voipAccess,
+    credentialId: req.user.credentialId,
   };
 };
 

--- a/server/eventService.ts
+++ b/server/eventService.ts
@@ -87,10 +87,11 @@ class EventService extends EventEmitter {
         try {
           // Check target audience filtering
           if (sequence.targetType === 'folder' && sequence.targetFolderIds && sequence.targetFolderIds.length > 0) {
+            const targetFolderIds = sequence.targetFolderIds;
             // Check if consumer has accounts in the target folders
             const consumerAccounts = await storage.getAccountsByConsumer(payload.consumerId);
             const hasAccountInTargetFolder = consumerAccounts.some(account => 
-              sequence.targetFolderIds.includes(account.folderId)
+              account.folderId !== null && targetFolderIds.includes(account.folderId)
             );
 
             if (!hasAccountInTargetFolder) {

--- a/server/migrations.ts
+++ b/server/migrations.ts
@@ -1575,7 +1575,7 @@ export async function runMigrations() {
         SET status = 'cancelled'
         WHERE status = 'sending'
       `);
-      if (stuckResult.rowCount > 0) {
+      if ((stuckResult.rowCount ?? 0) > 0) {
         console.log(`  ✓ Marked ${stuckResult.rowCount} stuck SMS campaigns as cancelled (can be resumed)`);
       } else {
         console.log(`  ✓ No stuck SMS campaigns found`);

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -12181,7 +12181,6 @@ export async function registerRoutes(app: Express): Promise<Server> {
         processedAt: payment.processedAt,
         createdAt: payment.createdAt,
         accountCreditor: payment.accountCreditor,
-        arrangementName: payment.arrangementName,
         notes: payment.notes,
         transactionId: payment.transactionId,
       }));
@@ -15126,7 +15125,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
           isRecurring: arrangement?.planType === 'fixed_monthly' || arrangement?.planType === 'range'
         });
         
-        if (shouldCreateSchedule) {
+        if (shouldCreateSchedule && arrangement) {
           console.log('🔨 Creating payment schedule...');
           // Check if consumer already has an active payment schedule for this account
           const existingSchedules = await storage.getActivePaymentSchedulesByConsumerAndAccount(consumerId, accountId, tenantId);
@@ -15418,7 +15417,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
                 const amountDollars = (amountCents / 100).toFixed(2);
                 const scheduleRecord = createdSchedule as any;
                 const firstPaymentDate = scheduleRecord?.startDate || paymentStartDate.toISOString().split('T')[0];
-                const consumerNameRaw = `${consumerForSmax?.firstName || ''} ${consumerForSmax?.lastName || ''}`.trim();
+                const dmpConsumer = await storage.getConsumer(consumerId);
+                const consumerNameRaw = `${dmpConsumer?.firstName || ''} ${dmpConsumer?.lastName || ''}`.trim();
 
                 await dmpService.insertAttempt(tenantId, {
                   filenumber: fileNumber,
@@ -18731,7 +18731,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
           amount: amountCents / 100,
           cardNumber: cardNumber.replace(/\s/g, ''),
           expirationDate: `${expiryYear}-${expiryMonth}`,
-          cardCode: cvv,
+          cvv,
           invoice: `admin_${Date.now()}`,
           description: `Admin payment for ${consumer.firstName} ${consumer.lastName}`,
         });
@@ -25297,7 +25297,6 @@ export async function registerRoutes(app: Express): Promise<Server> {
         fromNumber: formatPhoneE164(From),
         toNumber: formatPhoneE164(To),
         status: 'ringing',
-        createdAt: new Date(),
       });
 
       // Generate TwiML to ring all agents from this tenant

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -907,7 +907,7 @@ export class DatabaseStorage implements IStorage {
       .orderBy(agencyCredentials.createdAt);
   }
 
-  async getAgencyCredentialsByTenantAndRole(tenantId: string, role: string): Promise<SelectAgencyCredentials[]> {
+  async getAgencyCredentialsByTenantAndRole(tenantId: string, role: SelectAgencyCredentials['role']): Promise<SelectAgencyCredentials[]> {
     return await db.select()
       .from(agencyCredentials)
       .where(and(
@@ -2124,7 +2124,7 @@ export class DatabaseStorage implements IStorage {
       .where(and(...conditions));
   }
 
-  async getSmsBlockedNumbers(tenantId: string): Promise<{ phoneNumber: string; reason: string; errorCode?: string | null; errorMessage?: string | null; failureCount: number; firstFailedAt: Date; lastFailedAt: Date }[]> {
+  async getSmsBlockedNumbers(tenantId: string): Promise<{ phoneNumber: string; reason: string; errorCode?: string | null; errorMessage?: string | null; failureCount: number | null; firstFailedAt: Date | null; lastFailedAt: Date | null }[]> {
     const results = await db
       .select({
         phoneNumber: smsBlockedNumbers.phoneNumber,


### PR DESCRIPTION
### Motivation

- Align TypeScript types with actual runtime/database shapes to eliminate compiler errors without changing UI or business logic.
- Add defensive null/undefined checks where code assumed non-null values returned from DB or external APIs.

### Description

- Narrowed and annotated types in the email builder and dashboard data fetching to match the discriminated unions and arrays used at runtime (`client/src/components/email-builder.tsx`, `client/src/pages/admin-dashboard.tsx`).
- Removed invalid UI pagination setter usages that referenced a nonexistent `setDisplayLimit` to keep filter/search behavior unchanged (`client/src/pages/accounts.tsx`).
- Added safe truthiness and null checks for payment schedules, sequence folder IDs, DB row counts, and arrangement handling to avoid runtime type mismatches (`client/src/pages/payments.tsx`, `server/eventService.ts`, `server/migrations.ts`, `server/routes.ts`).
- Propagated actual authenticated user shape fields (`role`, `voipAccess`, `credentialId`) from middleware and tightened storage API types for credential roles and SMS-blocked-number fields to match DB shapes (`server/authMiddleware.ts`, `server/storage.ts`).
- Fixed Authorize.Net request shape by using the correct CVV property name and removed unsupported response/insert properties from API responses to align with DB schema (`server/routes.ts`).
- Extended the `check` npm script to run TypeScript checks for server/web, `api`, and `mobile-agency-app` projects (`package.json`).

### Testing

- Ran full TypeScript check with `npm run check` which runs `tsc` across the repo and project tsconfigs, and it completed successfully. ✅
- Executed unit tests with `npm test`; all tests passed (`15` tests, `0` failures). ✅
- Ran `npx tsc --noEmit` and incremental type checks during the fix cycle to verify compiler errors were resolved. ✅
- Started production build with `npm run build` (Vite/esbuild transform began); final bundle completion could not be independently confirmed due to an environment warning and interrupted output. ⚠️

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7c8b483f8c832a8ad3f8599b3ebbea)