### PR TITLE
Prevent duplicate platform announcement replies

### DIFF
--- a/server/migrations.ts
+++ b/server/migrations.ts
@@ -50,6 +50,21 @@ export async function runMigrations() {
         received_at TIMESTAMP DEFAULT NOW()
       )
     `);
+    // Postmark retries inbound webhooks when it does not receive a successful
+    // response. Keep those retries from creating duplicate inbox entries while
+    // preserving replies created before MessageID was available.
+    await client.query(`
+      DELETE FROM platform_announcement_replies duplicate
+      USING platform_announcement_replies original
+      WHERE duplicate.message_id IS NOT NULL
+        AND duplicate.message_id = original.message_id
+        AND duplicate.id > original.id
+    `);
+    await client.query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS platform_announcement_reply_message_idx
+      ON platform_announcement_replies(message_id)
+      WHERE message_id IS NOT NULL
+    `);
 
     await client.query(`
       CREATE TABLE IF NOT EXISTS tenant_departments (

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -23836,6 +23836,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
               VALUES (${platformDelivery.announcement_id}, ${platformDelivery.id}, ${platformDelivery.tenant_id},
                       ${platformDelivery.consumer_id}, ${fromEmail}, ${Subject || '(No Subject)'},
                       ${TextBody || ''}, ${HtmlBody || ''}, ${MessageID || null}, ${inReplyToMessageId})
+              ON CONFLICT (message_id) WHERE message_id IS NOT NULL DO NOTHING
             `);
             console.log('✅ Routed platform announcement reply to Global Admin inbox');
             return res.status(200).json({ message: 'Platform announcement reply received' });


### PR DESCRIPTION
### Motivation

- Postmark can retry inbound webhooks when it doesn't receive a successful response, which can create duplicate platform announcement reply records. 
- Inbound replies to platform announcements must be routed exclusively to the Global Admin inbox and should be idempotent. 

### Description

- Add a migration cleanup step in `server/migrations.ts` that deletes existing duplicate `platform_announcement_replies` rows that share the same non-null `message_id`. 
- Create a partial unique index `platform_announcement_reply_message_idx` on `platform_announcement_replies(message_id)` where `message_id IS NOT NULL` to enforce idempotency going forward. 
- Update the inbound webhook handling in `server/routes.ts` to insert platform announcement replies with `ON CONFLICT (message_id) WHERE message_id IS NOT NULL DO NOTHING` so retried webhooks do not create duplicates. 

### Testing

- Ran `npm test` and all unit tests passed (`16` tests, `0` failures). 
- Ran `git diff --check` to verify no whitespace/diff issues and it reported clean. 
- Ran `npm run check` (TypeScript checks), which surfaced pre-existing unrelated TypeScript errors in other areas and did not block this change; those errors are outside this PR's scope.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a872417a774832a987ce0da4f090e1f)