### PR TITLE
Add nonprofit (church) support, donation checkout, and custom tenant landing pages

### DIFF
--- a/client/src/pages/agency-landing.tsx
+++ b/client/src/pages/agency-landing.tsx
@@ -26,10 +26,12 @@ import {
 import chainLogo from "@/assets/chain-logo.png";
 import { getAgencySlugFromRequest } from "@shared/utils/subdomain";
 import { resolvePolicyContent } from "./agency-policy-utils";
+import { getCustomLandingPage } from "./custom-landing-pages";
 
-interface AgencyBranding {
+export interface AgencyBranding {
   agencyName: string;
   agencySlug: string;
+  businessType: string;
   logoUrl: string | null;
   primaryColor: string;
   secondaryColor: string;
@@ -42,6 +44,7 @@ interface AgencyBranding {
   landingPageHeadline?: string | null;
   landingPageSubheadline?: string | null;
   customLandingPageUrl?: string | null;
+  donationUrl?: string | null;
 }
 
 export default function AgencyLanding() {
@@ -72,6 +75,7 @@ export default function AgencyLanding() {
     return {
       agencyName: fallbackName,
       agencySlug: resolvedSlug,
+      businessType: "call_center",
       logoUrl: null,
       primaryColor: "#2563eb",
       secondaryColor: "#4f46e5",
@@ -176,6 +180,20 @@ export default function AgencyLanding() {
     background: `linear-gradient(135deg, ${accentColor}, ${accentSecondary})`,
   };
 
+  const CustomLandingPage = getCustomLandingPage(resolvedBranding.agencySlug);
+  if (CustomLandingPage) {
+    return (
+      <CustomLandingPage
+        branding={resolvedBranding}
+        onSignIn={handleFindBalance}
+        onCreateAccount={() => setLocation(`/consumer-register/${resolvedBranding.agencySlug}`)}
+        onDonate={resolvedBranding.donationUrl
+          ? () => window.location.assign(resolvedBranding.donationUrl!)
+          : undefined}
+      />
+    );
+  }
+
   const featureCards = [
     {
       icon: CreditCard,
@@ -212,6 +230,9 @@ export default function AgencyLanding() {
     },
   ];
 
+  const isDonationPortal = resolvedBranding.businessType === "nonprofit_organization";
+  const donationUrl = resolvedBranding.donationUrl;
+
   return (
     <div className="relative min-h-screen overflow-hidden bg-slate-950 text-white">
       <div className="pointer-events-none absolute inset-0 overflow-hidden">
@@ -245,7 +266,8 @@ export default function AgencyLanding() {
                 Sign in
               </Button>
               <Button
-                className="rounded-full bg-blue-500 px-6 text-white hover:bg-blue-400"
+                className="rounded-full px-6 text-white brightness-100 transition hover:brightness-110"
+                style={{ backgroundColor: accentColor }}
                 onClick={() => setLocation(`/consumer-register/${resolvedBranding.agencySlug}`)}
                 data-testid="button-register"
               >
@@ -260,7 +282,8 @@ export default function AgencyLanding() {
             <div>
               <Badge
                 variant="outline"
-                className="border-blue-400/50 bg-blue-500/10 text-blue-100"
+                className="text-blue-50"
+                style={{ borderColor: `${accentColor}80`, backgroundColor: `${accentColor}20` }}
               >
                 Powered by Chain Software Group
               </Badge>
@@ -273,11 +296,14 @@ export default function AgencyLanding() {
               <div className="mt-8 flex flex-col gap-4 sm:flex-row sm:items-center">
                 <Button
                   size="lg"
-                  className="h-12 rounded-full bg-blue-500 px-8 text-base font-medium hover:bg-blue-400"
-                  onClick={handleFindBalance}
+                  className="h-12 rounded-full px-8 text-base font-medium text-white brightness-100 transition hover:brightness-110"
+                  style={{ backgroundColor: accentColor }}
+                  onClick={isDonationPortal && donationUrl
+                    ? () => window.location.assign(donationUrl)
+                    : handleFindBalance}
                   data-testid="button-find-balance"
                 >
-                  Find my balance
+                  {isDonationPortal && donationUrl ? "Donate now" : "Find my balance"}
                   <ArrowRight className="ml-2 h-4 w-4" />
                 </Button>
                 <Button

--- a/client/src/pages/agency-registration.tsx
+++ b/client/src/pages/agency-registration.tsx
@@ -20,7 +20,7 @@ const registrationWithCredentialsSchema = agencyTrialRegistrationSchema.extend({
   username: z.string().min(3, "Username must be at least 3 characters").max(50),
   password: z.string().min(8, "Password must be at least 8 characters").max(100),
   confirmPassword: z.string(),
-  businessType: z.enum(['call_center', 'billing_service', 'subscription_provider', 'freelancer_consultant', 'property_management']).default('call_center'),
+  businessType: z.enum(['call_center', 'billing_service', 'subscription_provider', 'freelancer_consultant', 'property_management', 'nonprofit_organization']).default('call_center'),
   billingMode: z.enum(['subscription', 'wallet']).default('subscription'),
 }).refine(data => data.password === data.confirmPassword, {
   message: "Passwords don't match",
@@ -413,10 +413,13 @@ export default function AgencyRegistration() {
                             <SelectItem value="property_management" data-testid="option-property-management">
                               Property Management
                             </SelectItem>
+                            <SelectItem value="nonprofit_organization" data-testid="option-nonprofit-organization">
+                              Church / Nonprofit Organization
+                            </SelectItem>
                           </SelectContent>
                         </Select>
                         <FormDescription>
-                          Choose the type that best describes your business. This customizes the platform terminology for your needs.
+                          Choose the organization type that best fits. Churches and nonprofits use donor, donation, and campaign terminology.
                         </FormDescription>
                         <FormMessage />
                       </FormItem>

--- a/client/src/pages/custom-landing-pages/README.md
+++ b/client/src/pages/custom-landing-pages/README.md
@@ -28,6 +28,11 @@ standard built-in landing page.
 
 ## Church and nonprofit donations
 
+This does **not** create a second church/nonprofit module or organization
+structure. It reuses the existing `nonprofit_organization` business type and its
+donor, donation, campaign, and giving-record terminology. The landing-page code
+only adds another public entry point into that existing tenant structure.
+
 Donation checkout and donor registration are separate actions. Configure the
 tenant as `nonprofit_organization` and set its **Guest Donation Checkout URL** in
 Settings. The built-in page then shows **Donate now**, which opens the church's

--- a/client/src/pages/custom-landing-pages/README.md
+++ b/client/src/pages/custom-landing-pages/README.md
@@ -1,0 +1,45 @@
+# Tenant-specific landing pages
+
+The normal agency landing page is configured in **Settings → Branding**. When an
+organization needs a completely different layout, a developer can build a React
+page specifically for that tenant without changing the experience for everyone
+else.
+
+## Add a custom page
+
+1. Create a component in this directory, for example
+   `first-church-landing.tsx`.
+2. Accept `CustomLandingPageProps`. The component receives the tenant's branding
+   data plus safe callbacks for signing in and creating an account.
+3. Import the component in `index.ts` and register it using the tenant's exact
+   slug:
+
+   ```tsx
+   import FirstChurchLanding from "./first-church-landing";
+
+   const customLandingPages = {
+     "first-church": FirstChurchLanding,
+   };
+   ```
+
+The public route and branding API stay the same. Only the registered tenant sees
+the custom component. Removing the registry entry immediately restores the
+standard built-in landing page.
+
+## Church and nonprofit donations
+
+Donation checkout and donor registration are separate actions. Configure the
+tenant as `nonprofit_organization` and set its **Guest Donation Checkout URL** in
+Settings. The built-in page then shows **Donate now**, which opens the church's
+hosted payment checkout without a Chain sign-in. Registration remains available
+for donors who want giving history, receipts, saved preferences, or ongoing
+communications.
+
+A custom church page receives an optional `onDonate` callback alongside
+`onSignIn` and `onCreateAccount`. Only render the donation action when that
+callback is present. Payment-card information should stay in the configured
+PCI-compliant checkout rather than being collected by a custom React component.
+
+Do not render tenant-provided JavaScript or raw HTML. Custom pages should be
+reviewed React components committed with the rest of the application so they
+receive normal code review, testing, and security updates.

--- a/client/src/pages/custom-landing-pages/index.ts
+++ b/client/src/pages/custom-landing-pages/index.ts
@@ -1,0 +1,28 @@
+import type { ComponentType } from "react";
+import type { AgencyBranding } from "../agency-landing";
+
+export interface CustomLandingPageProps {
+  branding: AgencyBranding;
+  onSignIn: () => void;
+  onCreateAccount: () => void;
+  /** Opens the church/nonprofit's hosted guest donation checkout, when configured. */
+  onDonate?: () => void;
+}
+
+/**
+ * Code-built landing pages registered by tenant slug.
+ *
+ * Keep this registry explicit: a tenant never receives another tenant's page,
+ * and unregistered tenants continue to use the configurable built-in design.
+ *
+ * Example:
+ *   import ChurchLandingPage from "./church-landing-page";
+ *   const customLandingPages = { "first-church": ChurchLandingPage };
+ */
+const customLandingPages: Record<string, ComponentType<CustomLandingPageProps>> = {};
+
+export function getCustomLandingPage(
+  tenantSlug: string,
+): ComponentType<CustomLandingPageProps> | undefined {
+  return customLandingPages[tenantSlug.toLowerCase()];
+}

--- a/client/src/pages/global-admin.tsx
+++ b/client/src/pages/global-admin.tsx
@@ -1218,6 +1218,7 @@ export default function GlobalAdmin() {
                       <SelectItem value="call_center">Call Center</SelectItem>
                       <SelectItem value="law_firm">Law Firm</SelectItem>
                       <SelectItem value="municipality">Municipality</SelectItem>
+                      <SelectItem value="nonprofit_organization">Church / Nonprofit</SelectItem>
                     </SelectContent>
                   </Select>
                   <p className="text-sm text-gray-500">This classifies the tenant; all platform features and large contact lists work the same.</p>
@@ -4246,6 +4247,7 @@ export default function GlobalAdmin() {
                     <SelectItem value="subscription_provider">Subscription Provider</SelectItem>
                     <SelectItem value="freelancer_consultant">Freelancer / Consultant</SelectItem>
                     <SelectItem value="property_management">Property Management</SelectItem>
+                    <SelectItem value="nonprofit_organization">Church / Nonprofit</SelectItem>
                   </SelectContent>
                 </Select>
                 <p className="text-sm text-blue-100/70">

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -1535,9 +1535,9 @@ export default function Settings() {
                   {/* Logo Upload Section */}
                   <div className="space-y-4 border-b pb-6">
                     <div>
-                      <Label className="text-base font-medium text-white">Company Logo</Label>
+                      <Label className="text-base font-medium text-white">Organization Logo</Label>
                       <p className="text-sm text-blue-100/70">
-                        Upload your company logo to display on the consumer portal
+                        Upload the logo for your company, church, nonprofit, or other organization
                       </p>
                     </div>
                     
@@ -1547,7 +1547,7 @@ export default function Settings() {
                         <div className="flex-shrink-0">
                           <img 
                             src={(settings as any).customBranding.logoUrl} 
-                            alt="Company Logo" 
+                            alt="Organization logo"
                             className="h-16 w-16 rounded-md border border-white/10 bg-white/10 object-contain"
                           />
                         </div>
@@ -1581,12 +1581,71 @@ export default function Settings() {
                     )}
                   </div>
 
+                  {/* Organization Colors */}
+                  <div className="space-y-4 border-b pb-6">
+                    <div>
+                      <Label className="text-base font-medium text-white">Organization Colors</Label>
+                      <p className="text-sm text-blue-100/70">
+                        Match the landing page accents to your website, ministry, or company brand
+                      </p>
+                    </div>
+
+                    <div className="grid gap-4 sm:grid-cols-2">
+                      {([
+                        { key: 'primaryColor', label: 'Primary Color', fallback: '#3B82F6' },
+                        { key: 'secondaryColor', label: 'Secondary Color', fallback: '#1E40AF' },
+                      ] as const).map(({ key, label, fallback }) => {
+                        const customBranding = (localSettings?.customBranding as any) || {};
+                        const value = customBranding[key] || fallback;
+
+                        return (
+                          <div key={key} className="space-y-2">
+                            <Label htmlFor={`branding-${key}`}>{label}</Label>
+                            <div className="flex gap-2">
+                              <Input
+                                id={`branding-${key}`}
+                                type="color"
+                                value={value}
+                                onChange={(e) => handleSettingsUpdate('customBranding', {
+                                  ...customBranding,
+                                  [key]: e.target.value,
+                                })}
+                                className="h-10 w-14 cursor-pointer border-white/20 bg-white/10 p-1"
+                                aria-label={`Choose ${label.toLowerCase()}`}
+                              />
+                              <Input
+                                key={value}
+                                defaultValue={value}
+                                onBlur={(e) => {
+                                  if (/^#[0-9a-fA-F]{6}$/.test(e.target.value)) {
+                                    handleSettingsUpdate('customBranding', {
+                                      ...customBranding,
+                                      [key]: e.target.value,
+                                    });
+                                  } else {
+                                    e.target.value = value;
+                                  }
+                                }}
+                                className={inputClasses}
+                                aria-label={`${label} hex value`}
+                                maxLength={7}
+                              />
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </div>
+                    <p className="text-xs text-blue-100/70">
+                      These colors are used for buttons, highlights, and gradients on your public landing page.
+                    </p>
+                  </div>
+
                   {/* Landing Page Customization Section */}
                   <div className="space-y-4 border-b pb-6">
                     <div>
                       <Label className="text-base font-medium text-white">Landing Page Welcome Message</Label>
                       <p className="text-sm text-blue-100/70">
-                        Customize the greeting consumers see when they visit your agency portal
+                        Customize the greeting people see when they visit your organization portal
                       </p>
                     </div>
                     
@@ -1595,7 +1654,7 @@ export default function Settings() {
                         <Label htmlFor="landing-headline">Main Headline</Label>
                         <Input
                           id="landing-headline"
-                          placeholder={`${(authUser as any)?.platformUser?.tenant?.name || 'Your Agency'} gives you a smarter way to stay current`}
+                          placeholder={`${(authUser as any)?.platformUser?.tenant?.name || 'Your Organization'} gives you a smarter way to stay connected`}
                           value={(localSettings?.customBranding as any)?.landingPageHeadline || ''}
                           onChange={(e) => {
                             const customBranding = (localSettings?.customBranding as any) || {};
@@ -1637,7 +1696,7 @@ export default function Settings() {
                         <Input
                           id="landing-page-url"
                           type="url"
-                          placeholder="https://yourcompany.com/portal"
+                          placeholder="https://yourorganization.org/portal"
                           value={(localSettings?.customBranding as any)?.customLandingPageUrl || ''}
                           onChange={(e) => {
                             const url = e.target.value;
@@ -1661,6 +1720,31 @@ export default function Settings() {
                           If provided, consumers will be redirected to this external URL instead of the built-in portal. Must start with http:// or https://
                         </p>
                       </div>
+
+                      {localSettings?.businessType === 'nonprofit_organization' && (
+                        <div>
+                          <Label htmlFor="donation-url">Guest Donation Checkout URL</Label>
+                          <Input
+                            id="donation-url"
+                            type="url"
+                            placeholder="https://donate.yourchurch.org"
+                            value={(localSettings?.customBranding as any)?.donationUrl || ''}
+                            onChange={(e) => {
+                              const customBranding = (localSettings?.customBranding as any) || {};
+                              handleSettingsUpdate('customBranding', {
+                                ...customBranding,
+                                donationUrl: e.target.value,
+                              });
+                            }}
+                            className={inputClasses}
+                            data-testid="input-donation-url"
+                          />
+                          <p className="mt-1 text-xs text-blue-100/70">
+                            The “Donate now” button opens this hosted checkout without requiring an account.
+                            Donor registration remains optional and is used for giving history and communication preferences.
+                          </p>
+                        </div>
+                      )}
                     </div>
                   </div>
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -7321,6 +7321,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         landingPageHeadline: customBranding?.landingPageHeadline || null,
         landingPageSubheadline: customBranding?.landingPageSubheadline || null,
         customLandingPageUrl: customBranding?.customLandingPageUrl || null,
+        donationUrl: customBranding?.donationUrl || null,
       };
 
       res.status(200).json(branding);
@@ -7786,7 +7787,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const registrationWithCredentialsSchema = agencyTrialRegistrationSchema.extend({
         username: z.string().min(3).max(50),
         password: z.string().min(8).max(100),
-        businessType: z.enum(['call_center', 'billing_service', 'subscription_provider', 'freelancer_consultant', 'property_management']).optional().default('call_center'),
+        businessType: z.enum(['call_center', 'billing_service', 'subscription_provider', 'freelancer_consultant', 'property_management', 'nonprofit_organization']).optional().default('call_center'),
         billingMode: z.enum(['subscription', 'wallet']).optional().default('subscription'),
       });
       
@@ -9820,15 +9821,12 @@ export async function registerRoutes(app: Express): Promise<Server> {
         showDocuments: z.boolean().optional(),
         allowSettlementRequests: z.boolean().optional(),
         customBranding: z.any().optional().refine((val) => {
-          // If customBranding has customLandingPageUrl, validate it
-          if (val && val.customLandingPageUrl) {
-            const url = val.customLandingPageUrl;
-            // Only allow http:// or https:// URLs
-            return typeof url === 'string' && (url.startsWith('http://') || url.startsWith('https://'));
-          }
-          return true;
+          const isSafeExternalUrl = (url: unknown) =>
+            !url || (typeof url === 'string' && (url.startsWith('http://') || url.startsWith('https://')));
+
+          return isSafeExternalUrl(val?.customLandingPageUrl) && isSafeExternalUrl(val?.donationUrl);
         }, {
-          message: "Custom landing page URL must start with http:// or https://"
+          message: "Custom landing page and donation URLs must start with http:// or https://"
         }),
         consumerPortalSettings: z.any().optional(),
         smsThrottleLimit: z.number().min(1).max(1000).optional(),
@@ -21851,7 +21849,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const creation = z.object({
         name: z.string().trim().min(1).max(100),
         email: z.string().trim().email(),
-        businessType: z.enum(['collection_agency', 'call_center', 'law_firm', 'municipality']).default('collection_agency'),
+        businessType: z.enum(['collection_agency', 'call_center', 'law_firm', 'municipality', 'nonprofit_organization']).default('collection_agency'),
       }).safeParse(req.body);
       if (!creation.success) {
         return res.status(400).json({ message: "Organization name, type, and a valid email are required", errors: creation.error.errors });
@@ -22458,7 +22456,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       
       // Validate input with known module IDs only
       const businessConfigSchema = z.object({
-        businessType: z.enum(['call_center', 'billing_service', 'subscription_provider', 'freelancer_consultant', 'property_management']),
+        businessType: z.enum(['call_center', 'billing_service', 'subscription_provider', 'freelancer_consultant', 'property_management', 'nonprofit_organization']),
         enabledModules: z.array(z.enum(['billing', 'subscriptions', 'work_orders', 'client_crm', 'messaging_center']))
       });
       


### PR DESCRIPTION
### Motivation
- Support churches/nonprofits as a tenant type with a hosted guest donation flow and tenant-specific landing pages. 
- Allow tenants to optionally provide a hosted donation checkout URL and to register explicit custom React landing pages per tenant.
- Surface organization-focused branding controls (colors, labels) and wire donation behavior into the public landing experience.

### Description
- Introduces a small custom landing page registry under `client/src/pages/custom-landing-pages/` with `index.ts` and a `README.md` describing how to add tenant-specific pages and the `CustomLandingPageProps` contract. 
- Extends `AgencyBranding` to include `businessType` and `donationUrl` and updates `client/src/pages/agency-landing.tsx` to: detect and render a registered custom landing component, show a `Donate now` CTA when `businessType === 'nonprofit_organization'` and `donationUrl` is set, and apply tenant color customizations to buttons and badges.
- Adds `nonprofit_organization` to business-type enums and UI selects in `agency-registration.tsx`, `global-admin.tsx`, and server-side routes to allow creating/updating tenants as nonprofits. 
- Adds tenant-level donation URL handling to settings UI in `client/src/pages/settings.tsx`, including color pickers for `primaryColor`/`secondaryColor`, updated labels from "Company" to "Organization", and a `Guest Donation Checkout URL` input shown for nonprofit tenants.
- Server-side (`server/routes.ts`) now returns `donationUrl` as part of the public branding API, validates `donationUrl` on settings updates, and accepts `nonprofit_organization` in relevant schemas and tenant creation/business-config endpoints.

### Testing
- Ran TypeScript type-check and application builds via the monorepo build commands (`pnpm -w tsc --noEmit` and `pnpm -w build`) with no compilation errors.
- Exercised the public branding API change by fetching `/api/public/agency-branding?slug=...` and verified `donationUrl` is present when configured.
- Manually verified the landing page shows the donated CTA and redirects to the configured hosted checkout when `businessType` is `nonprofit_organization` and `donationUrl` is set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a846c9bb258832aac83ccef83b88c62)