### PR TITLE
Make inbound email replies private per-user and add inbox filters + routing/storage updates

### DIFF
--- a/client/src/components/admin-layout.tsx
+++ b/client/src/components/admin-layout.tsx
@@ -147,6 +147,7 @@ export default function AdminLayout({ children }: AdminLayoutProps) {
     { name: "Email Campaigns", href: buildNavHref("/communications?tab=campaigns"), icon: "fas fa-envelope" },
     { name: "SMS Campaigns", href: buildNavHref("/communications?tab=campaigns"), icon: "fas fa-comment-alt" },
     { name: "Templates", href: buildNavHref("/communications?tab=templates"), icon: "fas fa-file-alt" },
+    { name: "Inbox", href: buildNavHref("/email-inbox"), icon: "fas fa-inbox" },
     { name: "Lists / Segments", href: buildNavHref("/consumers"), icon: "fas fa-list" },
     { name: "Communications History", href: buildNavHref("/communications?tab=overview"), icon: "fas fa-history" },
     { name: "Reports / Analytics", href: buildNavHref("/communications?tab=overview"), icon: "fas fa-chart-line" },

--- a/client/src/pages/email-inbox.tsx
+++ b/client/src/pages/email-inbox.tsx
@@ -52,6 +52,7 @@ interface SmsReply {
 export default function CommunicationsInbox() {
   const { toast } = useToast();
   const [activeTab, setActiveTab] = useState<'email' | 'sms'>('email');
+  const [emailFilter, setEmailFilter] = useState<'all' | 'unread' | 'read'>('all');
   const [selectedEmail, setSelectedEmail] = useState<EmailReply | null>(null);
   const [selectedSms, setSelectedSms] = useState<SmsReply | null>(null);
   const [showEmailReplyDialog, setShowEmailReplyDialog] = useState(false);
@@ -270,6 +271,11 @@ export default function CommunicationsInbox() {
   const unreadEmailCount = emails.filter(email => !email.isRead).length;
   const unreadSmsCount = smsMessages.filter(sms => !sms.isRead).length;
   const totalUnreadCount = unreadEmailCount + unreadSmsCount;
+  const filteredEmails = emails.filter(email => {
+    if (emailFilter === 'unread') return !email.isRead;
+    if (emailFilter === 'read') return email.isRead;
+    return true;
+  });
 
   const glassPanelClass = "rounded-3xl border border-white/15 bg-[#0b1733]/80 text-blue-50 shadow-xl shadow-blue-900/20 backdrop-blur";
 
@@ -329,6 +335,23 @@ export default function CommunicationsInbox() {
                   <CardDescription className="text-xs">
                     {emails.length} total email{emails.length !== 1 ? 's' : ''}
                   </CardDescription>
+                  <div className="flex gap-2 pt-2" role="group" aria-label="Filter emails by read status">
+                    {(['all', 'unread', 'read'] as const).map(filter => (
+                      <Button
+                        key={filter}
+                        type="button"
+                        size="sm"
+                        variant={emailFilter === filter ? 'default' : 'outline'}
+                        onClick={() => setEmailFilter(filter)}
+                        data-testid={`filter-emails-${filter}`}
+                        aria-pressed={emailFilter === filter}
+                        className="capitalize"
+                      >
+                        {filter}
+                        {filter === 'unread' && unreadEmailCount > 0 ? ` (${unreadEmailCount})` : ''}
+                      </Button>
+                    ))}
+                  </div>
                 </CardHeader>
                 <CardContent className="p-0">
                   {isLoadingEmails ? (
@@ -358,9 +381,15 @@ export default function CommunicationsInbox() {
                       <p className="text-sm font-medium text-slate-900 dark:text-white">No emails yet</p>
                       <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">Inbound emails will appear here</p>
                     </div>
+                  ) : filteredEmails.length === 0 ? (
+                    <div className="p-12 text-center" data-testid="text-no-filtered-emails">
+                      <MailOpen className="w-12 h-12 mx-auto mb-3 text-slate-400 dark:text-slate-500" />
+                      <p className="text-sm font-medium text-slate-900 dark:text-white">No {emailFilter} emails</p>
+                      <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">Choose another filter to view messages</p>
+                    </div>
                   ) : (
                     <div className="divide-y divide-slate-200 dark:divide-slate-700">
-                      {emails.map((email) => (
+                      {filteredEmails.map((email) => (
                         <button
                           key={email.id}
                           onClick={() => handleEmailClick(email)}

--- a/server/migrations.ts
+++ b/server/migrations.ts
@@ -1874,6 +1874,15 @@ export async function runMigrations() {
       console.log(`  ⚠ campaign_log_items table (already exists or error): ${err.message}`);
     }
 
+    // Keep inbound email replies private to the user who initiated the thread.
+    try {
+      await client.query(`ALTER TABLE email_replies ADD COLUMN IF NOT EXISTS assigned_user_id text`);
+      await client.query(`CREATE INDEX IF NOT EXISTS idx_email_replies_user_inbox ON email_replies(tenant_id, assigned_user_id, received_at DESC)`);
+      console.log('  ✓ email_replies per-user inbox assignment');
+    } catch (err: any) {
+      console.log(`  ⚠ email_replies per-user inbox assignment: ${err.message}`);
+    }
+
     // Add Stripe payment intent ID to invoices
     try {
       await client.query(`ALTER TABLE invoices ADD COLUMN IF NOT EXISTS stripe_payment_intent_id text`);

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1145,6 +1145,7 @@ async function processSmartArrangementSave(
     tenantWithSettings: any;
     tenantBranding: any;
     tenant: Tenant;
+    senderUserId: string;
   }) {
     const {
       campaignId,
@@ -1155,6 +1156,7 @@ async function processSmartArrangementSave(
       tenantWithSettings,
       tenantBranding,
       tenant,
+      senderUserId,
     } = options;
 
     // Deduplicate by email address, keeping the most recent consumer record for each email
@@ -1234,6 +1236,7 @@ async function processSmartArrangementSave(
         tenantId,
         consumerId: consumer.id,
         templateId: template.id,
+        senderUserId,
       };
 
       if (consumerAccount?.accountNumber) {
@@ -2756,7 +2759,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         return res.status(403).json({ message: "No tenant access" });
       }
 
-      const conversation = await storage.getConsumerConversation(req.params.id, tenantId);
+      const conversation = await storage.getConsumerConversation(req.params.id, tenantId, req.user.id);
       
       // Combine and sort all messages chronologically
       const allMessages = [
@@ -4380,6 +4383,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
               tenantWithSettings: tenantContext.tenantWithSettings,
               tenantBranding: tenantContext.tenantBranding,
               tenant: tenantContext.tenant,
+              senderUserId: req.user.id,
             });
 
             const fullTemplate = (template.subject || '') + ' ' + (template.html || '');
@@ -4579,6 +4583,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         metadata: {
           type: 'individual',
           tenantId: tenantId,
+          senderUserId: req.user.id,
         },
         tenantId: tenantId, // Track email usage by tenant
       });
@@ -4719,7 +4724,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         return res.status(403).json({ message: "No tenant access" });
       }
 
-      const replies = await storage.getEmailRepliesByTenant(tenantId);
+      const replies = await storage.getEmailRepliesByUser(tenantId, req.user.id);
       res.json(replies);
     } catch (error) {
       console.error("Error fetching email replies:", error);
@@ -4734,7 +4739,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         return res.status(403).json({ message: "No tenant access" });
       }
 
-      const reply = await storage.getEmailReplyById(req.params.id, tenantId);
+      const reply = await storage.getEmailReplyById(req.params.id, tenantId, req.user.id);
       if (!reply) {
         return res.status(404).json({ message: "Email reply not found" });
       }
@@ -4753,7 +4758,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         return res.status(403).json({ message: "No tenant access" });
       }
 
-      const reply = await storage.markEmailReplyAsRead(req.params.id, tenantId);
+      const reply = await storage.markEmailReplyAsRead(req.params.id, tenantId, req.user.id);
       res.json(reply);
     } catch (error) {
       console.error("Error marking email reply as read:", error);
@@ -4770,12 +4775,12 @@ export async function registerRoutes(app: Express): Promise<Server> {
       }
 
       const { id } = req.params;
-      const reply = await storage.getEmailReplyById(id, tenantId);
+      const reply = await storage.getEmailReplyById(id, tenantId, req.user.id);
       if (!reply) {
         return res.status(404).json({ message: "Email reply not found" });
       }
 
-      await storage.deleteEmailReply(id, tenantId);
+      await storage.deleteEmailReply(id, tenantId, req.user.id);
       res.json({ message: "Email reply deleted successfully" });
     } catch (error) {
       console.error("Error deleting email reply:", error);
@@ -4799,7 +4804,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       }
 
       // Get the original email
-      const originalEmail = await storage.getEmailReplyById(id, tenantId);
+      const originalEmail = await storage.getEmailReplyById(id, tenantId, req.user.id);
       if (!originalEmail) {
         return res.status(404).json({ message: "Email reply not found" });
       }
@@ -4835,6 +4840,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
           type: 'reply-response',
           tenantId: tenantId,
           originalEmailId: id,
+          senderUserId: req.user.id,
         },
         tenantId: tenantId,
         consumerId: originalEmail.consumerId || undefined, // Link reply to consumer for conversation tracking
@@ -23590,6 +23596,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       // Find the original email by looking at In-Reply-To header to determine which tenant this belongs to
       let matchedTenant = null;
       let inReplyToMessageId = null;
+      let assignedUserId: string | null = null;
       
       // Extract In-Reply-To header from Headers array
       if (Headers && Array.isArray(Headers)) {
@@ -23603,12 +23610,16 @@ export async function registerRoutes(app: Express): Promise<Server> {
           
           // Look up the original email in emailLogs to find the tenant
           const [originalEmail] = await db
-            .select({ tenantId: emailLogs.tenantId })
+            .select({ tenantId: emailLogs.tenantId, metadata: emailLogs.metadata })
             .from(emailLogs)
             .where(eq(emailLogs.messageId, inReplyToMessageId))
             .limit(1);
           
           if (originalEmail) {
+            const originalMetadata = originalEmail.metadata as Record<string, unknown> | null;
+            assignedUserId = typeof originalMetadata?.senderUserId === 'string'
+              ? originalMetadata.senderUserId
+              : null;
             const tenant = await storage.getTenant(originalEmail.tenantId);
             if (tenant) {
               matchedTenant = tenant;
@@ -23660,6 +23671,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
           textBody: TextBody || '',
           htmlBody: HtmlBody || '',
           messageId: MessageID,
+          inReplyToMessageId,
+          assignedUserId,
           isRead: false,
         });
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -303,10 +303,10 @@ export interface IStorage {
   
   // Email reply operations
   createEmailReply(reply: InsertEmailReply): Promise<EmailReply>;
-  getEmailRepliesByTenant(tenantId: string): Promise<(EmailReply & { consumerName: string; consumerEmail: string })[]>;
-  getEmailReplyById(id: string, tenantId: string): Promise<EmailReply | undefined>;
-  markEmailReplyAsRead(id: string, tenantId: string): Promise<EmailReply>;
-  deleteEmailReply(id: string, tenantId: string): Promise<void>;
+  getEmailRepliesByUser(tenantId: string, userId: string): Promise<(EmailReply & { consumerName: string; consumerEmail: string })[]>;
+  getEmailReplyById(id: string, tenantId: string, userId: string): Promise<EmailReply | undefined>;
+  markEmailReplyAsRead(id: string, tenantId: string, userId: string): Promise<EmailReply>;
+  deleteEmailReply(id: string, tenantId: string, userId: string): Promise<void>;
   
   // SMS reply operations
   createSmsReply(reply: InsertSmsReply): Promise<SmsReply>;
@@ -316,7 +316,7 @@ export interface IStorage {
   deleteSmsReply(id: string, tenantId: string): Promise<void>;
   
   // Consumer conversation operations
-  getConsumerConversation(consumerId: string, tenantId: string): Promise<{
+  getConsumerConversation(consumerId: string, tenantId: string, userId: string): Promise<{
     emails: { sent: any[]; received: any[] };
     sms: { sent: any[]; received: any[] };
   }>;
@@ -1676,12 +1676,12 @@ export class DatabaseStorage implements IStorage {
     return newReply;
   }
 
-  async getEmailRepliesByTenant(tenantId: string): Promise<(EmailReply & { consumerName: string; consumerEmail: string })[]> {
+  async getEmailRepliesByUser(tenantId: string, userId: string): Promise<(EmailReply & { consumerName: string; consumerEmail: string })[]> {
     const result = await db
       .select()
       .from(emailReplies)
       .leftJoin(consumers, eq(emailReplies.consumerId, consumers.id))
-      .where(eq(emailReplies.tenantId, tenantId))
+      .where(and(eq(emailReplies.tenantId, tenantId), eq(emailReplies.assignedUserId, userId)))
       .orderBy(desc(emailReplies.receivedAt));
 
     return result.map(row => ({
@@ -1691,26 +1691,26 @@ export class DatabaseStorage implements IStorage {
     }));
   }
 
-  async getEmailReplyById(id: string, tenantId: string): Promise<EmailReply | undefined> {
+  async getEmailReplyById(id: string, tenantId: string, userId: string): Promise<EmailReply | undefined> {
     const [reply] = await db
       .select()
       .from(emailReplies)
-      .where(and(eq(emailReplies.id, id), eq(emailReplies.tenantId, tenantId)));
+      .where(and(eq(emailReplies.id, id), eq(emailReplies.tenantId, tenantId), eq(emailReplies.assignedUserId, userId)));
     return reply;
   }
 
-  async markEmailReplyAsRead(id: string, tenantId: string): Promise<EmailReply> {
+  async markEmailReplyAsRead(id: string, tenantId: string, userId: string): Promise<EmailReply> {
     const [updatedReply] = await db
       .update(emailReplies)
       .set({ isRead: true, readAt: new Date() })
-      .where(and(eq(emailReplies.id, id), eq(emailReplies.tenantId, tenantId)))
+      .where(and(eq(emailReplies.id, id), eq(emailReplies.tenantId, tenantId), eq(emailReplies.assignedUserId, userId)))
       .returning();
     return updatedReply;
   }
 
-  async deleteEmailReply(id: string, tenantId: string): Promise<void> {
+  async deleteEmailReply(id: string, tenantId: string, userId: string): Promise<void> {
     await db.delete(emailReplies)
-      .where(and(eq(emailReplies.id, id), eq(emailReplies.tenantId, tenantId)));
+      .where(and(eq(emailReplies.id, id), eq(emailReplies.tenantId, tenantId), eq(emailReplies.assignedUserId, userId)));
   }
 
   // SMS reply operations
@@ -4480,7 +4480,7 @@ export class DatabaseStorage implements IStorage {
     return entry;
   }
 
-  async getConsumerConversation(consumerId: string, tenantId: string): Promise<{
+  async getConsumerConversation(consumerId: string, tenantId: string, userId: string): Promise<{
     emails: { sent: any[]; received: any[] };
     sms: { sent: any[]; received: any[] };
   }> {
@@ -4503,7 +4503,8 @@ export class DatabaseStorage implements IStorage {
       .where(
         and(
           eq(emailLogs.tenantId, tenantId),
-          or(...emailConditions)
+          or(...emailConditions),
+          sql`${emailLogs.metadata}->>'senderUserId' = ${userId}`
         )
       )
       .orderBy(desc(emailLogs.sentAt));
@@ -4515,7 +4516,8 @@ export class DatabaseStorage implements IStorage {
       .where(
         and(
           eq(emailReplies.tenantId, tenantId),
-          eq(emailReplies.consumerId, consumerId)
+          eq(emailReplies.consumerId, consumerId),
+          eq(emailReplies.assignedUserId, userId)
         )
       )
       .orderBy(desc(emailReplies.receivedAt));

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -373,6 +373,7 @@ export const emailReplies = pgTable("email_replies", {
   htmlBody: text("html_body"),
   messageId: text("message_id"), // Postmark inbound message ID
   inReplyToMessageId: text("in_reply_to_message_id"), // Original message ID if this is a reply
+  assignedUserId: text("assigned_user_id"), // Tenant user who sent the original email; inboxes are private per user
   isRead: boolean("is_read").default(false),
   readAt: timestamp("read_at"),
   readBy: text("read_by"), // Email/username of person who read it


### PR DESCRIPTION
### Motivation
- Prevent cross-user visibility of inbound email replies by assigning replies to the user who initiated the thread and exposing only that user's inbox. 
- Surface the assigned-user behavior in the UI by adding per-user filters for read/unread messages and ensuring municipality nav includes the Inbox link. 

### Description
- Database migration and schema updates add `assigned_user_id` to `email_replies` and create an index for per-user tenant inbox queries, and the schema table `email_replies` was updated to include `assignedUserId`. 
- Routes and email sending/campaign code now record `senderUserId` into email metadata and restrict inbox endpoints to the authenticated `req.user.id`, and inbound Postmark processing extracts the original sender from `email_logs.metadata` to populate `assignedUserId` when storing replies. 
- Storage interface and `DatabaseStorage` implementation signatures were changed to per-user variants (`getEmailRepliesByUser`, `getEmailReplyById(..., userId)`, `markEmailReplyAsRead(..., userId)`, `deleteEmailReply(..., userId)`, and `getConsumerConversation(..., userId)`) with corresponding query filters to enforce user scoping. 
- Frontend updates include adding an `Inbox` nav item for municipality tenants and adding email read-state filter buttons (`all`, `unread`, `read`) with `filteredEmails` applied to the email list and an empty-state view for filtered results. 

### Testing
- Ran backend automated tests via `npm test` which exercised storage and route changes and they completed successfully. 
- Ran frontend unit tests via `npm run test:client` which validated the UI changes and they completed successfully. 
- Migrated local development DB to apply the new `assigned_user_id` column and index and verified inbound reply creation and per-user inbox queries manually against the test data.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a825eb22000832a8498a755ea33c337)