### PR TITLE
Require tenant-specific Twilio configuration (remove global SMS fallback)

### DIFF
--- a/client/src/pages/__tests__/enterprise-readiness.test.ts
+++ b/client/src/pages/__tests__/enterprise-readiness.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import test from 'node:test';
 import { activeSeatUsage, canActivateUser, processCursorBatches } from '../../../../shared/enterpriseCapacity';
 import { buildConsumersPageUrl } from '../../hooks/use-paginated-consumers';
@@ -68,4 +69,14 @@ test('consumer list requests always opt into the paginated response contract', (
   assert.equal(parsed.searchParams.get('cursor'), '00000000-0000-0000-0000-000000000100');
   assert.equal(parsed.searchParams.get('search'), 'Jane@example.com');
   assert.equal(parsed.searchParams.get('registration'), 'registered');
+});
+
+test('SMS sending fails closed instead of using global Twilio configuration', () => {
+  const smsServiceSource = readFileSync(
+    new URL('../../../../server/smsService.ts', import.meta.url),
+    'utf8',
+  );
+
+  assert.doesNotMatch(smsServiceSource, /process\.env\.TWILIO_(?:ACCOUNT_SID|AUTH_TOKEN|PHONE_NUMBER)/);
+  assert.doesNotMatch(smsServiceSource, /clients\.get\(['"]default['"]\)/);
 });

--- a/docs/MUNICIPALITY_TENANT_EXPERIENCE.md
+++ b/docs/MUNICIPALITY_TENANT_EXPERIENCE.md
@@ -18,7 +18,7 @@ Accounts, Payments, Billing, payment plans, merchant settings, payment arrangeme
 
 The owner is presented as the **Primary Administrator**. Municipal user roles are mapped onto the existing permission-compatible roles: Administrator (`manager`), Communications Staff (`agent`), Viewer, and Contact Importer (`uploader`). Password reset initiation emails a one-hour reset link; passwords remain hashed and are never returned to administrators.
 
-Each user email is used for account identification, administrative display, and password-reset delivery. It does not have to belong to a particular municipal domain. SMS is available only after the municipality saves its own Twilio account SID, auth token, and sending number; municipal SMS never falls back to the platform or another tenant's Twilio configuration.
+Each user email is used for account identification, administrative display, and password-reset delivery. It does not have to belong to a particular municipal domain. SMS is available only after the tenant saves its own Twilio account SID, auth token, and sending number. This isolation applies to every company and tenant: SMS never falls back to the platform or another tenant's Twilio configuration.
 
 ## Public experience
 

--- a/server/smsService.ts
+++ b/server/smsService.ts
@@ -74,24 +74,10 @@ class SmsService {
   }
 
   constructor() {
-    this.initializeDefaultTwilio();
     // Start processing queue every 10 seconds
     setInterval(() => this.processQueue(), 10000);
     // Reset rate limit counters every minute
     setInterval(() => this.resetCounters(), 60000);
-  }
-
-  private initializeDefaultTwilio() {
-    // Initialize with default credentials if available (for backwards compatibility)
-    const accountSid = process.env.TWILIO_ACCOUNT_SID;
-    const authToken = process.env.TWILIO_AUTH_TOKEN;
-
-    if (accountSid && authToken) {
-      this.clients.set('default', twilio(accountSid, authToken));
-      console.log('Twilio SMS service initialized');
-    } else {
-      console.warn('Twilio credentials not found. SMS service will be disabled.');
-    }
   }
 
   private async getTwilioClient(tenantId: string): Promise<twilio.Twilio | null> {
@@ -113,12 +99,9 @@ class SmsService {
       console.error(`Error getting Twilio credentials for tenant ${tenantId}:`, error);
     }
 
-    // Municipalities must never send through another tenant's/global Twilio account.
-    const tenant = await storage.getTenant(tenantId);
-    if (tenant?.businessType === 'municipality') return null;
-
-    // Legacy non-municipal tenants may use the platform fallback.
-    return this.clients.get('default') || null;
+    // Every tenant must supply its own credentials. A platform/global client must
+    // never be used because it could send from phone numbers owned by somebody else.
+    return null;
   }
 
   private async getTwilioPhoneNumber(tenantId: string): Promise<string | null> {
@@ -133,11 +116,9 @@ class SmsService {
       console.error(`Error getting Twilio phone number for tenant ${tenantId}:`, error);
     }
 
-    const tenant = await storage.getTenant(tenantId);
-    if (tenant?.businessType === 'municipality') return null;
-
-    // Legacy non-municipal tenants may use the platform fallback.
-    return process.env.TWILIO_PHONE_NUMBER || null;
+    // Every tenant must supply its own sending number. There is intentionally no
+    // environment/global fallback, so missing tenant configuration fails closed.
+    return null;
   }
 
   private resetCounters() {


### PR DESCRIPTION
### Motivation
- Prevent any tenant or company from sending SMS using global or another tenant's Twilio credentials or phone number by default. 
- Ensure SMS sending fails closed when a tenant has not configured its own Twilio account and sending number.

### Description
- Remove the platform/global Twilio client and environment fallbacks from `server/smsService.ts` so there is no `default` client or `process.env.TWILIO_*` fallback. 
- Make `getTwilioClient` return `null` when a tenant lacks its own `twilioAccountSid`/`twilioAuthToken`, and make `getTwilioPhoneNumber` return `null` when a tenant lacks a configured sending number. 
- Remove the `initializeDefaultTwilio` call and function so the constructor no longer seeds a global client. 
- Add a regression test in `client/src/pages/__tests__/enterprise-readiness.test.ts` that asserts the server source no longer references `process.env.TWILIO_*` or a `clients.get('default')` fallback. 
- Update `docs/MUNICIPALITY_TENANT_EXPERIENCE.md` to clarify that SMS isolation (no fallback) applies to every company and tenant.

### Testing
- Ran `npm test`, all unit tests passed (`17` tests, 0 failures). 
- Ran `npm run check` (TypeScript `tsc` checks) and it succeeded with no type errors. 
- Ran `git diff --check` to validate no whitespace or patch issues and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a825da9b780832a973f84a51c197c86)