### PR TITLE
Add DMP arrangement creation and preflight reconciliation checks

### DIFF
--- a/server/dmpArrangementOwnership.test.ts
+++ b/server/dmpArrangementOwnership.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+test("sends the complete recurring schedule to DMP", async () => {
+  process.env.DATABASE_URL ||= "postgresql://test:test@localhost:5432/test";
+  const { DebtManagerProService } = await import("./dmpService");
+  const service = new DebtManagerProService() as any;
+  let request: any;
+  service.getDmpConfig = async () => ({ enabled: true, apiUrl: "https://dmp.test", username: "u", password: "p" });
+  service.makeRequest = async (_config: any, method: string, endpoint: string, body: any) => {
+    request = { method, endpoint, body };
+    return { state: "SUCCESS" };
+  };
+
+  const sent = await service.insertPaymentArrangement("tenant-1", {
+    filenumber: "FILE-1",
+    payorname: "Test Consumer",
+    arrangementtype: "Biweekly",
+    paymentamount: 25,
+    nextpaymentdate: "2026-08-19",
+    remainingpayments: 3,
+    frequency: "biweekly",
+    cardtoken: "vault-token",
+  });
+
+  assert.equal(sent, true);
+  assert.equal(request.method, "POST");
+  assert.equal(request.endpoint, "/api/v2/insert_payplan_external");
+  assert.deepEqual(request.body.paymentdata, [
+    { paymentamount: "25.00", paymentdate: "2026-08-19" },
+    { paymentamount: "25.00", paymentdate: "2026-09-02" },
+    { paymentamount: "25.00", paymentdate: "2026-09-16" },
+  ]);
+});

--- a/server/dmpPaymentReconciliation.test.ts
+++ b/server/dmpPaymentReconciliation.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { findMatchingDmpPayment, normalizeDmpPayment } from "./dmpPaymentReconciliation";
+
+test("normalizes alternate DMP payment fields", () => {
+  assert.deepEqual(
+    normalizeDmpPayment({
+      payment_date: "2026-08-19T14:00:00Z",
+      payment_amount: "42.50",
+      payment_status: "COMPLETED",
+      transaction_id: "dmp-123",
+    }),
+    { date: "2026-08-19", amountCents: 4250, status: "COMPLETED", transactionId: "dmp-123" },
+  );
+});
+
+test("matches completed and scheduled DMP installments for the same date and amount", () => {
+  assert.ok(findMatchingDmpPayment(
+    [{ paymentdate: "2026-08-19", paymentamount: 50, paymentstatus: "COMPLETED" }],
+    "2026-08-19",
+    5000,
+  ));
+  assert.ok(findMatchingDmpPayment(
+    [{ scheduled_date: "2026-08-19", amount: "50.00", status: "SCHEDULED" }],
+    "2026-08-19",
+    5000,
+  ));
+});
+
+test("does not match another amount, date, or an inactive payment", () => {
+  const records = [
+    { paymentdate: "2026-08-18", paymentamount: 50, paymentstatus: "COMPLETED" },
+    { paymentdate: "2026-08-19", paymentamount: 40, paymentstatus: "COMPLETED" },
+    { paymentdate: "2026-08-19", paymentamount: 50, paymentstatus: "DECLINED" },
+  ];
+  assert.equal(findMatchingDmpPayment(records, "2026-08-19", 5000), null);
+});

--- a/server/dmpPaymentReconciliation.ts
+++ b/server/dmpPaymentReconciliation.ts
@@ -1,0 +1,64 @@
+export interface NormalizedDmpPayment {
+  date: string | null;
+  amountCents: number;
+  status: string;
+  transactionId: string | null;
+}
+
+const inactivePaymentStatus = /declin|cancel|void|nsf|charge.?back|refund|revers|fail|return/i;
+
+function normalizeDate(value: unknown): string | null {
+  if (!value) return null;
+  const raw = String(value).trim();
+  const dateOnly = raw.match(/^(\d{4}-\d{2}-\d{2})/);
+  if (dateOnly) return dateOnly[1];
+
+  const parsed = new Date(raw);
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString().slice(0, 10);
+}
+
+export function normalizeDmpPayment(payment: any): NormalizedDmpPayment {
+  const amount = Number(
+    payment?.paymentamount ?? payment?.payment_amount ?? payment?.amount ?? 0,
+  );
+
+  return {
+    date: normalizeDate(
+      payment?.paymentdate ??
+        payment?.payment_date ??
+        payment?.date ??
+        payment?.scheduleddate ??
+        payment?.scheduled_date,
+    ),
+    // DMP payment amounts are dollars in both its read and write APIs.
+    amountCents: Number.isFinite(amount) ? Math.round(amount * 100) : 0,
+    status: String(
+      payment?.paymentstatus ?? payment?.payment_status ?? payment?.status ?? "",
+    ).trim(),
+    transactionId: String(
+      payment?.transactionid ?? payment?.transaction_id ?? payment?.reference ?? "",
+    ).trim() || null,
+  };
+}
+
+/**
+ * Returns the DMP record satisfying a Chain installment on the given day.
+ * Pending/scheduled records count too: DMP owns those charges, so Chain must not
+ * submit a competing charge. Failed, reversed, and cancelled records do not.
+ */
+export function findMatchingDmpPayment(
+  payments: any[] | null | undefined,
+  paymentDate: string,
+  amountCents: number,
+): NormalizedDmpPayment | null {
+  if (!Array.isArray(payments)) return null;
+
+  return payments
+    .map(normalizeDmpPayment)
+    .find(
+      payment =>
+        payment.date === paymentDate &&
+        payment.amountCents === amountCents &&
+        !inactivePaymentStatus.test(payment.status),
+    ) ?? null;
+}

--- a/server/dmpService.ts
+++ b/server/dmpService.ts
@@ -60,6 +60,21 @@ interface DmpPaymentData {
   invoice?: string;
 }
 
+export interface DmpPaymentArrangementData {
+  filenumber: string;
+  payorname: string;
+  arrangementtype: string;
+  paymentamount: number;
+  nextpaymentdate: string;
+  remainingpayments?: number;
+  frequency?: string;
+  cardtoken?: string;
+  cardlast4?: string;
+  cardbrand?: string;
+  expirymonth?: string;
+  expiryyear?: string;
+}
+
 interface DmpAttemptData {
   filenumber: string;
   attempttype: string;
@@ -107,7 +122,7 @@ interface DmpDisposition {
   status_mapping?: string;
 }
 
-class DebtManagerProService {
+export class DebtManagerProService {
   private tokenCache: Map<string, { token: string; expires: number }> = new Map();
 
   private async getDmpConfig(
@@ -352,6 +367,43 @@ class DebtManagerProService {
 
     console.log(`[DMP] Posting payment to DMP for filenumber: ${payment.filenumber}`);
     return await this.makeRequest<any>(config, 'POST', '/api/v2/insert_payments_external', payment);
+  }
+
+  async insertPaymentArrangement(tenantId: string, arrangement: DmpPaymentArrangementData): Promise<boolean> {
+    const config = await this.getDmpConfig(tenantId);
+    if (!config) return false;
+
+    const paymentdata: Array<{ paymentamount: string; paymentdate: string }> = [];
+    const count = Math.max(1, arrangement.remainingpayments || 1);
+    const currentDate = new Date(`${arrangement.nextpaymentdate}T12:00:00Z`);
+    for (let index = 0; index < count; index++) {
+      paymentdata.push({
+        paymentamount: arrangement.paymentamount.toFixed(2),
+        paymentdate: currentDate.toISOString().slice(0, 10),
+      });
+      if (arrangement.frequency === 'weekly') currentDate.setUTCDate(currentDate.getUTCDate() + 7);
+      else if (arrangement.frequency === 'biweekly') currentDate.setUTCDate(currentDate.getUTCDate() + 14);
+      else currentDate.setUTCMonth(currentDate.getUTCMonth() + 1);
+    }
+
+    const result = await this.makeRequest<any>(config, 'POST', '/api/v2/insert_payplan_external', {
+      filenumber: arrangement.filenumber,
+      paymentdate: arrangement.nextpaymentdate,
+      payorname: arrangement.payorname || 'Consumer',
+      paymentmethod: 'CREDIT CARD',
+      paymentstatus: 'PENDING',
+      typeofpayment: 'Online',
+      cardtype: arrangement.cardbrand || 'Unknown',
+      cardnumber: arrangement.cardtoken || (arrangement.cardlast4 ? `XXXX-XXXX-XXXX-${arrangement.cardlast4}` : ''),
+      cardexpirationmonth: arrangement.expirymonth || '',
+      cardexpirationyear: arrangement.expiryyear || '',
+      paymentamount: arrangement.paymentamount.toFixed(2),
+      invoice: `CHAIN-ARR-${Date.now()}`,
+      arrangementtype: arrangement.arrangementtype,
+      paymentdata,
+    });
+
+    return result?.state === 'SUCCESS' || result?.success === true;
   }
 
   async insertAttempt(tenantId: string, attempt: DmpAttemptData): Promise<any | null> {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -52,6 +52,7 @@ import express from "express";
 import { emailService } from "./emailService";
 import { smsService } from "./smsService";
 import { smaxService } from "./smaxService";
+import { dmpService } from "./dmpService";
 import { eventService } from "./eventService";
 import { uploadLogo } from "./r2Storage";
 import externalApiRouter from "./external-api";
@@ -79,6 +80,7 @@ import {
 import { computeALaCarteBill, computeSubscriptionBill, generateInvoiceNumber } from "./billing";
 import { generateInvoicePdf } from "./invoicePdf";
 import { canActivateUser } from "@shared/enterpriseCapacity";
+import { findMatchingDmpPayment } from "./dmpPaymentReconciliation";
 
 import { listConsumers, paginateConsumers, updateConsumer, deleteConsumers, ConsumerNotFoundError } from "@shared/server/consumers";
 import { resolveConsumerPortalUrl } from "@shared/utils/consumerPortal";
@@ -13930,7 +13932,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
                 remainingPayments,
                 totalPayments: totalPaymentsCalc,
                 status: 'active',
-                source: 'chain',
+                source: (settings as any)?.dmpEnabled && account.filenumber ? 'dmp' : 'chain',
+                processor: (settings as any)?.dmpEnabled && account.filenumber ? 'dmp' : 'chain',
                 smaxSynced: false,
               });
 
@@ -14022,12 +14025,30 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
               if ((settings as any)?.dmpEnabled && account.filenumber) {
                 try {
-                  const { dmpService } = await import('./dmpService');
                   const fileNumber = account.filenumber;
                   const arrangementName = arrangement.name || arrangement.planType;
                   const firstPaymentDate = paymentStartDate.toISOString().split('T')[0];
                   const amountDollars = (amountCents / 100).toFixed(2);
                   const consumerName = consumer ? `${consumer.firstName} ${consumer.lastName}`.trim() : '';
+
+                  const arrangementSent = await dmpService.insertPaymentArrangement(tenantId, {
+                    filenumber: fileNumber,
+                    payorname: consumerName || 'Consumer',
+                    arrangementtype: arrangementName,
+                    paymentamount: amountCents / 100,
+                    nextpaymentdate: createdSchedule.nextPaymentDate,
+                    remainingpayments: createdSchedule.remainingPayments || undefined,
+                    frequency: arrangementFrequency,
+                    cardtoken: savedPaymentMethod.paymentToken,
+                    cardlast4: savedPaymentMethod.cardLast4,
+                    cardbrand: savedPaymentMethod.cardBrand || undefined,
+                    expirymonth: savedPaymentMethod.expiryMonth || undefined,
+                    expiryyear: savedPaymentMethod.expiryYear || undefined,
+                  });
+                  if (!arrangementSent) {
+                    await storage.updatePaymentSchedule(createdSchedule.id, tenantId, { status: 'paused' });
+                    console.error('DMP arrangement creation failed; Chain schedule paused so Chain cannot run it');
+                  }
 
                   await dmpService.insertAttempt(tenantId, {
                     filenumber: fileNumber,
@@ -14483,11 +14504,33 @@ export async function registerRoutes(app: Express): Promise<Server> {
                 remainingPayments,
                 totalPayments: totalPaymentsCalcNMI,
                 status: 'active',
-                source: 'chain',
+                source: (settings as any)?.dmpEnabled && account.filenumber ? 'dmp' : 'chain',
+                processor: (settings as any)?.dmpEnabled && account.filenumber ? 'dmp' : 'chain',
                 smaxSynced: false,
               });
 
               console.log('✅ Payment schedule created for NMI arrangement');
+
+              if ((settings as any)?.dmpEnabled && account.filenumber) {
+                const consumerName = consumer ? `${consumer.firstName || ''} ${consumer.lastName || ''}`.trim() : '';
+                const arrangementSent = await dmpService.insertPaymentArrangement(tenantId, {
+                  filenumber: account.filenumber,
+                  payorname: consumerName || 'Consumer',
+                  arrangementtype: arrangement.name || arrangement.planType,
+                  paymentamount: amountCents / 100,
+                  nextpaymentdate: createdSchedule.nextPaymentDate,
+                  remainingpayments: createdSchedule.remainingPayments || undefined,
+                  frequency: arrangementFrequency,
+                  cardtoken: savedPaymentMethod.paymentToken,
+                  cardlast4: savedPaymentMethod.cardLast4,
+                  cardbrand: savedPaymentMethod.cardBrand || undefined,
+                  expirymonth: savedPaymentMethod.expiryMonth || undefined,
+                  expiryyear: savedPaymentMethod.expiryYear || undefined,
+                });
+                if (!arrangementSent) {
+                  await storage.updatePaymentSchedule(createdSchedule.id, tenantId, { status: 'paused' });
+                }
+              }
 
               // Send arrangement notification
               const consumerForNotification = await storage.getConsumer(consumerId);
@@ -15199,7 +15242,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
               remainingPayments,
               totalPayments: totalPaymentsUSAePay,
               status: 'active',
-              source: 'chain',
+              source: (settings as any)?.dmpEnabled && (account as any)?.filenumber ? 'dmp' : 'chain',
+              processor: (settings as any)?.dmpEnabled && (account as any)?.filenumber ? 'dmp' : 'chain',
               smaxSynced: false,
             });
             
@@ -15437,7 +15481,6 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
             if ((settings as any)?.dmpEnabled && (account as any)?.filenumber) {
               try {
-                const { dmpService } = await import('./dmpService');
                 const fileNumber = (account as any).filenumber;
                 const arrangementName = arrangement.name || arrangement.planType;
                 const amountDollars = (amountCents / 100).toFixed(2);
@@ -15445,6 +15488,25 @@ export async function registerRoutes(app: Express): Promise<Server> {
                 const firstPaymentDate = scheduleRecord?.startDate || paymentStartDate.toISOString().split('T')[0];
                 const dmpConsumer = await storage.getConsumer(consumerId);
                 const consumerNameRaw = `${dmpConsumer?.firstName || ''} ${dmpConsumer?.lastName || ''}`.trim();
+
+                const arrangementSent = await dmpService.insertPaymentArrangement(tenantId, {
+                  filenumber: fileNumber,
+                  payorname: consumerNameRaw || 'Consumer',
+                  arrangementtype: arrangementName,
+                  paymentamount: amountCents / 100,
+                  nextpaymentdate: scheduleRecord?.nextPaymentDate || firstPaymentDate,
+                  remainingpayments: scheduleRecord?.remainingPayments || undefined,
+                  frequency: mainArrangementFrequency || 'monthly',
+                  cardtoken: savedPaymentMethod?.paymentToken || undefined,
+                  cardlast4: savedPaymentMethod?.cardLast4 || undefined,
+                  cardbrand: savedPaymentMethod?.cardBrand || undefined,
+                  expirymonth: savedPaymentMethod?.expiryMonth || undefined,
+                  expiryyear: savedPaymentMethod?.expiryYear || undefined,
+                });
+                if (!arrangementSent && createdSchedule?.id) {
+                  await storage.updatePaymentSchedule(createdSchedule.id, tenantId, { status: 'paused' });
+                  console.error('DMP arrangement creation failed; Chain schedule paused so Chain cannot run it');
+                }
 
                 await dmpService.insertAttempt(tenantId, {
                   filenumber: fileNumber,
@@ -16181,6 +16243,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
               eq(paymentSchedulesTable.status, 'active'),
               lte(paymentSchedulesTable.nextPaymentDate, today),
               sql`COALESCE(${paymentSchedulesTable.source}, 'chain') != 'smax'`,
+              sql`COALESCE(${paymentSchedulesTable.processor}, 'chain') = 'chain'`,
               ...(targetScheduleId ? [eq(paymentSchedulesTable.id, targetScheduleId)] : [])
             )
           );
@@ -16213,6 +16276,72 @@ export async function registerRoutes(app: Express): Promise<Server> {
                 console.log(`⏭️ Skipping scheduled payment: ${statusValidation.reason}`);
                 failedPayments.push({ scheduleId: schedule.id, accountId: schedule.accountId, reason: statusValidation.reason });
                 try { await storage.createPaymentProcessingLog({ tenantId: tenant.id, scheduleId: schedule.id, consumerId: consumer.id, accountId: schedule.accountId, consumerName, accountNumber: scheduleAccount?.accountNumber || undefined, creditor: scheduleAccount?.creditor || undefined, amountCents: schedule.amountCents, status: 'skipped', failureReason: statusValidation.reason, runType }); } catch (logError) { console.error('Failed to log:', logError); }
+                continue;
+              }
+            }
+
+            const advanceSatisfiedInstallment = async (reason: string) => {
+              const nextPayment = calculateNextPaymentDate(new Date(`${schedule.nextPaymentDate}T12:00:00`), schedule.frequency || 'monthly');
+              const remainingPayments = schedule.remainingPayments !== null ? schedule.remainingPayments - 1 : null;
+              const status = remainingPayments === 0 ? 'completed' : 'active';
+              const nextPaymentDate = nextPayment.toLocaleDateString('en-CA', { timeZone: 'America/New_York' });
+
+              await storage.updatePaymentSchedule(schedule.id, tenant.id, {
+                nextPaymentDate,
+                remainingPayments,
+                lastProcessedAt: new Date(),
+                status,
+                failedAttempts: 0,
+                lastFailureReason: null,
+              });
+              await storage.createPaymentProcessingLog({
+                tenantId: tenant.id,
+                scheduleId: schedule.id,
+                consumerId: consumer.id,
+                accountId: schedule.accountId,
+                consumerName,
+                accountNumber: scheduleAccount?.accountNumber || undefined,
+                creditor: scheduleAccount?.creditor || undefined,
+                amountCents: schedule.amountCents,
+                status: 'skipped',
+                failureReason: reason,
+                runType,
+              });
+              failedPayments.push({ scheduleId: schedule.id, accountId: schedule.accountId, reason });
+              console.log(`⏭️ ${reason}; advanced schedule ${schedule.id} to ${nextPaymentDate}`);
+            };
+
+            // A one-time/manual Chain payment made today satisfies today's installment.
+            // Advance the schedule so the overdue query cannot charge it tomorrow.
+            const chainPaymentsToday = await storage.getPaymentsByTenantAndDate(tenant.id, today);
+            const matchingChainPayment = chainPaymentsToday.find(payment =>
+              payment.accountId === schedule.accountId &&
+              payment.status === 'completed' &&
+              payment.amountCents === schedule.amountCents
+            );
+            if (matchingChainPayment) {
+              await advanceSatisfiedInstallment('Matching Chain payment already completed today');
+              continue;
+            }
+
+            // DMP is checked immediately before charging. A completed payment or a
+            // DMP-owned scheduled payment for this installment prevents Chain from
+            // submitting a duplicate charge. Fail closed if DMP cannot be checked.
+            if ((settings as any)?.dmpEnabled && scheduleAccount?.filenumber) {
+              try {
+                const dmpPayments = await dmpService.getPayments(tenant.id, scheduleAccount.filenumber);
+                const matchingDmpPayment = findMatchingDmpPayment(dmpPayments, today, schedule.amountCents);
+                if (matchingDmpPayment) {
+                  await advanceSatisfiedInstallment(
+                    `Matching DMP payment exists today (${matchingDmpPayment.status || 'status not supplied'})`,
+                  );
+                  continue;
+                }
+              } catch (dmpError) {
+                const reason = 'DMP payment check unavailable; charge deferred to prevent a duplicate';
+                console.error(`⚠️ ${reason}:`, dmpError);
+                await storage.createPaymentProcessingLog({ tenantId: tenant.id, scheduleId: schedule.id, consumerId: consumer.id, accountId: schedule.accountId, consumerName, accountNumber: scheduleAccount.accountNumber || undefined, creditor: scheduleAccount.creditor || undefined, amountCents: schedule.amountCents, status: 'skipped', failureReason: reason, runType });
+                failedPayments.push({ scheduleId: schedule.id, accountId: schedule.accountId, reason });
                 continue;
               }
             }


### PR DESCRIPTION
### Motivation
- Integrate with Debt Manager Pro (DMP) so arrangements created in Chain can be sent to DMP and Chain avoids submitting duplicate charges when DMP already owns an installment.
- Provide robust reconciliation for incoming DMP payment records that may use alternate field names and status variants.

### Description
- Add `insertPaymentArrangement` to `dmpService.ts` to send complete recurring payment schedules to DMP, build `paymentdata` entries, and return a boolean success indicator.
- Introduce `dmpPaymentReconciliation.ts` which normalizes diverse DMP payment payloads and exposes `findMatchingDmpPayment` to locate non‑inactive DMP records that match a date and amount.
- Update `routes.ts` to route schedule source/processor to `dmp` when DMP is enabled and to send arrangements to DMP during multiple arrangement creation flows, pausing Chain schedules if DMP arrangement creation fails.
- Before charging a scheduled installment, add preflight checks that advance/skip schedules when a matching Chain payment exists today or when `findMatchingDmpPayment` finds a DMP-owned installment, and add a fail‑closed behavior if the DMP check is unavailable.

### Testing
- Added unit tests `server/dmpPaymentReconciliation.test.ts` covering `normalizeDmpPayment` and `findMatchingDmpPayment` behaviors and `server/dmpArrangementOwnership.test.ts` verifying `insertPaymentArrangement` builds the expected `paymentdata` payload and calls the correct DMP endpoint.
- Ran the test suite with `node --test` for the new tests and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8604e37030832aa614bf9f60987b5e)