### PR TITLE
Add branded downloadable PDF invoices

### DIFF
--- a/client/src/pages/billing.tsx
+++ b/client/src/pages/billing.tsx
@@ -1834,11 +1834,14 @@ export default function Billing() {
                                 <Button
                                   variant="outline"
                                   size="sm"
+                                  asChild
                                   data-testid={`button-download-${invoice.invoiceNumber}`}
                                   className="rounded-xl border border-white/20 bg-transparent px-4 py-2 text-xs font-semibold text-blue-100 transition hover:bg-white/10 hover:text-white"
                                 >
-                                  <Download className="mr-2 h-4 w-4" />
-                                  Download
+                                  <a href={`/api/billing/invoices/${invoice.id}/pdf`} download={`Chain-Invoice-${invoice.invoiceNumber}.pdf`}>
+                                    <Download className="mr-2 h-4 w-4" />
+                                    PDF
+                                  </a>
                                 </Button>
                               </div>
                             </div>

--- a/server/emailService.ts
+++ b/server/emailService.ts
@@ -28,6 +28,7 @@ export interface EmailOptions {
   tenantId?: string; // For usage tracking
   consumerId?: string; // For conversation tracking - link email to consumer
   useBroadcastStream?: boolean; // Use broadcast stream for marketing/bulk emails (automations, campaigns)
+  attachments?: Array<{ name: string; content: Buffer; contentType: string }>;
 }
 
 // Default sender address - verified in Postmark
@@ -90,6 +91,13 @@ export class EmailService {
         Metadata: normalizedMetadata,
         TrackOpens: true, // Enable open tracking
       };
+      if (options.attachments?.length) {
+        emailPayload.Attachments = options.attachments.map(attachment => ({
+          Name: attachment.name,
+          Content: attachment.content.toString('base64'),
+          ContentType: attachment.contentType,
+        }));
+      }
       
       // Use broadcast stream for marketing/bulk emails (automations, campaigns)
       emailPayload.MessageStream = options.useBroadcastStream

--- a/server/invoicePdf.ts
+++ b/server/invoicePdf.ts
@@ -1,0 +1,103 @@
+import fs from "fs";
+import path from "path";
+
+export interface InvoicePdfData {
+  invoiceNumber: string;
+  tenantName: string;
+  status: string;
+  periodStart: Date;
+  periodEnd: Date;
+  dueDate: Date;
+  totalAmountCents: number;
+  lineItems?: Array<{ description: string; amountCents: number; quantity?: number; unitLabel?: string }> | null;
+}
+
+const money = (cents: number) => new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(cents / 100);
+const date = (value: Date) => value.toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" });
+const pdfText = (value: unknown) => String(value ?? "").replace(/[^\x20-\x7e]/g, " ").replace(/([\\()])/g, "\\$1");
+const text = (x: number, y: number, size: number, value: unknown, font = "F1", color = "0.10 0.16 0.27") =>
+  `BT /${font} ${size} Tf ${color} rg 1 0 0 1 ${x} ${y} Tm (${pdfText(value)}) Tj ET\n`;
+
+function logoBuffer(): Buffer {
+  const candidates = [
+    path.resolve(process.cwd(), "client/src/assets/chain-logo.png"),
+    path.resolve(process.cwd(), "dist/chain-logo.png"),
+  ];
+  const logoPath = candidates.find(fs.existsSync);
+  if (!logoPath) throw new Error("Chain logo asset was not found");
+  return fs.readFileSync(logoPath);
+}
+
+/** Creates a dependency-free, branded PDF suitable for email attachment or download. */
+export function generateInvoicePdf(invoice: InvoicePdfData): Buffer {
+  const logo = logoBuffer(); // The checked-in logo is JPEG encoded despite its legacy .png extension.
+  if (logo[0] !== 0xff || logo[1] !== 0xd8) throw new Error("Chain logo must be JPEG encoded");
+
+  const items = invoice.lineItems?.length
+    ? invoice.lineItems
+    : [{ description: "Chain platform services", amountCents: invoice.totalAmountCents }];
+  const pages = Array.from({ length: Math.max(1, Math.ceil(items.length / 16)) }, (_, i) => items.slice(i * 16, (i + 1) * 16));
+  const firstDynamicObject = 6;
+  const pageIds = pages.map((_, i) => firstDynamicObject + i * 2 + 1);
+  const objects: Buffer[] = [];
+  const add = (value: string | Buffer) => objects.push(Buffer.isBuffer(value) ? value : Buffer.from(value, "binary"));
+
+  add("<< /Type /Catalog /Pages 2 0 R >>");
+  add(`<< /Type /Pages /Count ${pages.length} /Kids [${pageIds.map(id => `${id} 0 R`).join(" ")}] >>`);
+  add("<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>");
+  add("<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold >>");
+  add(Buffer.concat([Buffer.from(`<< /Type /XObject /Subtype /Image /Width 512 /Height 512 /ColorSpace /DeviceRGB /BitsPerComponent 8 /Filter /DCTDecode /Length ${logo.length} >>\nstream\n`, "binary"), logo, Buffer.from("\nendstream", "binary")]));
+
+  pages.forEach((pageItems, pageIndex) => {
+    let stream = "0.04 0.10 0.18 rg 0 0 612 792 re f\n";
+    stream += "q 92 0 0 92 46 654 cm /Logo Do Q\n";
+    stream += text(154, 716, 24, "CHAIN", "F2", "0.18 0.78 0.86");
+    stream += text(154, 692, 10, "SOFTWARE GROUP", "F2", "0.45 0.65 0.74");
+    stream += text(420, 714, 25, "INVOICE", "F2", "1 1 1");
+    stream += text(420, 690, 10, `#${invoice.invoiceNumber}`, "F1", "0.72 0.82 0.88");
+    stream += "0.10 0.20 0.31 rg 40 620 532 2 re f\n";
+    stream += text(46, 590, 9, "BILL TO", "F2", "0.35 0.76 0.83");
+    stream += text(46, 570, 14, invoice.tenantName, "F2", "1 1 1");
+    stream += text(330, 590, 9, "BILLING PERIOD", "F2", "0.35 0.76 0.83");
+    stream += text(330, 570, 11, `${date(invoice.periodStart)} - ${date(invoice.periodEnd)}`, "F1", "1 1 1");
+    stream += text(46, 535, 9, "DUE DATE", "F2", "0.35 0.76 0.83");
+    stream += text(46, 516, 11, date(invoice.dueDate), "F1", "1 1 1");
+    stream += text(330, 535, 9, "STATUS", "F2", "0.35 0.76 0.83");
+    stream += text(330, 516, 11, invoice.status.toUpperCase(), "F2", "1 1 1");
+    stream += "0.08 0.19 0.30 rg 40 475 532 30 re f\n";
+    stream += text(52, 486, 9, "DESCRIPTION", "F2", "0.72 0.82 0.88");
+    stream += text(500, 486, 9, "AMOUNT", "F2", "0.72 0.82 0.88");
+    let y = 450;
+    for (const item of pageItems) {
+      const detail = item.quantity != null && item.unitLabel ? ` (${item.quantity} ${item.unitLabel})` : "";
+      const description = `${item.description}${detail}`.slice(0, 72);
+      stream += text(52, y, 10, description, "F1", "0.91 0.95 0.97");
+      stream += text(500, y, 10, money(item.amountCents), "F2", "0.91 0.95 0.97");
+      stream += "0.12 0.22 0.32 RG 46 " + (y - 10) + " m 566 " + (y - 10) + " l S\n";
+      y -= 25;
+    }
+    if (pageIndex === pages.length - 1) {
+      stream += text(400, 75, 12, "TOTAL DUE", "F2", "0.72 0.82 0.88");
+      stream += text(492, 72, 18, money(invoice.totalAmountCents), "F2", "0.18 0.78 0.86");
+    }
+    stream += text(46, 35, 8, `Chain Software Group  |  Page ${pageIndex + 1} of ${pages.length}`, "F1", "0.45 0.58 0.66");
+    const content = Buffer.from(stream, "binary");
+    const contentId = firstDynamicObject + pageIndex * 2;
+    add(Buffer.concat([Buffer.from(`<< /Length ${content.length} >>\nstream\n`, "binary"), content, Buffer.from("endstream", "binary")]));
+    add(`<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 3 0 R /F2 4 0 R >> /XObject << /Logo 5 0 R >> >> /Contents ${contentId} 0 R >>`);
+  });
+
+  const chunks: Buffer[] = [Buffer.from("%PDF-1.4\n%\xff\xff\xff\xff\n", "binary")];
+  const offsets = [0];
+  let offset = chunks[0].length;
+  objects.forEach((object, index) => {
+    offsets.push(offset);
+    const wrapped = Buffer.concat([Buffer.from(`${index + 1} 0 obj\n`, "binary"), object, Buffer.from("\nendobj\n", "binary")]);
+    chunks.push(wrapped);
+    offset += wrapped.length;
+  });
+  const xrefOffset = offset;
+  const xref = `xref\n0 ${objects.length + 1}\n0000000000 65535 f \n${offsets.slice(1).map(n => `${String(n).padStart(10, "0")} 00000 n `).join("\n")}\ntrailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\nstartxref\n${xrefOffset}\n%%EOF\n`;
+  chunks.push(Buffer.from(xref, "binary"));
+  return Buffer.concat(chunks);
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -77,6 +77,7 @@ import {
   type MessagingPlanId,
 } from "@shared/billing-plans";
 import { computeALaCarteBill, computeSubscriptionBill, generateInvoiceNumber } from "./billing";
+import { generateInvoicePdf } from "./invoicePdf";
 import { canActivateUser } from "@shared/enterpriseCapacity";
 
 import { listConsumers, paginateConsumers, updateConsumer, deleteConsumers, ConsumerNotFoundError } from "@shared/server/consumers";
@@ -1618,11 +1619,26 @@ async function sendChainInvoiceEmail(params: {
         <p>Log in to your billing dashboard to view details and make a payment.</p>
       </div>
     `;
+    const invoicePdf = generateInvoicePdf({
+      invoiceNumber: params.invoiceNumber,
+      tenantName: params.tenantName || 'Customer',
+      status: 'pending',
+      periodStart: params.periodStart,
+      periodEnd: params.periodEnd,
+      dueDate: params.dueDate,
+      totalAmountCents: Math.round(params.totalBill * 100),
+      lineItems: params.lineItems,
+    });
     await emailService.sendEmail({
       to: params.tenantEmail,
       subject: `Chain Invoice ${params.invoiceNumber} - $${params.totalBill.toFixed(2)} Due ${params.dueDate.toLocaleDateString()}`,
       html: emailHtml,
       tenantId: params.tenantId,
+      attachments: [{
+        name: `Chain-Invoice-${params.invoiceNumber}.pdf`,
+        content: invoicePdf,
+        contentType: 'application/pdf',
+      }],
     });
     console.log(`📧 Invoice email sent to ${params.tenantEmail} (${params.invoiceNumber})`);
   } catch (emailErr) {
@@ -19313,6 +19329,36 @@ export async function registerRoutes(app: Express): Promise<Server> {
     } catch (error) {
       console.error("Error fetching invoices:", error);
       res.status(500).json({ message: "Failed to fetch invoices" });
+    }
+  });
+
+  app.get('/api/billing/invoices/:invoiceId/pdf', authenticateUser, requireOwner, async (req: any, res) => {
+    try {
+      const tenantId = req.user.tenantId;
+      if (!tenantId) return res.status(403).json({ message: "No tenant access" });
+
+      const [result] = await db
+        .select({ invoice: invoices, tenantName: tenants.name })
+        .from(invoices)
+        .innerJoin(tenants, eq(invoices.tenantId, tenants.id))
+        .where(and(eq(invoices.id, req.params.invoiceId), eq(invoices.tenantId, tenantId)))
+        .limit(1);
+      if (!result) return res.status(404).json({ message: "Invoice not found" });
+
+      const pdf = generateInvoicePdf({
+        ...result.invoice,
+        tenantName: result.tenantName,
+        status: result.invoice.status || 'pending',
+        lineItems: result.invoice.lineItems,
+      });
+      const safeNumber = result.invoice.invoiceNumber.replace(/[^a-zA-Z0-9_-]/g, '_');
+      res.setHeader('Content-Type', 'application/pdf');
+      res.setHeader('Content-Disposition', `attachment; filename="Chain-Invoice-${safeNumber}.pdf"`);
+      res.setHeader('Content-Length', pdf.length.toString());
+      res.send(pdf);
+    } catch (error) {
+      console.error("Error generating invoice PDF:", error);
+      res.status(500).json({ message: "Failed to generate invoice PDF" });
     }
   });
 


### PR DESCRIPTION
### Motivation
- Tenants need downloadable, branded PDF versions of invoices (with the Chain logo) attached to email and available for direct download.

### Description
- Add a dependency-free PDF generator in `server/invoicePdf.ts` that renders Chain-branded invoices (logo, tenant, billing period, line items, totals and multi-page support) and returns a `Buffer` via `generateInvoicePdf`.
- Extend `EmailOptions` and `EmailService.sendEmail` to accept `attachments` and map them to Postmark-compatible `Attachments`, then attach the generated PDF to invoice emails in the shared `sendChainInvoiceEmail` flow in `server/routes.ts`.
- Add an authenticated, tenant-scoped download endpoint `GET /api/billing/invoices/:invoiceId/pdf` that verifies tenant ownership and streams the generated PDF with a safe filename.
- Wire the billing UI download button to the endpoint by updating `client/src/pages/billing.tsx` so tenants can click a `PDF` download that returns `Chain-Invoice-<invoiceNumber>.pdf`.

### Testing
- Ran TypeScript compile check with `npm run check` (no errors reported). 
- Ran unit tests with `npm test` and all tests passed (`15` tests, `0` failures).
- Manually generated a sample PDF using `npx tsx` invoking `generateInvoicePdf` and verified a valid `%PDF-1.4` header and produced file bytes. 
- Noted environment limitations: `pdfinfo` is not installed here and `npm install pdf-lib` failed due to registry access (implemented generator without external PDF dependency).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7c9b1ed54c832aaaa31796062cafaa)